### PR TITLE
Add GuardDuty allowed values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -29376,7 +29376,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -29387,7 +29390,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyFilterAction"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description",
@@ -29440,7 +29446,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyIPSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-location",
@@ -29516,7 +29525,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html#cfn-guardduty-member-status",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyMemberStatus"
+          }
         }
       }
     },
@@ -29539,7 +29551,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyThreadIntelSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-location",
@@ -36608,6 +36623,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -26638,7 +26638,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -26649,7 +26652,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyFilterAction"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description",
@@ -26702,7 +26708,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyIPSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-location",
@@ -26778,7 +26787,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html#cfn-guardduty-member-status",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyMemberStatus"
+          }
         }
       }
     },
@@ -26801,7 +26813,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyThreadIntelSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-location",
@@ -33078,6 +33093,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -22082,6 +22082,46 @@
         "SCHEDULED"
       ]
     },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
+      ]
+    },
     "HttpProtocol": {
       "AllowedValues": [
         "http",

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -24946,7 +24946,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -24957,7 +24960,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyFilterAction"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description",
@@ -25010,7 +25016,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyIPSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-location",
@@ -25086,7 +25095,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html#cfn-guardduty-member-status",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyMemberStatus"
+          }
         }
       }
     },
@@ -25109,7 +25121,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyThreadIntelSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-location",
@@ -31373,6 +31388,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -26051,7 +26051,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -26062,7 +26065,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyFilterAction"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description",
@@ -26115,7 +26121,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyIPSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-location",
@@ -26191,7 +26200,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html#cfn-guardduty-member-status",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyMemberStatus"
+          }
         }
       }
     },
@@ -26214,7 +26226,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyThreadIntelSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-location",
@@ -32757,6 +32772,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -28356,7 +28356,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -28367,7 +28370,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyFilterAction"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description",
@@ -28420,7 +28426,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyIPSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-location",
@@ -28496,7 +28505,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html#cfn-guardduty-member-status",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyMemberStatus"
+          }
         }
       }
     },
@@ -28519,7 +28531,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyThreadIntelSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-location",
@@ -35142,6 +35157,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -23350,7 +23350,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -23361,7 +23364,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyFilterAction"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description",
@@ -23414,7 +23420,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyIPSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-location",
@@ -23490,7 +23499,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html#cfn-guardduty-member-status",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyMemberStatus"
+          }
         }
       }
     },
@@ -23513,7 +23525,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyThreadIntelSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-location",
@@ -29630,6 +29645,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -29025,7 +29025,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -29036,7 +29039,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyFilterAction"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description",
@@ -29089,7 +29095,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyIPSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-location",
@@ -29165,7 +29174,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html#cfn-guardduty-member-status",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyMemberStatus"
+          }
         }
       }
     },
@@ -29188,7 +29200,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyThreadIntelSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-location",
@@ -36076,6 +36091,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -23549,6 +23549,46 @@
         "SCHEDULED"
       ]
     },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
+      ]
+    },
     "HttpProtocol": {
       "AllowedValues": [
         "http",

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -31906,7 +31906,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -31917,7 +31920,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyFilterAction"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description",
@@ -31970,7 +31976,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyIPSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-location",
@@ -32046,7 +32055,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html#cfn-guardduty-member-status",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyMemberStatus"
+          }
         }
       }
     },
@@ -32069,7 +32081,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyThreadIntelSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-location",
@@ -39930,6 +39945,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -24352,7 +24352,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -24363,7 +24366,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyFilterAction"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description",
@@ -24416,7 +24422,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyIPSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-location",
@@ -24492,7 +24501,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html#cfn-guardduty-member-status",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyMemberStatus"
+          }
         }
       }
     },
@@ -24515,7 +24527,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyThreadIntelSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-location",
@@ -31026,6 +31041,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -21212,7 +21212,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -27074,6 +27077,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -22009,7 +22009,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -22020,7 +22023,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyFilterAction"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description",
@@ -22073,7 +22079,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyIPSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-location",
@@ -22149,7 +22158,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html#cfn-guardduty-member-status",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyMemberStatus"
+          }
         }
       }
     },
@@ -22172,7 +22184,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyThreadIntelSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-location",
@@ -28032,6 +28047,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -31708,7 +31708,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -31719,7 +31722,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyFilterAction"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description",
@@ -31772,7 +31778,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyIPSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-location",
@@ -31848,7 +31857,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html#cfn-guardduty-member-status",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyMemberStatus"
+          }
         }
       }
     },
@@ -31871,7 +31883,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyThreadIntelSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-location",
@@ -39752,6 +39767,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -28961,7 +28961,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -28972,7 +28975,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyFilterAction"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description",
@@ -29025,7 +29031,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyIPSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-location",
@@ -29101,7 +29110,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html#cfn-guardduty-member-status",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyMemberStatus"
+          }
         }
       }
     },
@@ -29124,7 +29136,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyThreadIntelSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-location",
@@ -36506,6 +36521,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -22415,6 +22415,46 @@
         "SCHEDULED"
       ]
     },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
+      ]
+    },
     "HttpProtocol": {
       "AllowedValues": [
         "http",

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -22861,6 +22861,46 @@
         "SCHEDULED"
       ]
     },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
+      ]
+    },
     "HttpProtocol": {
       "AllowedValues": [
         "http",

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -23920,7 +23920,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -23931,7 +23934,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyFilterAction"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description",
@@ -23984,7 +23990,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyIPSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-location",
@@ -24060,7 +24069,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html#cfn-guardduty-member-status",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyMemberStatus"
+          }
         }
       }
     },
@@ -24083,7 +24095,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyThreadIntelSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-location",
@@ -30469,6 +30484,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -31696,7 +31696,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-detector.html#cfn-guardduty-detector-findingpublishingfrequency",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyDetectorFrequency"
+          }
         }
       }
     },
@@ -31707,7 +31710,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-action",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyFilterAction"
+          }
         },
         "Description": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-filter.html#cfn-guardduty-filter-description",
@@ -31760,7 +31766,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyIPSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-location",
@@ -31836,7 +31845,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-member.html#cfn-guardduty-member-status",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "GuardDutyMemberStatus"
+          }
         }
       }
     },
@@ -31859,7 +31871,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-format",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "GuardDutyThreadIntelSetFormat"
+          }
         },
         "Location": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-threatintelset.html#cfn-guardduty-threatintelset-location",
@@ -39733,6 +39748,46 @@
         "CONDITIONAL",
         "ON_DEMAND",
         "SCHEDULED"
+      ]
+    },
+    "GuardDutyDetectorFrequency": {
+      "AllowedValues": [
+        "FIFTEEN_MINUTES",
+        "ONE_HOUR",
+        "SIX_HOURS"
+      ]
+    },
+    "GuardDutyFilterAction": {
+      "AllowedValues": [
+        "ARCHIVE",
+        "NOOP"
+      ]
+    },
+    "GuardDutyIPSetFormat": {
+      "AllowedValues": [
+        "OTX_CSV",
+        "STIX",
+        "TXT"
+      ]
+    },
+    "GuardDutyMemberStatus": {
+      "AllowedValues": [
+        "Created",
+        "Disabled",
+        "Enabled",
+        "Invited",
+        "Removed",
+        "Resigned"
+      ]
+    },
+    "GuardDutyThreadIntelSetFormat": {
+      "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
+        "OTX_CSV",
+        "PROOF_POINT",
+        "STIX",
+        "TXT"
       ]
     },
     "HttpProtocol": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1056,6 +1056,46 @@
           "SUCCEEDED"
         ]
       },
+      "GuardDutyDetectorFrequency": {
+        "AllowedValues": [
+          "FIFTEEN_MINUTES",
+          "ONE_HOUR",
+          "SIX_HOURS"
+        ]
+      },
+      "GuardDutyFilterAction": {
+        "AllowedValues": [
+          "ARCHIVE",
+          "NOOP"
+        ]
+      },
+      "GuardDutyIPSetFormat": {
+        "AllowedValues": [
+          "OTX_CSV",
+          "STIX",
+          "TXT"
+        ]
+      },
+      "GuardDutyMemberStatus": {
+        "AllowedValues": [
+          "Created",
+          "Disabled",
+          "Enabled",
+          "Invited",
+          "Removed",
+          "Resigned"
+        ]
+      },
+      "GuardDutyThreadIntelSetFormat": {
+        "AllowedValues": [
+          "ALIEN_VAULT",
+          "FIRE_EYE",
+          "OTX_CSV",
+          "PROOF_POINT",
+          "STIX",
+          "TXT"
+        ]
+      },
       "HttpProtocol": {
         "AllowedValues": [
           "http",

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -1677,6 +1677,42 @@
       "ValueType": "VpcId"
     }
   },
+
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::GuardDuty::Detector/Properties/FindingPublishingFrequency/Value",
+    "value": {
+      "ValueType": "GuardDutyDetectorFrequency"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::GuardDuty::Filter/Properties/Action/Value",
+    "value": {
+      "ValueType": "GuardDutyFilterAction"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::GuardDuty::IPSet/Properties/Format/Value",
+    "value": {
+      "ValueType": "GuardDutyIPSetFormat"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::GuardDuty::Member/Properties/Status/Value",
+    "value": {
+      "ValueType": "GuardDutyMemberStatus"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::GuardDuty::ThreatIntelSet/Properties/Format/Value",
+    "value": {
+      "ValueType": "GuardDutyThreadIntelSetFormat"
+    }
+  },
   {
     "op": "add",
     "path": "/ResourceTypes/AWS::Neptune::DBInstance/Properties/DBInstanceClass/Value",

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -550,6 +550,41 @@ Resources:
         Conditions:
           - LogicalOperator: "GREATER_THAN" # Invalid AllowedValue
             State: "SUCEEDED" # Invalid AllowedValue
+  GuardDutyDetector:
+    Type: "AWS::GuardDuty::Detector"
+    Properties:
+      Enable: True
+      FindingPublishingFrequency: "HOURLY" # Invalid AllowedValue
+  GuardDutyFilter:
+    Type: "AWS::GuardDuty::Filter"
+    Properties:
+      Action: "Noop" # Invalid AllowedValue
+      Description: "A mandatory Description"
+      DetectorId: "-1"
+      FindingCriteria:
+        Criterion: {}
+      Rank: 1
+  GuardDutyIPSet:
+    Type: "AWS::GuardDuty::IPSet"
+    Properties:
+      Activate: False
+      DetectorId: "-1"
+      Format: "stix" # Invalid AllowedValue
+      Location: "http://localhost"
+  GuardDutyMember:
+    Type: AWS::GuardDuty::Member
+    Properties:
+      Email: "info@example.com"
+      MemberId: !Ref "AWS::AccountId"
+      DetectorId: "-1"
+      Status: "Active" # Invalid AllowedValue
+  GuardDutyThreadIntelSet:
+    Type: "AWS::GuardDuty::ThreatIntelSet"
+    Properties:
+      Activate: False
+      DetectorId: "-1"
+      Format: "ALIENVAULT" # Invalid AllowedValue
+      Location: "http://localhost"
   NeptuneInstance:
     Type: "AWS::Neptune::DBInstance"
     Properties:

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -249,6 +249,7 @@ Resources:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
       ComparisonOperator: "GreaterThan" # Invalid AllowedValue
+      MetricName: "my-metric"
       EvaluationPeriods: 1
       Statistic: "Total" # Invalid AllowedValue
       Threshold: 0.0
@@ -465,6 +466,7 @@ Resources:
   DLMPolicy:
     Type: "AWS::DLM::LifecyclePolicy"
     Properties:
+      ExecutionRoleArn: ""
       PolicyDetails:
         ResourceTypes:
           - "VOLUMES" # Invalid AllowedValue
@@ -676,7 +678,7 @@ Resources:
       DnsConfig:
         DnsRecords:
           - Type: "CNAME" # Invalid AllowedValue
-            TTL: "60"
+            TTL: 60
   SesReceiptRule:
     Type: "AWS::SES::ReceiptRule"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -558,6 +558,41 @@ Resources:
         Conditions:
           - LogicalOperator: "EQUALS" # Valid AllowedValue
             State: "SUCCEEDED" # Valid AllowedValue
+  GuardDutyDetector:
+    Type: "AWS::GuardDuty::Detector"
+    Properties:
+      Enable: True
+      FindingPublishingFrequency: "FIFTEEN_MINUTES" # Valid AllowedValue
+  GuardDutyFilter:
+    Type: "AWS::GuardDuty::Filter"
+    Properties:
+      Action: "NOOP" # Valid AllowedValue
+      Description: "A mandatory Description"
+      DetectorId: "-1"
+      FindingCriteria:
+        Criterion: {}
+      Rank: 1
+  GuardDutyIPSet:
+    Type: "AWS::GuardDuty::IPSet"
+    Properties:
+      Activate: False
+      DetectorId: "-1"
+      Format: "STIX" # Valid AllowedValue
+      Location: "http://localhost"
+  GuardDutyMember:
+    Type: AWS::GuardDuty::Member
+    Properties:
+      Email: "info@example.com"
+      MemberId: !Ref "AWS::AccountId"
+      DetectorId: "-1"
+      Status: "Resigned" # Valid AllowedValue
+  GuardDutyThreadIntelSet:
+    Type: "AWS::GuardDuty::ThreatIntelSet"
+    Properties:
+      Activate: False
+      DetectorId: "-1"
+      Format: "ALIEN_VAULT" # Valid AllowedValue
+      Location: "http://localhost"
   NeptuneInstance:
     Type: "AWS::Neptune::DBInstance"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -250,6 +250,7 @@ Resources:
     Properties:
       ComparisonOperator: "GreaterThanOrEqualToThreshold" # Valid AllowedValue
       EvaluationPeriods: 1
+      MetricName: "my-metric"
       Statistic: "SampleCount" # Valid AllowedValue
       Threshold: 0.0
       TreatMissingData: "notBreaching" # Valid AllowedValue
@@ -473,6 +474,7 @@ Resources:
   DLMPolicy:
     Type: "AWS::DLM::LifecyclePolicy"
     Properties:
+      ExecutionRoleArn: ""
       PolicyDetails:
         ResourceTypes:
           - "VOLUME" # Valid AllowedValue
@@ -683,7 +685,7 @@ Resources:
       DnsConfig:
         DnsRecords:
           - Type: "A" # Valid AllowedValue
-            TTL: "60"
+            TTL: 60
   SesReceiptRule:
     Type: "AWS::SES::ReceiptRule"
     Properties:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 160)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 165)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Add all the allowed values of the [`AWS::GuardDuty`]( https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-reference-guardduty.html) Resources


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
