### PR TITLE
Add AllowedValues for PerformanceInsightsRetentionPeriod

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -32198,7 +32198,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -36859,6 +36862,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -29135,7 +29135,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -33322,6 +33325,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -19402,7 +19402,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -22324,6 +22327,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -27443,7 +27443,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -31629,6 +31632,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -28585,7 +28585,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -33008,6 +33011,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -30971,7 +30971,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -35393,6 +35396,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -25766,7 +25766,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -29874,6 +29877,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -32058,7 +32058,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -36327,6 +36330,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -20464,7 +20464,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -23791,6 +23794,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -35170,7 +35170,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -40181,6 +40184,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -27156,7 +27156,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -31277,6 +31280,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -23453,7 +23453,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -27318,6 +27321,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -24382,7 +24382,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -28276,6 +28279,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -34972,7 +34972,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -40003,6 +40006,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -32225,7 +32225,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -36757,6 +36760,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -19719,7 +19719,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -22657,6 +22660,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -19881,7 +19881,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -23103,6 +23106,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -26535,7 +26535,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -30713,6 +30716,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -34960,7 +34960,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "PerformanceInsightsRetentionPeriod"
+          }
         },
         "Port": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-port",
@@ -39984,6 +39987,12 @@
           "String"
         ]
       }
+    },
+    "PerformanceInsightsRetentionPeriod": {
+      "AllowedValues": [
+        7,
+        731
+      ]
     },
     "PlacementGroup": {
       "GetAtt": {},

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1313,6 +1313,12 @@
           ]
         }
       },
+      "PerformanceInsightsRetentionPeriod": {
+        "AllowedValues": [
+          7,
+          731
+        ]
+      },
       "PlacementGroup": {
         "GetAtt": {
         },

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -1413,6 +1413,13 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::RDS::Instance/Properties/PerformanceInsightsRetentionPeriod/Value",
+    "value": {
+      "ValueType": "PerformanceInsightsRetentionPeriod"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::Route53::RecordSet/Properties/Failover/Value",
     "value": {
       "ValueType": "RecordSetFailover"


### PR DESCRIPTION
*Issue #50 , if available:*

*Description of changes:*

Noted that PerformanceInsightsRetentionPeriod can only be 7 or 731 days. https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
