### PR TITLE
Fix the Matches output (again)

### DIFF
--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -39,8 +39,9 @@ def main():
                 matches.extend(template_matches)
             LOGGER.debug('Completed linting of file: %s', str(filename))
 
-        if matches:
-            print(formatter.print_matches(matches))
+        matches_output = formatter.print_matches(matches)
+        if matches_output:
+            print(matches_output)
         return cfnlint.core.get_exit_code(matches)
     except cfnlint.core.CfnLintExitException as e:
         LOGGER.error(str(e))

--- a/src/cfnlint/formatters/__init__.py
+++ b/src/cfnlint/formatters/__init__.py
@@ -25,6 +25,9 @@ class BaseFormatter(object):
 
     def print_matches(self, matches):
         """Output all the matches"""
+        if not matches:
+            return None
+
         # Output each match on a separate line by default
         output = []
         for match in matches:


### PR DESCRIPTION
The previous hot-fix was not really correct (oops). The IDE plugins _always_ expect a json. So with no matches a `[]`.  The previous fix was incorrect since it didn't output anything.

Slighty reworked the code: The Formatter builds the output. Only if there is output it is printed
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
