### PR TITLE
 Add Budget Notification min/max values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -3376,7 +3376,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
           "PrimitiveType": "Double",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThreshold"
+          }
         },
         "ThresholdType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
@@ -35685,6 +35688,10 @@
         "ACTUAL",
         "FORECASTED"
       ]
+    },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
     },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -3284,7 +3284,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
           "PrimitiveType": "Double",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThreshold"
+          }
         },
         "ThresholdType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
@@ -32203,6 +32206,10 @@
         "ACTUAL",
         "FORECASTED"
       ]
+    },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
     },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -21182,6 +21182,10 @@
         "FORECASTED"
       ]
     },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
+    },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [
         "ABSOLUTE_VALUE",

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -2988,7 +2988,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
           "PrimitiveType": "Double",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThreshold"
+          }
         },
         "ThresholdType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
@@ -30503,6 +30506,10 @@
         "ACTUAL",
         "FORECASTED"
       ]
+    },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
     },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -3284,7 +3284,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
           "PrimitiveType": "Double",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThreshold"
+          }
         },
         "ThresholdType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
@@ -31828,6 +31831,10 @@
         "ACTUAL",
         "FORECASTED"
       ]
+    },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
     },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -3376,7 +3376,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
           "PrimitiveType": "Double",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThreshold"
+          }
         },
         "ThresholdType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
@@ -34214,6 +34217,10 @@
         "ACTUAL",
         "FORECASTED"
       ]
+    },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
     },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -2822,7 +2822,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
           "PrimitiveType": "Double",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThreshold"
+          }
         },
         "ThresholdType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
@@ -28783,6 +28786,10 @@
         "ACTUAL",
         "FORECASTED"
       ]
+    },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
     },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -3301,7 +3301,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
           "PrimitiveType": "Double",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThreshold"
+          }
         },
         "ThresholdType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
@@ -35156,6 +35159,10 @@
         "ACTUAL",
         "FORECASTED"
       ]
+    },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
     },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -22680,6 +22680,10 @@
         "FORECASTED"
       ]
     },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
+    },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [
         "ABSOLUTE_VALUE",

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -3376,7 +3376,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
           "PrimitiveType": "Double",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThreshold"
+          }
         },
         "ThresholdType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
@@ -38977,6 +38980,10 @@
         "ACTUAL",
         "FORECASTED"
       ]
+    },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
     },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -2839,7 +2839,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
           "PrimitiveType": "Double",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThreshold"
+          }
         },
         "ThresholdType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
@@ -30187,6 +30190,10 @@
         "ACTUAL",
         "FORECASTED"
       ]
+    },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
     },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -26220,6 +26220,10 @@
         "FORECASTED"
       ]
     },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
+    },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [
         "ABSOLUTE_VALUE",

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -2025,7 +2025,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
           "PrimitiveType": "Double",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThreshold"
+          }
         },
         "ThresholdType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
@@ -27120,6 +27123,10 @@
         "ACTUAL",
         "FORECASTED"
       ]
+    },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
     },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -3376,7 +3376,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
           "PrimitiveType": "Double",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThreshold"
+          }
         },
         "ThresholdType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
@@ -38747,6 +38750,10 @@
         "ACTUAL",
         "FORECASTED"
       ]
+    },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
     },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -3218,7 +3218,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
           "PrimitiveType": "Double",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThreshold"
+          }
         },
         "ThresholdType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
@@ -35591,6 +35594,10 @@
         "ACTUAL",
         "FORECASTED"
       ]
+    },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
     },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -21527,6 +21527,10 @@
         "FORECASTED"
       ]
     },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
+    },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [
         "ABSOLUTE_VALUE",

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -21874,6 +21874,10 @@
         "FORECASTED"
       ]
     },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
+    },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [
         "ABSOLUTE_VALUE",

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -2960,7 +2960,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
           "PrimitiveType": "Double",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThreshold"
+          }
         },
         "ThresholdType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
@@ -29531,6 +29534,10 @@
         "ACTUAL",
         "FORECASTED"
       ]
+    },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
     },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -3376,7 +3376,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold",
           "PrimitiveType": "Double",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "BudgetNotificationThreshold"
+          }
         },
         "ThresholdType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-thresholdtype",
@@ -38767,6 +38770,10 @@
         "ACTUAL",
         "FORECASTED"
       ]
+    },
+    "BudgetNotificationThreshold": {
+      "NumberMax": 1000000000,
+      "NumberMin": 0.1
     },
     "BudgetNotificationThresholdType": {
       "AllowedValues": [

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -210,6 +210,10 @@
           "LESS_THAN"
         ]
       },
+      "BudgetNotificationThreshold": {
+        "NumberMax": 1000000000,
+        "NumberMin": 0.1
+      },
       "BudgetNotificationNotificationType": {
         "AllowedValues": [
           "ACTUAL",

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -134,6 +134,13 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::Budgets::Budget.Notification/Properties/Threshold/Value",
+    "value": {
+      "ValueType": "BudgetNotificationThreshold"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::Budgets::Budget.Subscriber/Properties/SubscriptionType/Value",
     "value": {
       "ValueType": "BudgetSubscriptionType"

--- a/src/cfnlint/rules/resources/properties/NumberSize.py
+++ b/src/cfnlint/rules/resources/properties/NumberSize.py
@@ -12,7 +12,7 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-import six
+import sys
 from cfnlint import CloudFormationLintRule
 from cfnlint import RuleMatch
 
@@ -23,7 +23,7 @@ class NumberSize(CloudFormationLintRule):
     """Check if a String has a length within the limit"""
     id = 'E3034'
     shortdesc = 'Check if a number is between min and max'
-    description = 'Check numbers for its value being between the minimum and maximum'
+    description = 'Check numbers (integers and floats) for its value being between the minimum and maximum'
     source_url = 'https://github.com/awslabs/cfn-python-lint/blob/master/docs/cfn-resource-specification.md#allowedpattern'
     tags = ['resources', 'property', 'number', 'size']
 
@@ -35,12 +35,18 @@ class NumberSize(CloudFormationLintRule):
             self.resource_sub_property_types.append(property_type_spec)
 
     def _check_number_value(self, value, path, **kwargs):
-        """ """
+        """ Check if the value is in the given ranges"""
         matches = []
         number_min = kwargs.get('number_min')
         number_max = kwargs.get('number_max')
 
-        if isinstance(value, six.integer_types):
+        # The Python types considered a "number"
+        if sys.version_info < (3,):
+            number_types = (float, int, long,)  # pylint: disable=undefined-variable
+        else:
+            number_types = (float, int,)
+
+        if isinstance(value, number_types):
             if not (number_min <= value <= number_max):
                 message = 'Value has to be between {0} and {1} at {2}'
                 matches.append(

--- a/test/fixtures/templates/good/resources/properties/number_size.yaml
+++ b/test/fixtures/templates/good/resources/properties/number_size.yaml
@@ -13,14 +13,14 @@ Resources:
           DeviceName: /dev/sdm
           Ebs:
             VolumeType: io1
-            Iops: 99
+            Iops: 2000
             DeleteOnTermination: false
             VolumeSize: 20
         -
           DeviceName: /dev/sdo
           Ebs:
             VolumeType: io1
-            Iops: 20001
+            Iops: 200
             DeleteOnTermination: false
             VolumeSize: 20
       NetworkInterfaces:
@@ -30,10 +30,10 @@ Resources:
     Properties:
       NotificationsWithSubscribers:
         - Notification:
-            Threshold: 1000000001
+            Threshold: 1000000000
   myBudgetMinFloat:
     Type: "AWS::Budgets::Budget"
     Properties:
       NotificationsWithSubscribers:
         - Notification:
-            Threshold: 0.09
+            Threshold: 0.1

--- a/test/integration/test_patched_specs.py
+++ b/test/integration/test_patched_specs.py
@@ -113,12 +113,23 @@ class TestPatchedSpecs(BaseTestCase):
         """Test Property Value Types"""
         for v_name, v_values in self.spec.get('ValueTypes').items():
             list_count = 0
+            number_count = 0
             string_count = 0
+
+            number_max = 0
+            number_min = 0
             for p_name, p_values in v_values.items():
                 self.assertIn(p_name, ['Ref', 'GetAtt', 'AllowedValues', 'AllowedPattern', 'AllowedPatternRegex', 'ListMin', 'ListMax', 'JsonMax', 'NumberMax', 'NumberMin', 'StringMax', 'StringMin'])
+
+                if p_name == 'NumberMin':
+                    number_min = p_values
+                if p_name == 'NumberMax':
+                    number_max = p_values
                 if p_name in ['ListMin', 'ListMax']:
                     list_count += 1
-                if p_name in ['ListMin', 'ListMax']:
+                if p_name in ['NumberMin', 'NumberMax']:
+                    number_count += 1
+                if p_name in ['StringMin', 'StringMax']:
                     string_count += 1
                 if p_name == 'Ref':
                     self.assertIsInstance(p_values, dict, 'ValueTypes: %s, Type: %s' % (v_name, p_name))
@@ -145,7 +156,10 @@ class TestPatchedSpecs(BaseTestCase):
                     for l_value in p_values:
                         self.assertIsInstance(l_value, (six.string_types, six.integer_types), 'ValueTypes: %s, Type: %s' % (v_name, p_name))
             self.assertIn(list_count, [0, 2], 'Both ListMin and ListMax must be specified')
+            self.assertIn(number_count, [0, 2], 'Both NumberMin and NumberMax must be specified')
             self.assertIn(string_count, [0, 2], 'Both StringMin and StringMax must be specified')
+            if number_count == 2:
+                self.assertTrue((number_max > number_min), 'NumberMax must be greater than NumberMin')
 
     def test_parameter_types(self):
         """Test Parameter Types"""

--- a/test/rules/resources/properties/test_number_size.py
+++ b/test/rules/resources/properties/test_number_size.py
@@ -22,6 +22,9 @@ class TestNumberSize(BaseRuleTestCase):
         """Setup"""
         super(TestNumberSize, self).setUp()
         self.collection.register(NumberSize())
+        self.success_templates = [
+            'test/fixtures/templates/good/resources/properties/number_size.yaml'
+        ]
 
     def test_file_positive(self):
         """Test Positive"""
@@ -29,4 +32,4 @@ class TestNumberSize(BaseRuleTestCase):
 
     def test_file_negative_string_size(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/number_size.yaml', 2)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/number_size.yaml', 4)


### PR DESCRIPTION
Add the min/max value of the Budget Notification threshold ([documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-notification.html#cfn-budgets-budget-notification-threshold)).

Fixed the float support in the  min/max rule and added the validation of the min/max configuration (max > min. If the values are equal, use "AllowedValues")