### PR TITLE
Fix CodePipeline input, and output artifact numbers for action Test and provider CodeBuild

### DIFF
--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
@@ -40,8 +40,8 @@ class CodepipelineStageActions(CloudFormationLintRule):
             },
             'Test': {
                 'CodeBuild': {
-                    'InputArtifactRange': 1,
-                    'OutputArtifactRange': (0, 1),
+                    'InputArtifactRange': (1, 5),
+                    'OutputArtifactRange': (0, 5),
                 }
             },
             'Approval': {

--- a/test/fixtures/templates/bad/resources_codepipeline_action_artifact_counts.yaml
+++ b/test/fixtures/templates/bad/resources_codepipeline_action_artifact_counts.yaml
@@ -41,6 +41,30 @@ Resources:
               OutputArtifacts:
               - Name: MyOutput1
               - Name: MyOutput2  # No Longer an error
+        - Name: Test
+          Actions:
+            - Name: Validate
+              ActionTypeId:
+                Category: Test
+                Owner: AWS
+                Provider: CodeBuild
+                Version: "1"
+              Configuration:
+                ProjectName: cfn-python-lint
+              InputArtifacts:
+                - Name: MyOutput1
+                - Name: MyOutput2
+                - Name: MyOutput3
+                - Name: MyOutput4
+                - Name: MyOutput5
+                - Name: MyOutput6 # Error
+              OutputArtifacts:
+                - Name: MyOutput1
+                - Name: MyOutput2
+                - Name: MyOutput3
+                - Name: MyOutput4
+                - Name: MyOutput5
+                - Name: MyOutput6 # Error
         - Name: MyApprovalStage
           Actions:
             - Name: MyApprovalAction

--- a/test/rules/resources/codepipeline/test_stageactions.py
+++ b/test/rules/resources/codepipeline/test_stageactions.py
@@ -31,7 +31,7 @@ class TestCodePipelineStageActions(BaseRuleTestCase):
 
     def test_file_artifact_counts(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources_codepipeline_action_artifact_counts.yaml', 2)
+        self.helper_file_negative('test/fixtures/templates/bad/resources_codepipeline_action_artifact_counts.yaml', 4)
 
     def test_file_invalid_version(self):
         """Test failure"""


### PR DESCRIPTION
Set **input** and **output** artifacts numbers to the latest valid values for **action** `Test` with **provider** `CodeBuild`.

See`AWS` [documentation](https://docs.aws.amazon.com/codepipeline/latest/userguide/reference-pipeline-structure.html#pipeline-requirements)

P.s

It looks like that there are more missing **action** and **providers** very likely that we'll add them with another **PR** later this week.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
