### PR TITLE
add rule to check network loadbalancer configuration

### DIFF
--- a/src/cfnlint/rules/resources/elb/Elb.py
+++ b/src/cfnlint/rules/resources/elb/Elb.py
@@ -71,4 +71,12 @@ HTTPS has certificate HTTP has no certificate'
                             certificate_protocols=['HTTPS', 'SSL'],
                             certificates=listener.get('SSLCertificateId')))
 
+        results = cfn.get_resource_properties(['AWS::ElasticLoadBalancingV2::LoadBalancer'])
+        for result in results:
+            properties = result['Value']
+            if 'Type' in properties and properties['Type'] == 'network':
+                if 'SecurityGroups' in properties:
+                    path = result['Path'] + ['SecurityGroups']
+                    matches.append(RuleMatch(path, 'Security groups are not supported for load balancers with type "network"'))
+
         return matches

--- a/test/fixtures/templates/bad/properties_elb.yaml
+++ b/test/fixtures/templates/bad/properties_elb.yaml
@@ -44,7 +44,7 @@ Resources:
           Value: 60
       Name: !Ref Name
       # application, network
-      Type: application
+      Type: network
       # internet-facing, internal
       Scheme: !Ref Scheme
       Subnets: !Ref Subnets

--- a/test/rules/resources/elb/test_elb.py
+++ b/test/rules/resources/elb/test_elb.py
@@ -34,4 +34,4 @@ class TestPropertyElb(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/properties_elb.yaml', 5)
+        self.helper_file_negative('test/fixtures/templates/bad/properties_elb.yaml', 6)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I had an issue when deploying a Network Load Balancer. If the type is 'Network' it can't have the property SecurityGroups


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
