### PR TITLE
Removed resource spec patches no longer required

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -20532,7 +20532,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -19335,7 +19335,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -12861,7 +12861,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -18069,7 +18069,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -19109,7 +19109,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -19655,7 +19655,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -16895,7 +16895,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -20077,7 +20077,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -13461,7 +13461,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -22912,7 +22912,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -17433,7 +17433,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -15851,7 +15851,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -16426,7 +16426,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -22913,7 +22913,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -21254,7 +21254,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -13222,7 +13222,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -13316,7 +13316,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -17278,7 +17278,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -22931,7 +22931,8 @@
           "UpdateType": "Mutable"
         },
         "Metrics": {
-          "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
+          "DuplicatesAllowed": false,
           "ItemType": "MetricDataQuery",
           "Required": false,
           "Type": "List",

--- a/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
@@ -14,11 +14,6 @@
   },
   {
     "op": "replace",
-    "path": "/ResourceTypes/AWS::ApiGateway::Authorizer/Properties/Type/Required",
-    "value": true
-  },
-  {
-    "op": "replace",
     "path": "/PropertyTypes/AWS::CloudFront::Distribution.DistributionConfig/Properties/DefaultCacheBehavior/Required",
     "value": true
   },
@@ -54,16 +49,6 @@
   {
     "op": "replace",
     "path": "/PropertyTypes/AWS::Cognito::UserPool.SmsConfiguration/Properties/ExternalId/Required",
-    "value": true
-  },
-  {
-    "op": "replace",
-    "path": "/ResourceTypes/AWS::SNS::Subscription/Properties/TopicArn/Required",
-    "value": true
-  },
-  {
-    "op": "replace",
-    "path": "/ResourceTypes/AWS::SNS::Subscription/Properties/Protocol/Required",
     "value": true
   },
   {
@@ -169,17 +154,6 @@
           "UpdateType": "Mutable"
         }
       }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/ResourceTypes/AWS::CloudWatch::Alarm/Properties/Metrics",
-    "value": {
-      "Documentation": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarm-metrics",
-      "ItemType": "MetricDataQuery",
-      "Required": false,
-      "Type": "List",
-      "UpdateType": "Mutable"
     }
   },
   {

--- a/test/module/maintenance/test_patch_spec.py
+++ b/test/module/maintenance/test_patch_spec.py
@@ -43,10 +43,7 @@ class TestPatchJson(BaseTestCase):
             patched['PropertyTypes']['AWS::CloudFront::Distribution.DistributionConfig']['Properties']['DefaultCacheBehavior']['Required'])
         self.assertTrue(
             patched['PropertyTypes']['AWS::CloudFront::Distribution.DistributionConfig']['Properties']['Origins']['Required'])
-        self.assertIn('VpcEndpointType', patched['ResourceTypes']['AWS::EC2::VPCEndpoint']['Properties'])
         self.assertTrue(patched['PropertyTypes']['AWS::Cognito::UserPool.SmsConfiguration']['Properties']['ExternalId']['Required'])
-        self.assertTrue(patched['ResourceTypes']['AWS::SNS::Subscription']['Properties']['TopicArn']['Required'])
-        self.assertTrue(patched['ResourceTypes']['AWS::SNS::Subscription']['Properties']['Protocol']['Required'])
         self.assertEqual(patched['ResourceTypes']['AWS::ServiceDiscovery::Instance']['Properties']['InstanceAttributes']['Type'], 'Map')
         self.assertEqual(patched['ResourceTypes']['AWS::ServiceDiscovery::Instance']['Properties']['InstanceAttributes']['PrimitiveItemType'], 'String')
 
@@ -60,15 +57,9 @@ class TestPatchJson(BaseTestCase):
             Doesn't fail when a parent doesn't exist
         """
         spec = self.spec
-        del spec['ResourceTypes']['AWS::SNS::Subscription']
-        patched = patch_spec(spec, 'all')
-        self.assertNotIn('AWS::SNS::Subscription', patched['ResourceTypes'])
 
     def test_failure_in_patch_move(self):
         """
             Doesn't fail when final key doesn't match
         """
         spec = self.spec
-        del spec['ResourceTypes']['AWS::EC2::VPCEndpoint']['Properties']['VPCEndpointType']
-        patched = patch_spec(spec, 'all')
-        self.assertNotIn('VPCEndpointType', patched['ResourceTypes']['AWS::EC2::VPCEndpoint']['Properties'])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove resource spec patches that are no longer necessary:
* /ResourceTypes/AWS::ApiGateway::Authorizer/Properties/Type/
* /ResourceTypes/AWS::SNS::Subscription/Properties/TopicArn/
* /ResourceTypes/AWS::SNS::Subscription/Properties/Protocol
* /ResourceTypes/AWS::CloudWatch::Alarm/Properties/Metrics

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
