### PR TITLE
Remove extra blank line when there are no errors

### DIFF
--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -39,7 +39,8 @@ def main():
                 matches.extend(template_matches)
             LOGGER.debug('Completed linting of file: %s', str(filename))
 
-        print(formatter.print_matches(matches))
+        if matches:
+            print(formatter.print_matches(matches))
         return cfnlint.core.get_exit_code(matches)
     except cfnlint.core.CfnLintExitException as e:
         LOGGER.error(str(e))


### PR DESCRIPTION
Introduced `in 0.14.1`. Reported in Slack:

```
Kind of a weird question.. From cfn-lint 0.15.0 I've started to notice 
that when I run cfn-lint an empty line is printed afterwards. It happens 
regardless of whether I add `-f quiet`, and I can't reproduce it on 0.14.0. 
Should I create an issue for it on GitHub or am I just doing something wrong?
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
