### PR TITLE
Better handle getatt to CloudFormation sub stacks

### DIFF
--- a/src/cfnlint/rules/resources/properties/ValueRefGetAtt.py
+++ b/src/cfnlint/rules/resources/properties/ValueRefGetAtt.py
@@ -120,7 +120,10 @@ class ValueRefGetAtt(CloudFormationLintRule):
         # You can sometimes get a list or a string with . in it
         if isinstance(value, list):
             resource_name = value[0]
-            resource_attribute = value[1:]
+            if len(value[1:]) == 1:
+                resource_attribute = value[1].split('.')
+            else:
+                resource_attribute = value[1:]
         elif isinstance(value, six.string_types):
             resource_name = value.split('.')[0]
             resource_attribute = value.split('.')[1:]

--- a/test/fixtures/templates/good/resources/properties/value.yaml
+++ b/test/fixtures/templates/good/resources/properties/value.yaml
@@ -128,4 +128,8 @@ Resources:
   Listener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
+      Protocol:
+        Fn::GetAtt:
+        - SubStack
+        - Outputs.Protocol
       LoadBalancerArn: !GetAtt SubStack.Outputs.LoadBalancerArn


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix rule E3008 to better handle CloudFormation sub stacks with GetAtt

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
