### PR TITLE
Add IOT policy variables to the Sub needed excludes

### DIFF
--- a/src/cfnlint/rules/functions/SubNeeded.py
+++ b/src/cfnlint/rules/functions/SubNeeded.py
@@ -33,9 +33,13 @@ class SubNeeded(CloudFormationLintRule):
 
     # IAM Policy has special variables that don't require !Sub, Check for these
     # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html
+    # https://docs.aws.amazon.com/iot/latest/developerguide/basic-policy-variables.html
+    # https://docs.aws.amazon.com/iot/latest/developerguide/thing-policy-variables.html
     resource_excludes = ['${aws:CurrentTime}', '${aws:EpochTime}', '${aws:TokenIssueTime}', '${aws:principaltype}',
                          '${aws:SecureTransport}', '${aws:SourceIp}', '${aws:UserAgent}', '${aws:userid}',
-                         '${aws:username}', '${ec2:SourceInstanceARN}']
+                         '${aws:username}', '${ec2:SourceInstanceARN}',
+                         '${iot:Connection.Thing.ThingName}', '${iot:Connection.Thing.ThingTypeName}',
+                         '${iot:Connection.Thing.IsAttached}', '${iot:ClientId}']
 
     def _match_values(self, searchRegex, cfnelem, path):
         """Recursively search for values matching the searchRegex"""

--- a/test/fixtures/templates/good/functions/sub_needed.yaml
+++ b/test/fixtures/templates/good/functions/sub_needed.yaml
@@ -54,3 +54,22 @@ Resources:
       RestApiId: !Ref GreetingApi
       MethodResponses:
       - StatusCode: '200'
+  IOTPolicies:
+    Type: "AWS::IoT::Policy"
+    Properties:
+      PolicyName: "root"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - iot:GetThingShadow
+              - iot:UpdateThingShadow
+              - iot:DeleteThingShadow
+            Resource:
+              - Fn::Join:
+                - ':'
+                - - arn:aws:iot
+                  - !Ref AWS::Region
+                  - !Ref AWS::AccountId
+                  - thing/${iot:Connection.Thing.ThingName}*


### PR DESCRIPTION
*Issue https://github.com/aws-cloudformation/cfn-python-lint/issues/764*

IoT also has Policy Variables: https://docs.aws.amazon.com/iot/latest/developerguide/thing-policy-variables.html and https://docs.aws.amazon.com/iot/latest/developerguide/basic-policy-variables.html

This PR adds these to the excluded. All but 1: `iot:Connection.Thing.Attributes[attributeName]`
The rule does not support this 'regex-like' configuration, that still need to be solved. So this does not solve the entire issue but already already catches most of them, making it valuable enough to add this in already.

Besides that, the exclude list could/should be improved, since the IoT policv variables apply to a specific `AWS::IoT::Policy`.

I think this is an improvement compared to "not checking it at all" and returning false negatives... But it needs to be improved further. Summary:

- Support "regex format" variables (`iot:Connection.Thing.Attributes[attributeName]`)
- Add separation of the excludes per resource type. Some apply to all, some to specific policies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
