### PR TITLE
New rule E3037 to check for duplicate items in a list

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -26774,7 +26774,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -24444,7 +24444,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -15490,7 +15490,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -22752,7 +22752,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -23857,7 +23857,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -25748,7 +25748,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -21541,7 +21541,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -26417,7 +26417,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -16515,7 +16515,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -29208,7 +29208,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -22509,7 +22509,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -19360,7 +19360,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -20185,7 +20185,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -29044,7 +29044,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -26714,7 +26714,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -15778,7 +15778,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -15872,7 +15872,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -22111,7 +22111,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -29029,7 +29029,7 @@
           "Required": false,
           "UpdateType": "Immutable",
           "Value": {
-            "ValueType": "IamRole.Arn"
+            "ValueType": "IamRole.NameOrArn"
           }
         },
         "SchedulingStrategy": {

--- a/src/cfnlint/rules/resources/properties/ListDuplicates.py
+++ b/src/cfnlint/rules/resources/properties/ListDuplicates.py
@@ -1,0 +1,108 @@
+"""
+  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import hashlib
+import json
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+from cfnlint.helpers import RESOURCE_SPECS
+
+
+class ListDuplicates(CloudFormationLintRule):
+    """Check if duplicates exist in a List"""
+    id = 'E3037'
+    shortdesc = 'Check if a list has duplicate values'
+    description = 'Certain lists don\'t support duplicate items. ' \
+                  'Check when duplicates are provided but not supported.'
+    source_url = 'https://github.com/aws-cloudformation/cfn-python-lint/blob/master/docs/cfn-resource-specification.md#allowedvalue'
+    tags = ['resources', 'property', 'list']
+
+    def initialize(self, cfn):
+        """Initialize the rule"""
+        for resource_type_spec in RESOURCE_SPECS.get(cfn.regions[0]).get('ResourceTypes'):
+            self.resource_property_types.append(resource_type_spec)
+        for property_type_spec in RESOURCE_SPECS.get(cfn.regions[0]).get('PropertyTypes'):
+            self.resource_sub_property_types.append(property_type_spec)
+
+    def _check_duplicates(self, values, path, scenario=None):
+        """ Check for Duplicates """
+        matches = []
+
+        list_items = []
+        if isinstance(values, list):
+            for index, value in enumerate(values):
+                value_hash = hashlib.sha1(json.dumps(value, sort_keys=True).encode('utf-8')).hexdigest()
+                if value_hash in list_items:
+                    if not scenario:
+                        message = 'List has a duplicate value at {0}'
+                        matches.append(RuleMatch(path + [index], message.format('/'.join(map(str, path + [index])))))
+                    else:
+                        scenario_text = ' and '.join(['condition "%s" is %s' % (k, v) for (k, v) in scenario.items()])
+                        message = 'List has a duplicate value at {0} when {1}'
+                        matches.append(RuleMatch(path, message.format('/'.join(map(str, path)), scenario_text)))
+
+                list_items.append(value_hash)
+
+        return matches
+
+    def check_duplicates(self, values, path, cfn):
+        """ Check for duplicates """
+        matches = []
+
+        if isinstance(values, list):
+            matches.extend(self._check_duplicates(values, path))
+        elif isinstance(values, dict):
+            props = cfn.get_object_without_conditions(values)
+            for prop in props:
+                matches.extend(self._check_duplicates(prop.get('Object'), path, prop.get('Scenario')))
+
+        return matches
+
+    def check(self, cfn, properties, value_specs, path):
+        """Check itself"""
+        matches = list()
+        for p_value, p_path in properties.items_safe(path[:]):
+            for prop in p_value:
+                if prop in value_specs:
+                    property_type = value_specs.get(prop).get('Type')
+                    duplicates_allowed = value_specs.get(prop).get('DuplicatesAllowed', True)
+                    if property_type == 'List' and not duplicates_allowed:
+                        matches.extend(
+                            self.check_duplicates(
+                                p_value[prop], p_path + [prop], cfn
+                            )
+                        )
+
+        return matches
+
+    def match_resource_sub_properties(self, properties, property_type, path, cfn):
+        """Match for sub properties"""
+        matches = list()
+
+        specs = RESOURCE_SPECS.get(cfn.regions[0]).get('PropertyTypes').get(property_type, {}).get('Properties', {})
+        matches.extend(self.check(cfn, properties, specs, path))
+
+        return matches
+
+    def match_resource_properties(self, properties, resource_type, path, cfn):
+        """Check CloudFormation Properties"""
+        matches = list()
+
+        specs = RESOURCE_SPECS.get(cfn.regions[0]).get('ResourceTypes').get(resource_type, {}).get('Properties', {})
+        matches.extend(self.check(cfn, properties, specs, path))
+
+        return matches

--- a/src/cfnlint/rules/resources/properties/ListDuplicatesAllowed.py
+++ b/src/cfnlint/rules/resources/properties/ListDuplicatesAllowed.py
@@ -1,0 +1,109 @@
+"""
+  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import hashlib
+import json
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+from cfnlint.helpers import RESOURCE_SPECS
+
+
+class ListDuplicatesAllowed(CloudFormationLintRule):
+    """Check if duplicates exist in a List"""
+    id = 'I3037'
+    shortdesc = 'Check if a list that allows duplicates has any duplicates'
+    description = 'Certain lists support duplicate items.' \
+                  'Provide an alert when list of strings or numbers have repeats.'
+    source_url = 'https://github.com/aws-cloudformation/cfn-python-lint/blob/master/docs/rules.md#rules-1'
+    tags = ['resources', 'property', 'list']
+
+    def initialize(self, cfn):
+        """Initialize the rule"""
+        for resource_type_spec in RESOURCE_SPECS.get(cfn.regions[0]).get('ResourceTypes'):
+            self.resource_property_types.append(resource_type_spec)
+        for property_type_spec in RESOURCE_SPECS.get(cfn.regions[0]).get('PropertyTypes'):
+            self.resource_sub_property_types.append(property_type_spec)
+
+    def _check_duplicates(self, values, path, scenario=None):
+        """ Check for Duplicates """
+        matches = []
+
+        list_items = []
+        if isinstance(values, list):
+            for index, value in enumerate(values):
+                value_hash = hashlib.sha1(json.dumps(value, sort_keys=True).encode('utf-8')).hexdigest()
+                if value_hash in list_items:
+                    if not scenario:
+                        message = 'List has a duplicate value at {0}'
+                        matches.append(RuleMatch(path + [index], message.format('/'.join(map(str, path + [index])))))
+                    else:
+                        scenario_text = ' and '.join(['condition "%s" is %s' % (k, v) for (k, v) in scenario.items()])
+                        message = 'List has a duplicate value at {0} when {1}'
+                        matches.append(RuleMatch(path, message.format('/'.join(map(str, path)), scenario_text)))
+
+                list_items.append(value_hash)
+
+        return matches
+
+    def check_duplicates(self, values, path, cfn):
+        """ Check for duplicates """
+        matches = []
+
+        if isinstance(values, list):
+            matches.extend(self._check_duplicates(values, path))
+        elif isinstance(values, dict):
+            props = cfn.get_object_without_conditions(values)
+            for prop in props:
+                matches.extend(self._check_duplicates(prop.get('Object'), path, prop.get('Scenario')))
+
+        return matches
+
+    def check(self, cfn, properties, value_specs, path):
+        """Check itself"""
+        matches = list()
+        for p_value, p_path in properties.items_safe(path[:]):
+            for prop in p_value:
+                if prop in value_specs:
+                    property_type = value_specs.get(prop).get('Type')
+                    primitive_type = value_specs.get(prop).get('PrimitiveItemType')
+                    duplicates_allowed = value_specs.get(prop).get('DuplicatesAllowed', False)
+                    if property_type == 'List' and duplicates_allowed and primitive_type in ['String', 'Integer']:
+                        matches.extend(
+                            self.check_duplicates(
+                                p_value[prop], p_path + [prop], cfn
+                            )
+                        )
+
+        return matches
+
+    def match_resource_sub_properties(self, properties, property_type, path, cfn):
+        """Match for sub properties"""
+        matches = list()
+
+        specs = RESOURCE_SPECS.get(cfn.regions[0]).get('PropertyTypes').get(property_type, {}).get('Properties', {})
+        matches.extend(self.check(cfn, properties, specs, path))
+
+        return matches
+
+    def match_resource_properties(self, properties, resource_type, path, cfn):
+        """Check CloudFormation Properties"""
+        matches = list()
+
+        specs = RESOURCE_SPECS.get(cfn.regions[0]).get('ResourceTypes').get(resource_type, {}).get('Properties', {})
+        matches.extend(self.check(cfn, properties, specs, path))
+
+        return matches

--- a/test/fixtures/templates/bad/resources/properties/list_duplicates.yaml
+++ b/test/fixtures/templates/bad/resources/properties/list_duplicates.yaml
@@ -1,0 +1,35 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  IamPolicy:
+    Type: String
+  PrimaryRegion:
+    Type: String
+Conditions:
+  isPrimaryRegion: !Equals [!Ref PrimaryRegion, 'us-east-1']
+Resources:
+  IamGroup:
+    Type: AWS::IAM::Group
+    Properties:
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AdministratorPolicy
+      - arn:aws:iam::aws:policy/AdministratorPolicy
+      - !Ref IamPolicy
+      - !Ref IamPolicy
+  IamGroupWithConditions:
+    Type: AWS::IAM::Group
+    Properties:
+      ManagedPolicyArns:
+        Fn::If:
+        - isPrimaryRegion
+        - - arn:aws:iam::aws:policy/AdministratorPolicy
+          - arn:aws:iam::aws:policy/AdministratorPolicy
+          - !Ref IamPolicy
+          - !Ref IamPolicy
+        - !Ref AWS::NoValue
+  IamGroupWithNestedConditions:
+    Type: AWS::IAM::Group
+    Properties:
+      ManagedPolicyArns:
+        - !If ['isPrimaryRegion', 'arn:aws:iam::aws:policy/AdministratorPolicy', !Ref 'AWS::NoValue']
+        - !If ['isPrimaryRegion', 'arn:aws:iam::aws:policy/AdministratorPolicy', !Ref 'AWS::NoValue']

--- a/test/fixtures/templates/bad/resources/properties/list_duplicates_allowed.yaml
+++ b/test/fixtures/templates/bad/resources/properties/list_duplicates_allowed.yaml
@@ -1,0 +1,48 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Metadata:
+  cfn-lint:
+    config:
+      include_checks:
+      - I
+Parameters:
+  PrimaryRegion:
+    Type: String
+  PrivateSubnetOne:
+    Type: String
+  PrivateSubnetTwo:
+    Type: String
+Conditions:
+  isPrimaryRegion: !Equals [!Ref PrimaryRegion, 'us-east-1']
+Resources:
+  MyASG:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      InstanceId: abc-123456
+      MaxSize: "1"
+      MinSize: "1"
+      VPCZoneIdentifier:
+        - !Ref PrivateSubnetTwo
+        - !Ref PrivateSubnetTwo
+  MyASG2:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      InstanceId: abc-123456
+      MaxSize: "1"
+      MinSize: "1"
+      VPCZoneIdentifier:
+        Fn::If:
+        - isPrimaryRegion
+        - - !Ref PrivateSubnetTwo
+          - !Ref PrivateSubnetTwo
+        - - !Ref PrivateSubnetOne
+          - !Ref PrivateSubnetTwo
+  MyASG3:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      InstanceId: abc-123456
+      MaxSize: "1"
+      MinSize: "1"
+      VPCZoneIdentifier:
+        - !If ['isPrimaryRegion', !Ref PrivateSubnetTwo, !Ref PrivateSubnetOne]
+        - !If ['isPrimaryRegion', !Ref PrivateSubnetTwo, !Ref PrivateSubnetOne]

--- a/test/fixtures/templates/good/resources/properties/list_duplicates.yaml
+++ b/test/fixtures/templates/good/resources/properties/list_duplicates.yaml
@@ -1,0 +1,46 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  IamPolicy1:
+    Type: String
+  IamPolicy2:
+    Type: String
+  PrimaryRegion:
+    Type: String
+Conditions:
+  isPrimaryRegion: !Equals [!Ref PrimaryRegion, 'us-east-1']
+Resources:
+  IamRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument: {}
+      ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/AdministratorPolicy
+      - arn:aws:iam::aws:policy/EC2FullAdmin
+      - !Ref IamPolicy1
+      - !Ref IamPolicy2
+  IamRoleWithConditions:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument: {}
+      ManagedPolicyArns:
+        Fn::If:
+        - isPrimaryRegion
+        - - arn:aws:iam::aws:policy/AdministratorPolicy
+          - arn:aws:iam::aws:policy/EC2FullAdmin
+          - !Ref IamPolicy1
+          - !Ref IamPolicy2
+        - !Ref AWS::NoValue
+  IamRoleWithNestedConditions:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument: {}
+      ManagedPolicyArns:
+        - !If ['isPrimaryRegion', 'arn:aws:iam::aws:policy/AdministratorPolicy', !Ref 'AWS::NoValue']
+        - !If ['isPrimaryRegion', 'arn:aws:iam::aws:policy/EC2FullAdmin', !Ref 'AWS::NoValue']
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:  # Duplicates are allowed even though the list only takes 1 value
+      - !Ref IamRole
+      - !Ref IamRole

--- a/test/fixtures/templates/good/resources/properties/list_duplicates_allowed.yaml
+++ b/test/fixtures/templates/good/resources/properties/list_duplicates_allowed.yaml
@@ -1,0 +1,48 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Metadata:
+  cfn-lint:
+    config:
+      include_checks:
+      - I
+Parameters:
+  PrimaryRegion:
+    Type: String
+  PrivateSubnetOne:
+    Type: String
+  PrivateSubnetTwo:
+    Type: String
+Conditions:
+  isPrimaryRegion: !Equals [!Ref PrimaryRegion, 'us-east-1']
+Resources:
+  MyASG:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      InstanceId: abc-123456
+      MaxSize: "1"
+      MinSize: "1"
+      VPCZoneIdentifier:
+        - !Ref PrivateSubnetOne
+        - !Ref PrivateSubnetTwo
+  MyASG2:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      InstanceId: abc-123456
+      MaxSize: "1"
+      MinSize: "1"
+      VPCZoneIdentifier:
+        Fn::If:
+        - isPrimaryRegion
+        - - !Ref PrivateSubnetOne
+          - !Ref PrivateSubnetTwo
+        - - !Ref PrivateSubnetOne
+          - !Ref PrivateSubnetTwo
+  MyASG3:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      InstanceId: abc-123456
+      MaxSize: "1"
+      MinSize: "1"
+      VPCZoneIdentifier:
+        - !If ['isPrimaryRegion', !Ref PrivateSubnetTwo, !Ref PrivateSubnetOne]
+        - "subnet-123456"

--- a/test/rules/resources/properties/test_list_duplicates.py
+++ b/test/rules/resources/properties/test_list_duplicates.py
@@ -1,0 +1,37 @@
+"""
+  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.resources.properties.ListDuplicates import ListDuplicates  # pylint: disable=E0401
+from ... import BaseRuleTestCase
+
+
+class TestListDuplicates(BaseRuleTestCase):
+    """Test Allowed Value Property Configuration"""
+    def setUp(self):
+        """Setup"""
+        super(TestListDuplicates, self).setUp()
+        self.collection.register(ListDuplicates())
+        self.success_templates = [
+            'test/fixtures/templates/good/resources/properties/list_duplicates.yaml'
+        ]
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/list_duplicates.yaml', 4)

--- a/test/rules/resources/properties/test_list_duplicates_allowed.py
+++ b/test/rules/resources/properties/test_list_duplicates_allowed.py
@@ -1,0 +1,37 @@
+"""
+  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.resources.properties.ListDuplicatesAllowed import ListDuplicatesAllowed  # pylint: disable=E0401
+from ... import BaseRuleTestCase
+
+
+class TestListDuplicatesAllowed(BaseRuleTestCase):
+    """Test Allowed Value Property Configuration"""
+    def setUp(self):
+        """Setup"""
+        super(TestListDuplicatesAllowed, self).setUp()
+        self.collection.register(ListDuplicatesAllowed())
+        self.success_templates = [
+            'test/fixtures/templates/good/resources/properties/list_duplicates_allowed.yaml'
+        ]
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/list_duplicates_allowed.yaml', 3)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add rule E3037 to check for duplicates in a list when the CloudFormation Spec says that duplicates aren't allowed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
