### PR TITLE
Associate Instance Profiles Roles to the appropriate type

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -2850,7 +2850,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -7427,7 +7427,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -21837,7 +21837,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -25003,7 +25003,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -26970,7 +26970,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -36692,6 +36692,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -36709,9 +36710,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -2775,7 +2775,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -7275,7 +7275,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -19730,7 +19730,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -22679,7 +22679,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -24646,7 +24646,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -33162,6 +33162,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -33179,9 +33180,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -12253,7 +12253,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -13979,7 +13979,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -15694,7 +15694,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -22149,6 +22149,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -22166,9 +22167,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -2479,7 +2479,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -6551,7 +6551,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -18443,7 +18443,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -20987,7 +20987,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -22954,7 +22954,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -31457,6 +31457,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -31474,9 +31475,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -2775,7 +2775,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -6913,7 +6913,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -19448,7 +19448,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -22092,7 +22092,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -24059,7 +24059,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -32841,6 +32841,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -32858,9 +32859,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -2850,7 +2850,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -7416,7 +7416,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -20960,7 +20960,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -23983,7 +23983,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -25950,7 +25950,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -35226,6 +35226,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -35243,9 +35244,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -2313,7 +2313,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -6385,7 +6385,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -17232,7 +17232,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -19776,7 +19776,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -21703,7 +21703,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -29714,6 +29714,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -29731,9 +29732,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -2775,7 +2775,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -7341,7 +7341,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -21382,7 +21382,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -24652,7 +24652,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -26619,7 +26619,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -36160,6 +36160,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -36177,9 +36178,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -12872,7 +12872,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -14935,7 +14935,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -16756,7 +16756,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -23616,6 +23616,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -23633,9 +23634,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -2850,7 +2850,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -7484,7 +7484,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -23933,7 +23933,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -27440,7 +27440,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -29407,7 +29407,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -40014,6 +40014,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -40031,9 +40032,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -2313,7 +2313,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -6830,7 +6830,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -17759,7 +17759,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -20738,7 +20738,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -22705,7 +22705,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -31110,6 +31110,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -31127,9 +31128,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -1516,7 +1516,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -5090,7 +5090,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -15515,7 +15515,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -17598,7 +17598,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -19565,7 +19565,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -27146,6 +27146,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -27163,9 +27164,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -1516,7 +1516,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -5588,7 +5588,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -16086,7 +16086,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -18604,7 +18604,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -20362,7 +20362,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -28116,6 +28116,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -28133,9 +28134,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -2850,7 +2850,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -7484,7 +7484,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -23736,7 +23736,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -27243,7 +27243,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -29240,7 +29240,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -39836,6 +39836,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -39853,9 +39854,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -2692,7 +2692,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -7315,7 +7315,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -21576,7 +21576,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -24940,7 +24940,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -26907,7 +26907,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -36590,6 +36590,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -36607,9 +36608,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -12614,7 +12614,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -14267,7 +14267,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -15982,7 +15982,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -22482,6 +22482,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -22499,9 +22500,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -12708,7 +12708,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -14361,7 +14361,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -16076,7 +16076,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -22928,6 +22928,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -22945,9 +22946,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -2451,7 +2451,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -6583,7 +6583,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -17615,7 +17615,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -20346,7 +20346,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -22273,7 +22273,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -30553,6 +30553,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -30570,9 +30571,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -2850,7 +2850,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "InstanceTypes": {
@@ -7484,7 +7484,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         }
       }
@@ -23754,7 +23754,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -27261,7 +27261,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "ImageId": {
@@ -29228,7 +29228,7 @@
           "Required": true,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamInstanceProfile.Arn"
+            "ValueType": "IamInstanceProfile"
           }
         },
         "KerberosAttributes": {
@@ -39817,6 +39817,7 @@
       }
     },
     "IamInstanceProfile": {
+      "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+",
       "GetAtt": {},
       "Ref": {
         "Parameters": [
@@ -39834,9 +39835,6 @@
       "Ref": {
         "Parameters": [
           "String"
-        ],
-        "Resources": [
-          "AWS::IAM::InstanceProfile"
         ]
       }
     },

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1146,7 +1146,8 @@
           "Resources": [
             "AWS::IAM::InstanceProfile"
           ]
-        }
+        },
+        "AllowedPatternRegex": "[a-zA-Z0-9+=,.@\\-_]+"
       },
       "IamInstanceProfile.Arn": {
         "GetAtt": {
@@ -1155,9 +1156,6 @@
         "Ref": {
           "Parameters": [
             "String"
-          ],
-          "Resources": [
-            "AWS::IAM::InstanceProfile"
           ]
         }
       },

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -87,7 +87,7 @@
     "op": "add",
     "path": "/PropertyTypes/AWS::Batch::ComputeEnvironment.ComputeResources/Properties/InstanceRole/Value",
     "value": {
-      "ValueType": "IamInstanceProfile.Arn"
+      "ValueType": "IamInstanceProfile"
     }
   },
   {
@@ -668,7 +668,7 @@
     "op": "add",
     "path": "/PropertyTypes/AWS::EC2::LaunchTemplate.IamInstanceProfile/Properties/Name/Value",
     "value": {
-      "ValueType": "IamInstanceProfile.Arn"
+      "ValueType": "IamInstanceProfile"
     }
   },
   {
@@ -952,7 +952,7 @@
     "op": "add",
     "path": "/ResourceTypes/AWS::AutoScaling::LaunchConfiguration/Properties/IamInstanceProfile/Value",
     "value": {
-      "ValueType": "IamInstanceProfile.Arn"
+      "ValueType": "IamInstanceProfile"
     }
   },
   {
@@ -1184,7 +1184,7 @@
     "op": "add",
     "path": "/ResourceTypes/AWS::EC2::Instance/Properties/IamInstanceProfile/Value",
     "value": {
-      "ValueType": "IamInstanceProfile.Arn"
+      "ValueType": "IamInstanceProfile"
     }
   },
   {
@@ -1284,7 +1284,7 @@
     "op": "add",
     "path": "/ResourceTypes/AWS::EMR::Cluster/Properties/JobFlowRole/Value",
     "value": {
-      "ValueType": "IamInstanceProfile.Arn"
+      "ValueType": "IamInstanceProfile"
     }
   },
   {

--- a/test/module/cfn_yaml/test_yaml.py
+++ b/test/module/cfn_yaml/test_yaml.py
@@ -39,7 +39,7 @@ class TestYamlParse(BaseTestCase):
             },
             "generic_bad": {
                 "filename": 'test/fixtures/templates/bad/generic.yaml',
-                "failures": 34
+                "failures": 35
             }
         }
 
@@ -69,4 +69,4 @@ class TestYamlParse(BaseTestCase):
 
                 matches = []
                 matches.extend(self.rules.run(filename, cfn))
-                assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)
+                assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), values.get('filename'))

--- a/test/module/test_rules_collections.py
+++ b/test/module/test_rules_collections.py
@@ -59,7 +59,7 @@ class TestTemplate(BaseTestCase):
         filename = 'test/fixtures/templates/bad/generic.yaml'
         template = cfnlint.decode.cfn_yaml.load(filename)
         cfn = Template(filename, template, ['us-east-1'])
-        expected_err_count = 34
+        expected_err_count = 35
         matches = []
         matches.extend(self.rules.run(filename, cfn))
         assert len(matches) == expected_err_count, 'Expected {} failures, got {}'.format(expected_err_count, len(matches))

--- a/test/rules/resources/properties/test_value_ref_getatt.py
+++ b/test/rules/resources/properties/test_value_ref_getatt.py
@@ -35,7 +35,7 @@ class TestValueRefGetAtt(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/generic.yaml', 1)
+        self.helper_file_negative('test/fixtures/templates/bad/generic.yaml', 2)
 
     def test_file_negative_value(self):
         """Test failure"""


### PR DESCRIPTION
*Issue #, if available:*
Fix #786 
*Description of changes:*
- Switch IAM Instance Profiles for certain resources to the version that only takes the name
- Add regex patter for the IAM Instance Profile when a name is being looked for

Regex taken from here.  https://docs.aws.amazon.com/cli/latest/reference/iam/create-instance-profile.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
