### PR TITLE
Update 03_value_types.json

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -926,7 +926,7 @@
           "azuredb",
           "db2",
           "dynamodb",
-          "mariad",
+          "mariadb",
           "mongodb",
           "mysql",
           "oracle",


### PR DESCRIPTION
Fixed typo in mariadb

Issue #, if available: #774 

Description of changes: Fixed typo in mariadb name for AllowedValues


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
