### PR TITLE
When auth is present for API Gateway use DefinitionBody instead

### DIFF
--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -78,8 +78,10 @@ class Transform(object):
                     resource_dict['Location'] = ''
                     Transform._update_to_s3_uri('Location', resource_dict)
             if resource_type == 'AWS::Serverless::Api':
-                if 'DefinitionBody' not in resource_dict:
+                if 'DefinitionBody' not in resource_dict and 'Auth' not in resource_dict:
                     Transform._update_to_s3_uri('DefinitionUri', resource_dict)
+                else:
+                    resource_dict['DefinitionBody'] = ''
 
     def transform_template(self):
         """


### PR DESCRIPTION
*Issue #, if available:*
Fix #756
*Description of changes:*
- When Auth is in the API definition use DefinitionBody instead of DefinitionUri

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
