### PR TITLE
Load package resource strings directly

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -121,7 +121,7 @@ LIMITS = {
 }
 
 
-def load_resources(filename='/data/CloudSpecs/us-east-1.json'):
+def load_resources(filename='data/CloudSpecs/us-east-1.json'):
     """Load resources"""
 
     filename = pkg_resources.resource_filename(
@@ -205,7 +205,7 @@ def is_custom_resource(resource_type):
 def initialize_specs():
     """ Reload Resource Specs """
     for reg in REGIONS:
-        RESOURCE_SPECS[reg] = load_resources(filename=('/data/CloudSpecs/%s.json' % reg))
+        RESOURCE_SPECS[reg] = load_resources(filename=('data/CloudSpecs/%s.json' % reg))
 
 
 initialize_specs()

--- a/src/cfnlint/rules/resources/rds/InstanceSize.py
+++ b/src/cfnlint/rules/resources/rds/InstanceSize.py
@@ -29,7 +29,7 @@ class InstanceSize(CloudFormationLintRule):
     source_url = 'https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html'
     tags = ['resources', 'rds']
 
-    valid_instance_types = cfnlint.helpers.load_resources('/data/AdditionalSpecs/RdsProperties.json')
+    valid_instance_types = cfnlint.helpers.load_resources('data/AdditionalSpecs/RdsProperties.json')
 
     def get_resources(self, cfn):
         """ Get resources that can be checked """


### PR DESCRIPTION
*Issue #, if available:*
#691

*Description of changes:*
- Uses pkg resource strings to load the JSON documents removing one of our deprecation warnings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
