### PR TITLE
Try catch around final _loc call

### DIFF
--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -824,7 +824,10 @@ class Template(object):
             # If the last item of the path is an integer, and the vaue is an array,
             # Get the location of the item in the array
             if isinstance(text, list) and isinstance(path[0], int):
-                result = self._loc(text[path[0]])
+                try:
+                    result = self._loc(text[path[0]])
+                except AttributeError as err:
+                    LOGGER.debug(err)
             else:
                 try:
                     for key in text:

--- a/test/module/cfn_json/test_cfn_json.py
+++ b/test/module/cfn_json/test_cfn_json.py
@@ -48,7 +48,7 @@ class TestCfnJson(BaseTestCase):
             },
             "vpc_management": {
                 "filename": 'test/fixtures/templates/quickstart/vpc-management.json',
-                "failures": 33
+                "failures": 35
             },
             "vpc": {
                 "filename": 'test/fixtures/templates/quickstart/vpc.json',


### PR DESCRIPTION
*Issue #, if available:*
Fix #768 
*Description of changes:*
Try catch around the last of the _loc calls.  Getting the value start and end mark will only work for strings as we don't currently override the int, float, float, etc. structures to support it but we would need to make sure we cover them all.  This seems easier.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
