### PR TITLE
Convert Serverless Application Location to String to prevent lookup

### DIFF
--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -73,6 +73,10 @@ class Transform(object):
             if resource_type in ['AWS::Serverless::LayerVersion']:
                 if resource_dict.get('ContentUri'):
                     Transform._update_to_s3_uri('ContentUri', resource_dict)
+            if resource_type == 'AWS::Serverless::Application':
+                if resource_dict.get('Location'):
+                    resource_dict['Location'] = ''
+                    Transform._update_to_s3_uri('Location', resource_dict)
             if resource_type == 'AWS::Serverless::Api':
                 if 'DefinitionBody' not in resource_dict:
                     Transform._update_to_s3_uri('DefinitionUri', resource_dict)

--- a/test/fixtures/templates/bad/transform_serverless_template.yaml
+++ b/test/fixtures/templates/bad/transform_serverless_template.yaml
@@ -53,6 +53,13 @@ Resources:
         LayerName: "Example"
         CompatibleRuntimes:
             - python3.6
+  AppName:
+    Type: AWS::Serverless::Application
+    Properties:
+      Parameters:
+        Debug: 'True'
+        MemorySizeMB: '128'
+        TimeoutSec: '300'
   myBucket:
     Type: AWS::S3::Bucket
     Properties: {}

--- a/test/fixtures/templates/good/transform.yaml
+++ b/test/fixtures/templates/good/transform.yaml
@@ -15,6 +15,16 @@ Resources:
         ContentUri: "./layers/example.zip"
         CompatibleRuntimes:
             - python3.6
+  AppName:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location:
+        ApplicationId: arn:aws:serverlessrepo:us-west-2:<my-account-id>:applications/<app-name>
+        SemanticVersion: 1.0.0
+      Parameters:
+        Debug: 'True'
+        MemorySizeMB: '128'
+        TimeoutSec: '300'
 Outputs:
   myOutput:
     Value: !GetAtt [ MyServerlessFunctionLogicalID, Arn ]

--- a/test/integration/test_good_templates.py
+++ b/test/integration/test_good_templates.py
@@ -43,6 +43,10 @@ class TestQuickStartTemplates(BaseTestCase):
                 "filename": 'test/fixtures/templates/good/transform.yaml',
                 "failures": 0
             },
+            'transform_bad': {
+                "filename": 'test/fixtures/templates/bad/transform_serverless_template.yaml',
+                "failures": 3
+            },
             'conditions': {
                 "filename": 'test/fixtures/templates/good/conditions.yaml',
                 "failures": 0


### PR DESCRIPTION
*Issue #, if available:*
Fix #700 
*Description of changes:*
Update pre-transform logic to switch a Serverless Application Location to a string preventing a lookup to the SAR


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
