### PR TITLE
Convert ContentUri in LayerVersion

### DIFF
--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -70,7 +70,9 @@ class Transform(object):
             if resource_type == 'AWS::Serverless::Function':
 
                 Transform._update_to_s3_uri('CodeUri', resource_dict)
-
+            if resource_type in ['AWS::Serverless::LayerVersion']:
+                if resource_dict.get('ContentUri'):
+                    Transform._update_to_s3_uri('ContentUri', resource_dict)
             if resource_type == 'AWS::Serverless::Api':
                 if 'DefinitionBody' not in resource_dict:
                     Transform._update_to_s3_uri('DefinitionUri', resource_dict)

--- a/test/fixtures/templates/bad/transform_serverless_template.yaml
+++ b/test/fixtures/templates/bad/transform_serverless_template.yaml
@@ -47,6 +47,12 @@ Resources:
               detail:
                 state:
                   - terminated
+  ExampleLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+        LayerName: "Example"
+        CompatibleRuntimes:
+            - python3.6
   myBucket:
     Type: AWS::S3::Bucket
     Properties: {}

--- a/test/fixtures/templates/good/transform.yaml
+++ b/test/fixtures/templates/good/transform.yaml
@@ -8,6 +8,13 @@ Resources:
       Handler: index.handler
       Runtime: nodejs4.3
       CodeUri: 's3://testBucket/mySourceCode.zip'
+  ExampleLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+        LayerName: "Example"
+        ContentUri: "./layers/example.zip"
+        CompatibleRuntimes:
+            - python3.6
 Outputs:
   myOutput:
     Value: !GetAtt [ MyServerlessFunctionLogicalID, Arn ]


### PR DESCRIPTION
*Issue #, if available:*
Fix #755
*Description of changes:*
- Convert AWS::Serverless::LayerVersion ContentUri to a S3 bucket location for lintening

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
