### PR TITLE
Add check on Route53 NS and PTR recordsets

### DIFF
--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -159,6 +159,34 @@ class RecordSet(CloudFormationLintRule):
 
         return matches
 
+    def check_ns_record(self, path, recordset):
+        """Check NS record Configuration"""
+        matches = []
+
+        resource_records = recordset.get('ResourceRecords')
+
+        for index, record in enumerate(resource_records):
+            if not isinstance(record, dict):
+                tree = path[:] + ['ResourceRecords', index]
+                if not re.match(self.REGEX_DOMAINNAME, record):
+                    message = 'NS record ({}) does not contain a valid domain name'
+                    matches.append(RuleMatch(tree, message.format(record)))
+        return matches
+
+    def check_ptr_record(self, path, recordset):
+        """Check PTR record Configuration"""
+        matches = []
+
+        resource_records = recordset.get('ResourceRecords')
+
+        for index, record in enumerate(resource_records):
+            if not isinstance(record, dict):
+                tree = path[:] + ['ResourceRecords', index]
+                if not re.match(self.REGEX_DOMAINNAME, record):
+                    message = 'PTR record ({}) does not contain a valid domain name'
+                    matches.append(RuleMatch(tree, message.format(record)))
+        return matches
+
     def check_txt_record(self, path, recordset):
         """Check TXT record Configuration"""
         matches = []
@@ -205,6 +233,10 @@ class RecordSet(CloudFormationLintRule):
                     matches.extend(self.check_cname_record(path, recordset))
                 elif recordset_type == 'MX':
                     matches.extend(self.check_mx_record(path, recordset))
+                elif recordset_type == 'NS':
+                    matches.extend(self.check_ns_record(path, recordset))
+                elif recordset_type == 'PTR':
+                    matches.extend(self.check_ptr_record(path, recordset))
                 elif recordset_type == 'TXT':
                     matches.extend(self.check_txt_record(path, recordset))
 

--- a/test/fixtures/templates/bad/route53.yaml
+++ b/test/fixtures/templates/bad/route53.yaml
@@ -31,7 +31,7 @@ Resources:
       Comment: "Invalid A Record"
       HostedZoneId: !Ref "MyHostedZone"
       Name: "www.example.com"
-      Type: "X" # Invalid record type
+      Type: "A"
       TTL: "300"
       ResourceRecords:
         - "127.0.0.1"
@@ -81,6 +81,26 @@ Resources:
       ResourceRecords:
         - "127.0.0.1"
         - "10 my domain"
+  MyNSRecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      Comment: "A valid NS Record"
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "www.example.com"
+      Type: "NS"
+      TTL: "300"
+      ResourceRecords:
+        - "127.0.0.1"
+  MyPTRRecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      Comment: "A valid NS Record"
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "www.example.com"
+      Type: "PTR"
+      TTL: "300"
+      ResourceRecords:
+        - "127.0.0.1"
   MyRecordSetGroup:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:

--- a/test/fixtures/templates/good/route53.yaml
+++ b/test/fixtures/templates/good/route53.yaml
@@ -101,6 +101,29 @@ Resources:
       ResourceRecords:
         - "10 mx1.example.com"
         - "10 mx1.example.com"
+  MyNSRecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      Comment: "A valid NS Record"
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "www.example.com"
+      Type: "NS"
+      TTL: "300"
+      ResourceRecords:
+        - "ns-2048.awsdns-64.com"
+        - "ns-2049.awsdns-65.net"
+        - "ns-2050.awsdns-66.org"
+        - "ns-2051.awsdns-67.co.uk"
+  MyPTRRecordSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      Comment: "A valid NS Record"
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "www.example.com"
+      Type: "PTR"
+      TTL: "300"
+      ResourceRecords:
+        - "hostname.example.com"
   MyRecordSetGroup:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:

--- a/test/rules/resources/route53/test_recordsets.py
+++ b/test/rules/resources/route53/test_recordsets.py
@@ -34,4 +34,4 @@ class TestRoute53RecordSets(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/route53.yaml', 28)
+        self.helper_file_negative('test/fixtures/templates/bad/route53.yaml', 30)


### PR DESCRIPTION
*Issue https://github.com/aws-cloudformation/cfn-python-lint/issues/94, if available:*

Add checks for the `NS` and `PTR` recordset type. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
