### PR TITLE
Allow the use of literals in Sub needed rule

### DIFF
--- a/src/cfnlint/rules/functions/SubNeeded.py
+++ b/src/cfnlint/rules/functions/SubNeeded.py
@@ -91,9 +91,14 @@ class SubNeeded(CloudFormationLintRule):
 
             # Exxclude the special IAM variables
             variable = parameter_string_path[-1]
+
             if 'Resource' in parameter_string_path:
                 if variable in self.resource_excludes:
                     continue
+
+            # Exclude literals (https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html)
+            if variable.startswith('${!'):
+                continue
 
             found_sub = False
             # Does the path contain an 'Fn::Sub'?

--- a/test/fixtures/templates/good/functions/sub_needed.yaml
+++ b/test/fixtures/templates/good/functions/sub_needed.yaml
@@ -18,6 +18,10 @@ Resources:
           Action:
             - "iam:UploadSSHPublicKey"
           Resource: "arn:aws:iam::*:user/${aws:username}"
+  Key:
+    Type: AWS::ApiGateway::ApiKey
+    Properties:
+      Description: "This is a literal instead of a sub: ${!Test2}"
   GreetingRequest:
     Type: AWS::ApiGateway::Method
     Properties:


### PR DESCRIPTION
*Issue https://github.com/aws-cloudformation/cfn-python-lint/issues/740:*

Support the use of literals in the SubNeeded rule. [Documentation]()https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html:

```To write a dollar sign and curly braces (${}) literally, add an exclamation point (!) after the open curly brace, such as ${!Literal}. AWS CloudFormation resolves this text as ${Literal}.```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
