### PR TITLE
Add HealthCheckTImeSeconds min/max values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -28271,7 +28271,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -37526,6 +37529,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -25941,7 +25941,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -33963,6 +33966,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -16965,7 +16965,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -22864,6 +22867,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -24249,7 +24249,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -32270,6 +32273,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -25354,7 +25354,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -33663,6 +33666,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -27245,7 +27245,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -36054,6 +36057,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -22998,7 +22998,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -30515,6 +30518,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -27914,7 +27914,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -36974,6 +36977,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -18030,7 +18030,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -24373,6 +24376,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -30705,7 +30705,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -40845,6 +40848,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -24006,7 +24006,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -31924,6 +31927,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -20860,7 +20860,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -27934,6 +27937,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -21657,7 +21657,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -28885,6 +28888,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -30541,7 +30541,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -40635,6 +40638,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -28211,7 +28211,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -37407,6 +37410,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -17253,7 +17253,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -23197,6 +23200,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -17347,7 +17347,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -23678,6 +23681,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -23568,7 +23568,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -31329,6 +31332,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -30526,7 +30526,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+          }
         },
         "HealthyThresholdCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
@@ -40648,6 +40651,10 @@
           "Strings"
         ]
       }
+    },
+    "TargetGroupHealthCheckTimeoutSeconds": {
+      "NumberMax": 60,
+      "NumberMin": 2
     },
     "VpcEndpointConnectionEvents": {
       "AllowedValues": [

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1810,6 +1810,10 @@
           ]
         }
       },
+      "TargetGroupHealthCheckTimeoutSeconds": {
+        "NumberMax": 60,
+        "NumberMin": 2
+      },
       "VpcEndpointConnectionEvents": {
         "AllowedValues": [
           "Accept",

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -1350,6 +1350,13 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::ElasticLoadBalancingV2::TargetGroup/Properties/HealthCheckTimeoutSeconds/Value",
+    "value": {
+      "ValueType": "TargetGroupHealthCheckTimeoutSeconds"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::Events::Rule/Properties/State/Value",
     "value": {
       "ValueType": "DefaultEnabledState"

--- a/src/cfnlint/rules/resources/properties/NumberSize.py
+++ b/src/cfnlint/rules/resources/properties/NumberSize.py
@@ -41,7 +41,7 @@ class NumberSize(CloudFormationLintRule):
         number_max = kwargs.get('number_max')
 
         if isinstance(value, six.integer_types):
-            if not number_min <= value <= number_max:
+            if not (number_min <= value <= number_max):
                 message = 'Value has to be between {0} and {1} at {2}'
                 matches.append(
                     RuleMatch(

--- a/test/fixtures/templates/bad/properties_elb.yaml
+++ b/test/fixtures/templates/bad/properties_elb.yaml
@@ -105,6 +105,7 @@ Resources:
   HttpTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
+      HealthCheckTimeoutSeconds: 1
       Port: 80
       Protocol: HTTP
       VpcId: !Ref Vpc

--- a/test/fixtures/templates/good/properties_elb.yaml
+++ b/test/fixtures/templates/good/properties_elb.yaml
@@ -101,6 +101,7 @@ Resources:
   HttpTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
+      HealthCheckTimeoutSeconds: 60
       Port: 80
       Protocol: HTTP
       VpcId: !Ref Vpc


### PR DESCRIPTION
Just happened to hit this one:

```validation error detected: Value '600' at 'healthCheckIntervalSeconds' failed to satisfy constraint: Member must have value less than or equal to 300 (Service: AmazonElasticLoadBalancingV2; Status Code: 400; Error Code: ValidationError; ```

So a nice excuse to take a look at the min/max rule. Small PR that adds the min(2) and max(60) of the `AWS::ElasticLoadBalancingV2::TargetGroup` `HealthCheckTimeoutSeconds ` property as documented: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
