### PR TITLE
Force Role ARNs to use GetAtt

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -33897,9 +33897,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -31648,9 +31648,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -22059,9 +22059,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -29943,9 +29943,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -31294,9 +31294,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -32374,9 +32374,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -28280,9 +28280,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -33050,9 +33050,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -23451,9 +23451,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -37564,9 +37564,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -29614,9 +29614,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -26446,9 +26446,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -27463,9 +27463,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -37623,9 +37623,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -35133,9 +35133,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -22392,9 +22392,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -22760,9 +22760,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -29119,9 +29119,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -37648,9 +37648,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::Role"
         ]
       }
     },

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1077,9 +1077,6 @@
         "Ref": {
           "Parameters": [
             "String"
-          ],
-          "Resources": [
-            "AWS::IAM::Role"
           ]
         }
       },


### PR DESCRIPTION
*Issue #, if available:*
Fix #715 
*Description of changes:*
Force References to Role ARNs to use the GetAtt and not Ref

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
