### PR TITLE
Remove the !Sub checks in the Allowed Pattern rule

### DIFF
--- a/src/cfnlint/rules/resources/properties/AllowedPattern.py
+++ b/src/cfnlint/rules/resources/properties/AllowedPattern.py
@@ -45,11 +45,13 @@ class AllowedPattern(CloudFormationLintRule):
             if isinstance(value[0], six.string_types):
                 # Remove the sub (${}) from the value
                 stripped_value = re.sub(r'\${.*}', '', value[0])
-                matches.extend(self.check_value(stripped_value, path[:] + [0], property_name, **kwargs))
+                if stripped_value:
+                    matches.extend(self.check_value(stripped_value, path[:] + [0], property_name, **kwargs))
         else:
             # Remove the sub (${}) from the value
             stripped_value = re.sub(r'\${.*}', '', value)
-            matches.extend(self.check_value(stripped_value, path[:], property_name, **kwargs))
+            if stripped_value:
+                matches.extend(self.check_value(stripped_value, path[:], property_name, **kwargs))
         return matches
 
     def check_value(self, value, path, property_name, **kwargs):

--- a/test/fixtures/templates/bad/properties_sg_ingress.yaml
+++ b/test/fixtures/templates/bad/properties_sg_ingress.yaml
@@ -16,6 +16,9 @@ Parameters:
   mySecurityGroupList:
     Description: Security Group List
     Type: List<Number>
+  myCidrIP:
+    Type: String
+    Default: "10.0.0.0/8"
 Resources:
   mySecurityGroupNonVpc:
     Type: AWS::EC2::SecurityGroup
@@ -41,6 +44,9 @@ Resources:
       -
         IpProtocol: "1"
         CidrIp: "10.0.0.0"
+      -
+        IpProtocol: "1"
+        CidrIp: !Sub "${myCidrIP}"
       -
         IpProtocol: 1
         SourceSecurityGroupId: !Ref mySecurityGroupNonVpc


### PR DESCRIPTION
*Issue https://github.com/aws-cloudformation/cfn-python-lint/issues/725, if available:*

A `!Sub` can also be used as a `!Ref`, in which the string that is checked is empty. The PR handles this scenario (added the test scenario from the issue)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
