### PR TITLE
Add Spec patch to make AWS::DynamoDB::Table AttributeDefinitions required

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -23782,7 +23782,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -21458,7 +21458,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -13498,7 +13498,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -19766,7 +19766,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -20871,7 +20871,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -22762,7 +22762,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -18592,7 +18592,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -23431,7 +23431,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -14508,7 +14508,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -26219,7 +26219,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -19535,7 +19535,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -17098,7 +17098,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -18123,7 +18123,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -26041,7 +26041,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -23719,7 +23719,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -13859,7 +13859,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -13953,7 +13953,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -19162,7 +19162,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -26059,7 +26059,7 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#cfn-dynamodb-table-attributedef",
           "DuplicatesAllowed": true,
           "ItemType": "AttributeDefinition",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Conditional"
         },

--- a/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
@@ -28,6 +28,11 @@
     "value": true
   },
   {
+    "op": "replace",
+    "path": "/ResourceTypes/AWS::DynamoDB::Table/Properties/AttributeDefinitions/Required",
+    "value": true
+  },
+  {
     "op": "move",
     "from": "/ResourceTypes/AWS::EC2::VPCEndpoint/Properties/VPCEndpointType",
     "path": "/ResourceTypes/AWS::EC2::VPCEndpoint/Properties/VpcEndpointType"

--- a/test/fixtures/templates/bad/formatters.yaml
+++ b/test/fixtures/templates/bad/formatters.yaml
@@ -7,6 +7,9 @@ Resources:
     Type: "AWS::DynamoDB::Table"
     Properties:
       TableName: !Sub "TableName"
+      AttributeDefinitions:
+        - AttributeName: "Id"
+          AttributeType: "S" # Valid AllowedValue
       KeySchema:
         -
           AttributeName: "ArtistId"


### PR DESCRIPTION
*Issue https://github.com/aws-cloudformation/cfn-python-lint/issues/713:*

Spec patch `AWS::DynamoDB::Table.AttributeDefinitions` to be required


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
