### PR TITLE
Allow for ignoring of templates when running

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Example:
 ```yaml
 templates:
 - test/fixtures/templates/good/**/*.yaml
+ignore_templates:
+- codebuild.yaml
 include_checks:
 - I
 ```
@@ -110,6 +112,7 @@ Optional parameters:
 | -l, --list-rules | | | List all the rules |
 | -r, --regions | regions | [REGIONS [REGIONS ...]]  | Test the template against many regions.  [Supported regions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) |
 | -b, --ignore-bad-template | ignore_bad_template | | Ignores bad template errors |
+| --ignore-templates | IGNORE_TEMPLATES [IGNORE_TEMPLATES ...] | Ignore templates from being scanned
 | -a, --append-rules | append_rules | [RULESDIR [RULESDIR ...]] | Specify one or more rules directories using one or more --append-rules arguments. |
 | -i, --ignore-checks | ignore_checks | [IGNORE_CHECKS [IGNORE_CHECKS ...]] | Only check rules whose ID do not match or prefix these values.  Examples: <br />- A value of `W` will disable all warnings<br />- `W2` disables all Warnings for Parameter rules.<br />- `W2001` will disable rule `W2001` |
 | -c, --include-checks | INCLUDE_CHECKS [INCLUDE_CHECKS ...] | Include rules whose id match these values

--- a/src/cfnlint/data/CfnLintCli/config/schema.json
+++ b/src/cfnlint/data/CfnLintCli/config/schema.json
@@ -44,6 +44,13 @@
         "type": "string"
       },
       "type": "array"
+    },
+    "ignore_templates": {
+      "description": "Templates to ignore",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
     }
   }
 }

--- a/test/module/config/test_config_mixin.py
+++ b/test/module/config/test_config_mixin.py
@@ -101,10 +101,26 @@ class TestConfigMixIn(BaseTestCase):
         """ Test precedence in  """
 
         yaml_mock.side_effect = [
-            {'templates': ['*.yaml']},
+            {'templates': ['test/fixtures/templates/badpath/*.yaml']},
             {}
         ]
         config = cfnlint.config.ConfigMixIn([])
 
         # test defaults
-        self.assertEqual(config.templates, ['*.yaml'])
+        self.assertEqual(config.templates, ['test/fixtures/templates/badpath/*.yaml'])
+
+    @patch('cfnlint.config.ConfigFileArgs._read_config', create=True)
+    def test_config_expand_ignore_templates(self, yaml_mock):
+        """ Test ignore templates """
+
+        yaml_mock.side_effect = [
+            {
+                'templates': ['test/fixtures/templates/bad/resources/iam/*.yaml'],
+                'ignore_templates': ['test/fixtures/templates/bad/resources/iam/resource_*.yaml']},
+            {}
+        ]
+        config = cfnlint.config.ConfigMixIn([])
+
+        # test defaults
+        self.assertNotIn('test/fixtures/templates/bad/resources/iam/resource_policy.yaml', config.templates)
+        self.assertEqual(len(config.templates), 2)

--- a/test/module/core/test_run_cli.py
+++ b/test/module/core/test_run_cli.py
@@ -81,8 +81,14 @@ class TestCli(BaseTestCase):
 
         self.assertEqual(len(matches), 1)
 
-    def test_template_config(self):
+    @patch('cfnlint.config.ConfigFileArgs._read_config', create=True)
+    def test_template_config(self, yaml_mock):
         """Test template config"""
+        yaml_mock.side_effect = [
+            {},
+            {}
+        ]
+
         filename = 'test/fixtures/templates/good/core/config_parameters.yaml'
         (args, _, _,) = cfnlint.core.get_args_filenames([
             '--template', filename, '--ignore-bad-template'])
@@ -101,8 +107,14 @@ class TestCli(BaseTestCase):
         self.assertEqual(args.update_documentation, False)
         self.assertEqual(args.update_specs, False)
 
-    def test_positional_template_parameters(self):
+    @patch('cfnlint.config.ConfigFileArgs._read_config', create=True)
+    def test_positional_template_parameters(self, yaml_mock):
         """Test overriding parameters"""
+        yaml_mock.side_effect = [
+            {},
+            {}
+        ]
+
         filename = 'test/fixtures/templates/good/core/config_parameters.yaml'
         (args, _, _) = cfnlint.core.get_args_filenames([
             filename, '--ignore-bad-template',
@@ -121,8 +133,14 @@ class TestCli(BaseTestCase):
         self.assertEqual(args.update_documentation, False)
         self.assertEqual(args.update_specs, False)
 
-    def test_override_parameters(self):
+    @patch('cfnlint.config.ConfigFileArgs._read_config', create=True)
+    def test_override_parameters(self, yaml_mock):
         """Test overriding parameters"""
+        yaml_mock.side_effect = [
+            {},
+            {}
+        ]
+
         filename = 'test/fixtures/templates/good/core/config_parameters.yaml'
         (args, _, _) = cfnlint.core.get_args_filenames([
             '--template', filename, '--ignore-bad-template',
@@ -141,8 +159,13 @@ class TestCli(BaseTestCase):
         self.assertEqual(args.update_documentation, False)
         self.assertEqual(args.update_specs, False)
 
-    def test_bad_config(self):
+    @patch('cfnlint.config.ConfigFileArgs._read_config', create=True)
+    def test_bad_config(self, yaml_mock):
         """ Test bad formatting in config"""
+        yaml_mock.side_effect = [
+            {},
+            {}
+        ]
 
         filename = 'test/fixtures/templates/bad/core/config_parameters.yaml'
         (args, _, _) = cfnlint.core.get_args_filenames([


### PR DESCRIPTION
*Issue #, if available:*
Fix #531
*Description of changes:*
- Allow for ignoring certain templates when linting multiple files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
