### PR TITLE
Update rule E2541 to not error when action names are not strings

### DIFF
--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
@@ -14,6 +14,7 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+import six
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 
@@ -39,6 +40,12 @@ class CodepipelineStageActions(CloudFormationLintRule):
                 }
             },
             'Test': {
+                'CodeBuild': {
+                    'InputArtifactRange': (1, 5),
+                    'OutputArtifactRange': (0, 5),
+                }
+            },
+            'Build': {
                 'CodeBuild': {
                     'InputArtifactRange': (1, 5),
                     'OutputArtifactRange': (0, 5),
@@ -167,12 +174,14 @@ class CodepipelineStageActions(CloudFormationLintRule):
         """Check that action names are unique."""
         matches = []
 
-        if action.get('Name') in action_names:
-            message = 'All action names within a stage must be unique. ({name})'.format(
-                name=action.get('Name')
-            )
-            matches.append(RuleMatch(path + ['Name'], message))
-        action_names.add(action.get('Name'))
+        action_name = action.get('Name')
+        if isinstance(action_name, six.string_types):
+            if action.get('Name') in action_names:
+                message = 'All action names within a stage must be unique. ({name})'.format(
+                    name=action.get('Name')
+                )
+                matches.append(RuleMatch(path + ['Name'], message))
+            action_names.add(action.get('Name'))
 
         return matches
 

--- a/test/fixtures/templates/good/resources/codepipeline/stage_actions.yaml
+++ b/test/fixtures/templates/good/resources/codepipeline/stage_actions.yaml
@@ -1,6 +1,9 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: >
-  Bad CodePipeline Template
+  Good CodePipeline Template
+Parameters:
+  CodeBuild:
+    Type: String
 Resources:
   TestPipeline:
     Type: AWS::CodePipeline::Pipeline
@@ -29,21 +32,7 @@ Resources:
                 OAuthToken: 'secret-token'
         - Name: MoreSource
           Actions:
-            - Name: !Ref Github
-              ActionTypeId:
-                Category: Source
-                Owner: ThirdParty
-                Provider: GitHub
-                Version: "1"
-              OutputArtifacts:
-                - Name: MyApp2
-              Configuration:
-                Owner: aws-cloudformation
-                Repo: cfn-python-lint
-                PollForSourceChanges: true
-                Branch: master
-                OAuthToken: 'secret-token'
-            - Name: CodeBuild
+            - Name: !Ref CodeBuild   # doesn't fail when Ref is used
               ActionTypeId:
                 Category: Build
                 Owner: AWS

--- a/test/rules/resources/codepipeline/test_stageactions.py
+++ b/test/rules/resources/codepipeline/test_stageactions.py
@@ -24,6 +24,9 @@ class TestCodePipelineStageActions(BaseRuleTestCase):
         """Setup"""
         super(TestCodePipelineStageActions, self).setUp()
         self.collection.register(CodepipelineStageActions())
+        self.success_templates = [
+            'test/fixtures/templates/good/resources/codepipeline/stage_actions.yaml'
+        ]
 
     def test_file_positive(self):
         """Test Positive"""


### PR DESCRIPTION
*Issue #, if available:*
Fix #752
*Description of changes:*
- Update rule E2541 to only check for duplicate names when the action name is a string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
