### PR TITLE
Allow VPCId to use a Parameter of Type String

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -37548,7 +37548,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -33985,7 +33985,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -22886,7 +22886,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -32292,7 +32292,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -33685,7 +33685,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -36076,7 +36076,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -30537,7 +30537,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -36996,7 +36996,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -24395,7 +24395,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -40867,7 +40867,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -31946,7 +31946,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -27956,7 +27956,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -28907,7 +28907,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -40657,7 +40657,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -37429,7 +37429,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -23219,7 +23219,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -23700,7 +23700,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -31351,7 +31351,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -40670,7 +40670,8 @@
       },
       "Ref": {
         "Parameters": [
-          "VpcId"
+          "VpcId",
+          "String"
         ],
         "Resources": [
           "AWS::EC2::VPC"

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1831,7 +1831,8 @@
         },
         "Ref": {
           "Parameters": [
-            "VpcId"
+            "VpcId",
+            "String"
           ],
           "Resources": [
             "AWS::EC2::VPC"

--- a/test/fixtures/templates/bad/properties_vpcid.yaml
+++ b/test/fixtures/templates/bad/properties_vpcid.yaml
@@ -4,7 +4,7 @@ Description: >
   Bad VpcID Parameters
 Parameters:
   VpcId:
-    Type: String
+    Type: Number
     Default: String
     Description: String
 Resources:


### PR DESCRIPTION
*Issue #, if available:*
Fix #801
*Description of changes:*
- Update specs to have VpcId to support String parameters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
