### PR TITLE
Include Managed Policy Doc max size in specs

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -29759,7 +29759,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -36851,6 +36854,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -27015,7 +27015,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -33315,6 +33318,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -17455,7 +17455,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -22243,6 +22246,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -25323,7 +25323,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -31610,6 +31613,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -26428,7 +26428,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -32994,6 +32997,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -28733,7 +28733,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -35379,6 +35382,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -23727,7 +23727,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -29867,6 +29870,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -29402,7 +29402,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -36313,6 +36316,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -18520,7 +18520,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -23748,6 +23751,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -32286,7 +32286,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -40170,6 +40173,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -24735,7 +24735,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -31269,6 +31272,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -21402,7 +21402,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -27299,6 +27302,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -22386,7 +22386,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -28234,6 +28237,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -32091,7 +32091,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -39960,6 +39963,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -29347,7 +29347,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -36752,6 +36755,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -17743,7 +17743,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -22576,6 +22579,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -17869,7 +17869,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -23022,6 +23025,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -24297,7 +24297,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -30671,6 +30674,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -32076,7 +32076,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-policydocument",
           "PrimitiveType": "Json",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamManagedPolicyDocument"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-managedpolicy.html#cfn-iam-managedpolicy-roles",
@@ -39973,6 +39976,14 @@
         ],
         "Resources": [
           "AWS::IAM::ManagedPolicy"
+        ]
+      }
+    },
+    "IamManagedPolicyDocument": {
+      "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
         ]
       }
     },

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1144,6 +1144,16 @@
           ]
         }
       },
+      "IamInstanceProfile.Arn": {
+        "GetAtt": {
+          "AWS::IAM::InstanceProfile": "Arn"
+        },
+        "Ref": {
+          "Parameters": [
+            "String"
+          ]
+        }
+      },
       "IamInstanceProfile.NameOrArn": {
         "GetAtt": {
           "AWS::IAM::InstanceProfile": "Arn"
@@ -1154,16 +1164,6 @@
           ],
           "Resources": [
             "AWS::IAM::InstanceProfile"
-          ]
-        }
-      },
-      "IamInstanceProfile.Arn": {
-        "GetAtt": {
-          "AWS::IAM::InstanceProfile": "Arn"
-        },
-        "Ref": {
-          "Parameters": [
-            "String"
           ]
         }
       },
@@ -1196,13 +1196,21 @@
           ]
         }
       },
-      "IamPath": {
+      "IamManagedPolicyDocument": {
+        "JsonMax": 6144,
         "Ref": {
           "Parameters": [
             "String"
           ]
-        },
-        "AllowedPatternRegex": "^/(.+/)*$"
+        }
+      },
+      "IamPath": {
+        "AllowedPatternRegex": "^/(.+/)*$",
+        "Ref": {
+          "Parameters": [
+            "String"
+          ]
+        }
       },
       "IamRole": {
         "GetAtt": {
@@ -1217,7 +1225,7 @@
         }
       },
       "IamRole.Arn": {
-        "AllowedPatternRegex": "arn:(aws[a-zA-Z-]*)?:iam::\\d{12}:role/[a-zA-Z_0-9+=,.@\\-_\/]+",
+        "AllowedPatternRegex": "arn:(aws[a-zA-Z-]*)?:iam::\\d{12}:role/[a-zA-Z_0-9+=,.@\\-_/]+",
         "GetAtt": {
           "AWS::IAM::Role": "Arn"
         },
@@ -1665,8 +1673,8 @@
       },
       "SecurityGroupDescription": {
         "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-        "StringMin": "",
-        "StringMax": "255"
+        "StringMax": "255",
+        "StringMin": ""
       },
       "SecurityGroupId": {
         "GetAtt": {

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -1900,5 +1900,12 @@
     "value": {
       "ValueType": "CodeCommitRepositoryName"
     }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::IAM::ManagedPolicy/Properties/PolicyDocument/Value",
+    "value": {
+      "ValueType": "IamManagedPolicyDocument"
+    }
   }
 ]


### PR DESCRIPTION
*Issue #, if available:*
Fix #808
*Description of changes:*
- Add AWS::IAM::ManagedPolicy PolicyDocument Json Max size based on limits from https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
