### PR TITLE
Add EC2 allowed Values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -25525,7 +25525,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -37106,6 +37109,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -25514,7 +25514,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -37092,6 +37095,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -25328,7 +25328,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -25370,13 +25373,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -37095,6 +37104,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -23184,7 +23184,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -33549,6 +33552,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -23195,7 +23195,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -33563,6 +33566,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -22998,7 +22998,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -23040,13 +23043,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -33552,6 +33561,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -14432,7 +14432,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -22459,6 +22462,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -14443,7 +14443,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -22473,6 +22476,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -14246,7 +14246,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -14288,13 +14291,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -22462,6 +22471,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -21503,7 +21503,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -31870,6 +31873,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -21306,7 +21306,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -21348,13 +21351,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -31859,6 +31868,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -21492,7 +21492,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -31856,6 +31859,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -22597,7 +22597,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -33235,6 +33238,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -22411,7 +22411,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -22453,13 +22456,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -33238,6 +33247,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -22608,7 +22608,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -33249,6 +33252,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -24499,7 +24499,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -35634,6 +35637,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -24302,7 +24302,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -24344,13 +24347,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -35623,6 +35632,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -24488,7 +24488,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -35620,6 +35623,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -20095,7 +20095,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -20137,13 +20140,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -30104,6 +30113,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -20292,7 +20292,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -30115,6 +30118,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -20281,7 +20281,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -30101,6 +30104,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -25168,7 +25168,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -36568,6 +36571,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -25157,7 +25157,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -36554,6 +36557,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -24971,7 +24971,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -25013,13 +25016,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -36557,6 +36566,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -15202,7 +15202,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -15244,13 +15247,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -23967,6 +23976,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -15388,7 +15388,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -23964,6 +23967,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -15399,7 +15399,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -23978,6 +23981,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -27959,7 +27959,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -40425,6 +40428,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -27762,7 +27762,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -27804,13 +27807,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -40414,6 +40423,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -27948,7 +27948,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -40411,6 +40414,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -21249,7 +21249,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -31510,6 +31513,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -21260,7 +21260,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -31524,6 +31527,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -21063,7 +21063,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -21105,13 +21108,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -31513,6 +31522,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -17914,7 +17914,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -17956,13 +17959,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -27533,6 +27542,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -18111,7 +18111,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -27544,6 +27547,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -18100,7 +18100,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -27530,6 +27533,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -19120,7 +19120,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -28467,6 +28470,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -19109,7 +19109,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -28453,6 +28456,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -18923,7 +18923,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -18965,13 +18968,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -28456,6 +28465,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -27762,7 +27762,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -40215,6 +40218,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -27751,7 +27751,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -40201,6 +40204,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -27565,7 +27565,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -27607,13 +27610,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -40204,6 +40213,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -25454,7 +25454,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -36993,6 +36996,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -25465,7 +25465,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -37007,6 +37010,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -25268,7 +25268,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -25310,13 +25313,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -36996,6 +37005,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -14534,7 +14534,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -14576,13 +14579,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -22795,6 +22804,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -14720,7 +14720,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -22792,6 +22795,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -14731,7 +14731,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -22806,6 +22809,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -14825,7 +14825,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -23252,6 +23255,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -14628,7 +14628,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -14670,13 +14673,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -23241,6 +23250,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -14814,7 +14814,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -23238,6 +23241,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -20851,7 +20851,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -30905,6 +30908,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -20862,7 +20862,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -30919,6 +30922,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -20665,7 +20665,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -20707,13 +20710,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -30908,6 +30917,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -27769,7 +27769,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-networkinterfacepermission.html#cfn-ec2-networkinterfacepermission-permission",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkInterfacePermission"
+          }
         }
       }
     },
@@ -40214,6 +40217,12 @@
           "String"
         ]
       }
+    },
+    "NetworkInterfacePermission": {
+      "AllowedValues": [
+        "EIP-ASSOCIATE",
+        "INSTANCE-ATTACH"
+      ]
     },
     "PerformanceInsightsRetentionPeriod": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -27583,7 +27583,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-cidrblock",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "CidrIp"
+          }
         },
         "Egress": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-egress",
@@ -27625,13 +27628,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-ruleaction",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleAction"
+          }
         },
         "RuleNumber": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-network-acl-entry.html#cfn-ec2-networkaclentry-rulenumber",
           "PrimitiveType": "Integer",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "NetworkAclRuleNumber"
+          }
         }
       }
     },
@@ -40217,6 +40226,16 @@
           "String"
         ]
       }
+    },
+    "NetworkAclRuleAction": {
+      "AllowedValues": [
+        "allow",
+        "deny"
+      ]
+    },
+    "NetworkAclRuleNumber": {
+      "NumberMax": 32766,
+      "NumberMin": 1
     },
     "NetworkInterfacePermission": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -27780,7 +27780,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-placementgroup.html#cfn-ec2-placementgroup-strategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementGroupStrategy"
+          }
         }
       }
     },
@@ -40228,6 +40231,13 @@
           "AWS::EC2::PlacementGroup"
         ]
       }
+    },
+    "PlacementGroupStrategy": {
+      "AllowedValues": [
+        "cluster",
+        "partition",
+        "spread"
+      ]
     },
     "PlacementTenancy": {
       "AllowedValues": [

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1394,6 +1394,16 @@
           ]
         }
       },
+      "NetworkAclRuleAction": {
+        "AllowedValues": [
+          "allow",
+          "deny"
+        ]
+      },
+      "NetworkAclRuleNumber": {
+        "NumberMax": 32766,
+        "NumberMin": 1
+      },
       "NetworkInterfacePermission": {
         "AllowedValues": [
           "EIP-ASSOCIATE",

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1412,6 +1412,13 @@
           ]
         }
       },
+      "PlacementGroupStrategy": {
+        "AllowedValues": [
+          "cluster",
+          "partition",
+          "spread"
+        ]
+      },
       "PlacementTenancy": {
         "AllowedValues": [
           "dedicated",

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1394,6 +1394,12 @@
           ]
         }
       },
+      "NetworkInterfacePermission": {
+        "AllowedValues": [
+          "EIP-ASSOCIATE",
+          "INSTANCE-ATTACH"
+        ]
+      },
       "PerformanceInsightsRetentionPeriod": {
         "AllowedValues": [
           7,

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -1282,6 +1282,13 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::NetworkInterfacePermission/Properties/Permission/Value",
+    "value": {
+      "ValueType": "NetworkInterfacePermission"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::EC2::PlacementGroup/Properties/Strategy/Value",
     "value": {
       "ValueType": "PlacementGroupStrategy"

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -1282,6 +1282,13 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::PlacementGroup/Properties/Strategy/Value",
+    "value": {
+      "ValueType": "PlacementGroupStrategy"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::EC2::RouteTable/Properties/VpcId/Value",
     "value": {
       "ValueType": "VpcId"

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -1282,6 +1282,27 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::NetworkAclEntry/Properties/CidrBlock/Value",
+    "value": {
+      "ValueType": "CidrIp"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::NetworkAclEntry/Properties/RuleAction/Value",
+    "value": {
+      "ValueType": "NetworkAclRuleAction"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::NetworkAclEntry/Properties/RuleNumber/Value",
+    "value": {
+      "ValueType": "NetworkAclRuleNumber"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::EC2::NetworkInterfacePermission/Properties/Permission/Value",
     "value": {
       "ValueType": "NetworkInterfacePermission"

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -591,6 +591,10 @@ Resources:
     Type: "AWS::Neptune::DBInstance"
     Properties:
       DBInstanceClass: "db.r3.xlarge" # Invalid AllowedValue
+  PlacementGroup:
+    Type: "AWS::EC2::PlacementGroup"
+    Properties:
+      Strategy: "combined" # Invalid AllowedValue
   RedshiftCluster:
     Type: "AWS::Redshift::Cluster"
     Properties:

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -591,6 +591,12 @@ Resources:
     Type: "AWS::Neptune::DBInstance"
     Properties:
       DBInstanceClass: "db.r3.xlarge" # Invalid AllowedValue
+  NetworkInterfacePermission:
+    Type: "AWS::EC2::NetworkInterfacePermission"
+    Properties:
+      AwsAccountId: !Ref "AWS::AccountId"
+      NetworkInterfaceId: "-1"
+      Permission: "Associate" # Invalid AllowedValue
   PlacementGroup:
     Type: "AWS::EC2::PlacementGroup"
     Properties:

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -591,6 +591,14 @@ Resources:
     Type: "AWS::Neptune::DBInstance"
     Properties:
       DBInstanceClass: "db.r3.xlarge" # Invalid AllowedValue
+  NetworkAclEntry:
+    Type: "AWS::EC2::NetworkAclEntry"
+    Properties:
+      CidrBlock: "127.0.0.1/32"
+      NetworkAclId: "-1"
+      Protocol: -1
+      RuleAction: "ALLOW" # Invlid AllowedValue
+      RuleNumber: 1
   NetworkInterfacePermission:
     Type: "AWS::EC2::NetworkInterfacePermission"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -608,6 +608,12 @@ Resources:
     Type: "AWS::Neptune::DBInstance"
     Properties:
       DBInstanceClass: "db.r4.8xlarge" # Valid AllowedValue
+  NetworkInterfacePermission:
+    Type: "AWS::EC2::NetworkInterfacePermission"
+    Properties:
+      AwsAccountId: !Ref "AWS::AccountId"
+      NetworkInterfaceId: "-1"
+      Permission: "EIP-ASSOCIATE" # Valid AllowedValue
   PlacementGroup:
     Type: "AWS::EC2::PlacementGroup"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -608,6 +608,10 @@ Resources:
     Type: "AWS::Neptune::DBInstance"
     Properties:
       DBInstanceClass: "db.r4.8xlarge" # Valid AllowedValue
+  PlacementGroup:
+    Type: "AWS::EC2::PlacementGroup"
+    Properties:
+      Strategy: "cluster" # Valid AllowedValue
   RedshiftCluster:
     Type: "AWS::Redshift::Cluster"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -608,6 +608,14 @@ Resources:
     Type: "AWS::Neptune::DBInstance"
     Properties:
       DBInstanceClass: "db.r4.8xlarge" # Valid AllowedValue
+  NetworkAclEntry:
+    Type: "AWS::EC2::NetworkAclEntry"
+    Properties:
+      CidrBlock: "127.0.0.1/32"
+      NetworkAclId: "-1"
+      Protocol: -1
+      RuleAction: "allow" # Valid AllowedValue
+      RuleNumber: 1
   NetworkInterfacePermission:
     Type: "AWS::EC2::NetworkInterfacePermission"
     Properties:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 183)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 184)

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 182)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 183)

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 181)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 182)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Add all the allowed values of the [`AWS::EC2`]( https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-reference-ec2.html) Resources. 

Since EC2 is huge, it's a subset PR containing:
- NetworkAcl
- NetworkInterface
- PlacementGroup

Added some other `ValueTypes` along the way

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
