### PR TITLE
Add EC2 allowed Values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -2824,7 +2824,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -2893,7 +2896,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -13637,7 +13643,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -13686,7 +13695,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -13912,7 +13924,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -20749,6 +20764,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -21779,13 +21800,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -21829,6 +21843,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {
@@ -21894,6 +21914,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -7030,7 +7030,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -7099,7 +7102,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -7820,7 +7826,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -25400,7 +25406,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -25626,7 +25635,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -36211,6 +36223,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -37327,13 +37345,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -37534,6 +37545,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -25357,7 +25357,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -37388,6 +37391,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -22653,7 +22653,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -33228,6 +33231,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -6878,7 +6878,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -6947,7 +6950,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -7668,7 +7674,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -22696,7 +22702,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -22922,7 +22931,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -32071,6 +32083,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -33167,13 +33185,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -33340,6 +33351,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -3004,7 +3004,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -3073,7 +3076,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -13939,7 +13945,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -14165,7 +14174,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -21036,6 +21048,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -22124,13 +22142,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -22232,6 +22243,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -13896,7 +13896,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -22185,6 +22188,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -6148,7 +6148,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -6217,7 +6220,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -6938,7 +6944,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -20998,7 +21004,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -21224,7 +21233,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -30373,6 +30385,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -31476,13 +31494,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -31629,6 +31640,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -20955,7 +20955,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -31537,6 +31540,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -6510,7 +6510,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -6579,7 +6582,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -7300,7 +7306,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -22103,7 +22109,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -22329,7 +22338,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -31690,6 +31702,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -32802,13 +32820,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -33020,6 +33031,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -22060,7 +22060,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -32863,6 +32866,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -7019,7 +7019,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -7088,7 +7091,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -7809,7 +7815,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -24266,7 +24272,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -24492,7 +24501,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -34441,6 +34453,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -35557,13 +35575,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -35763,6 +35774,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -24223,7 +24223,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -35618,6 +35621,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -5982,7 +5982,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -6051,7 +6054,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -6772,7 +6778,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -19787,7 +19793,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -20013,7 +20022,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -28647,6 +28659,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -29735,13 +29753,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -29880,6 +29891,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -19744,7 +19744,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -29796,6 +29799,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -6944,7 +6944,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -7013,7 +7016,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -7734,7 +7740,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -24848,7 +24854,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -25074,7 +25083,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -35234,6 +35246,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -36353,13 +36371,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -36548,6 +36559,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -24805,7 +24805,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -36414,6 +36417,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -14852,7 +14852,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -23631,6 +23634,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -3079,7 +3079,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -3148,7 +3151,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -14895,7 +14901,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -15121,7 +15130,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -22482,6 +22494,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -23570,13 +23588,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -23685,6 +23696,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -7087,7 +7087,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -7156,7 +7159,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -7877,7 +7883,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -27460,7 +27466,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -27686,7 +27695,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -38845,6 +38857,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -39969,13 +39987,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -40203,6 +40214,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -27417,7 +27417,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -40030,6 +40033,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -6433,7 +6433,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -6502,7 +6505,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -7223,7 +7229,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -20755,7 +20761,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -20981,7 +20990,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -30043,6 +30055,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -31139,13 +31157,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -31282,6 +31293,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -20712,7 +20712,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -31200,6 +31203,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -4684,7 +4684,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -4753,7 +4756,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -5474,7 +5480,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -17606,7 +17612,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -17832,7 +17841,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -26080,6 +26092,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -27168,13 +27186,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -27309,6 +27320,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -17563,7 +17563,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -27229,6 +27232,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -5185,7 +5185,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -5254,7 +5257,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -5975,7 +5981,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -18615,7 +18621,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -18841,7 +18850,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -26990,6 +27002,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -28093,13 +28111,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -28238,6 +28249,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -18572,7 +18572,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -28154,6 +28157,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -7087,7 +7087,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -7156,7 +7159,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -7877,7 +7883,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -27442,7 +27448,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -27668,7 +27677,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -38825,6 +38837,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -39956,13 +39974,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -40202,6 +40213,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -27399,7 +27399,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -40017,6 +40020,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -6918,7 +6918,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -6987,7 +6990,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -7708,7 +7714,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -24943,7 +24949,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -25169,7 +25178,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -35436,6 +35448,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -36555,13 +36573,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -36761,6 +36772,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -24900,7 +24900,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -36616,6 +36619,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -2898,7 +2898,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -2967,7 +2970,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -14227,7 +14233,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -14453,7 +14462,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -21565,6 +21577,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -22653,13 +22671,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -22745,6 +22756,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -14184,7 +14184,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -22714,6 +22717,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -14278,7 +14278,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -23061,6 +23064,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -2898,7 +2898,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -2967,7 +2970,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -14321,7 +14327,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -14547,7 +14556,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -21912,6 +21924,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -23000,13 +23018,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -23195,6 +23206,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -20314,7 +20314,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -30570,6 +30573,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -6180,7 +6180,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -6249,7 +6252,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -6970,7 +6976,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -20357,7 +20363,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -20583,7 +20592,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -29393,6 +29405,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -30509,13 +30527,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -30690,6 +30701,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -7087,7 +7087,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-creditspecification.html#cfn-ec2-instance-creditspecification-cpucredits",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2CpuCredits"
+          }
         }
       }
     },
@@ -7156,7 +7159,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance-elasticinferenceaccelerator.html#cfn-ec2-instance-elasticinferenceaccelerator-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "ElasticInferenceAccelerator"
+          }
         }
       }
     },
@@ -7877,7 +7883,7 @@
           "Required": false,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+            "ValueType": "Ec2Tenancy"
           }
         }
       }
@@ -27460,7 +27466,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-affinity",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Affinity"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-availabilityzone",
@@ -27686,7 +27695,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Conditional"
+          "UpdateType": "Conditional",
+          "Value": {
+            "ValueType": "Ec2Tenancy"
+          }
         },
         "UserData": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-userdata",
@@ -38845,6 +38857,12 @@
     }
   },
   "ValueTypes": {
+    "Affinity": {
+      "AllowedValues": [
+        "default",
+        "host"
+      ]
+    },
     "AllocationId": {
       "GetAtt": {
         "AWS::EC2::EIP": "AllocationId"
@@ -39969,13 +39987,6 @@
         "terminate"
       ]
     },
-    "EC2LaunchConfigurationPlacementTenancy": {
-      "AllowedValues": [
-        "dedicated",
-        "default",
-        "host"
-      ]
-    },
     "EC2MarketType": {
       "AllowedValues": [
         "spot"
@@ -40215,6 +40226,20 @@
           "String"
         ]
       }
+    },
+    "Ec2Tenancy": {
+      "AllowedValues": [
+        "dedicated",
+        "default",
+        "host"
+      ]
+    },
+    "ElasticInferenceAccelerator": {
+      "AllowedValues": [
+        "eia1.large",
+        "eia1.medium",
+        "eia1.xlarge"
+      ]
     },
     "GlueConnectionInputType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -27417,7 +27417,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-autoplacement",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2HostAutoPlacement"
+          }
         },
         "AvailabilityZone": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-host.html#cfn-ec2-host-availabilityzone",
@@ -40030,6 +40033,12 @@
       "AllowedValues": [
         "standard",
         "unlimited"
+      ]
+    },
+    "Ec2HostAutoPlacement": {
+      "AllowedValues": [
+        "off",
+        "on"
       ]
     },
     "Ec2InstanceType": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -3,6 +3,12 @@
     "op": "add",
     "path": "/ValueTypes",
     "value": {
+      "Affinity": {
+        "AllowedValues": [
+          "default",
+          "host"
+        ]
+      },
       "AllocationId": {
         "GetAtt": {
           "AWS::EC2::EIP": "AllocationId"
@@ -1041,7 +1047,7 @@
           "terminate"
         ]
       },
-      "EC2LaunchConfigurationPlacementTenancy": {
+      "Ec2Tenancy": {
         "AllowedValues": [
           "dedicated",
           "default",
@@ -1091,6 +1097,13 @@
         "AllowedValues": [
           "one-time",
           "persistent"
+        ]
+      },
+      "ElasticInferenceAccelerator": {
+        "AllowedValues": [
+          "eia1.large",
+          "eia1.medium",
+          "eia1.xlarge"
         ]
       },
       "GlueConnectionInputType": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1086,6 +1086,12 @@
           "unlimited"
         ]
       },
+      "Ec2HostAutoPlacement": {
+        "AllowedValues": [
+          "off",
+          "on"
+        ]
+      },
       "Ec2InstanceType": {
         "Ref": {
           "Parameters": [

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -1792,6 +1792,13 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::Host/Properties/AutoPlacement/Value",
+    "value": {
+      "ValueType": "Ec2HostAutoPlacement"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::EC2::Instance/Properties/InstanceType/Value",
     "value": {
       "ValueType": "Ec2InstanceType"

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -463,6 +463,20 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::EC2::Instance.CreditSpecification/Properties/CPUCredits/Value",
+    "value": {
+      "ValueType": "Ec2CpuCredits"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::EC2::Instance.ElasticInferenceAccelerator/Properties/Type/Value",
+    "value": {
+      "ValueType": "ElasticInferenceAccelerator"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::EC2::LaunchTemplate.BlockDeviceMapping/Properties/VolumeType/Value",
     "value": {
       "ValueType": "EbsVolumeType"
@@ -507,7 +521,7 @@
     "op": "add",
     "path": "/PropertyTypes/AWS::EC2::LaunchTemplate.Placement/Properties/Tenancy/Value",
     "value": {
-      "ValueType": "EC2LaunchConfigurationPlacementTenancy"
+      "ValueType": "Ec2Tenancy"
     }
   },
   {
@@ -1295,6 +1309,13 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::Instance/Properties/Affinity/Value",
+    "value": {
+      "ValueType": "Affinity"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::EC2::Instance/Properties/IamInstanceProfile/Value",
     "value": {
       "ValueType": "IamInstanceProfile"
@@ -1342,6 +1363,13 @@
     "path": "/ResourceTypes/AWS::EC2::Instance/Properties/SubnetId/Value",
     "value": {
       "ValueType": "SubnetId"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::Instance/Properties/Tenancy/Value",
+    "value": {
+      "ValueType": "Ec2Tenancy"
     }
   },
   {

--- a/src/cfnlint/rules/resources/properties/AvailabilityZone.py
+++ b/src/cfnlint/rules/resources/properties/AvailabilityZone.py
@@ -33,6 +33,7 @@ class AvailabilityZone(CloudFormationLintRule):
             'AWS::DAX::Cluster',
             'AWS::AutoScaling::AutoScalingGroup',
             'AWS::RDS::DBCluster',
+            'AWS::EC2::Volume',
             'AWS::ElasticLoadBalancing::LoadBalancer',
             'AWS::OpsWorks::Instance',
             'AWS::RDS::DBInstance',

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -515,6 +515,9 @@ Resources:
   EC2Instance:
     Type: "AWS::EC2::Instance"
     Properties:
+      Affinity: "dedicated" # Invalid AllowedValue
+      CreditSpecification:
+        CPUCredits: "default" # Invalid AllowedValue
       ImageId: "ami-2f726546"
       InstanceType: "t1.small" # Invalid AllowedValue
       KeyName: ""
@@ -522,6 +525,9 @@ Resources:
         - DeviceName: "/dev/sdm"
           Ebs:
             VolumeType: "magnetic" # Invalid AllowedValue
+      ElasticInferenceAccelerators:
+        - Type: "t2.medium" # Invalid AllowedValue
+      Tenancy: "instance" # Invalid AllowedValue
   EC2LaunchTemplate:
     Type: "AWS::EC2::LaunchTemplate"
     Properties:

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -512,6 +512,12 @@ Resources:
           KeyType: "hash" # Invalid AllowedValue
       StreamSpecification:
         StreamViewType: "NEW_AND_OLD" # Invalid AllowedValue
+  EC2Host:
+    Type: "AWS::EC2::Host"
+    Properties:
+      AutoPlacement: "On" # Invalid allowed Value
+      AvailabilityZone: "eu-west-1a"
+      InstanceType: "t3.medium"
   EC2Instance:
     Type: "AWS::EC2::Instance"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -539,6 +539,9 @@ Resources:
   EC2Instance:
     Type: "AWS::EC2::Instance"
     Properties:
+      Affinity: "default" # Valid AllowedValue
+      CreditSpecification:
+        CPUCredits: "standard" # Valid AllowedValue
       ImageId: "ami-2f726546"
       InstanceType: "t1.micro" # Valid AllowedValue
       KeyName: ""
@@ -546,6 +549,9 @@ Resources:
         - DeviceName: "/dev/sdm"
           Ebs:
             VolumeType: "gp2" # Valid AllowedValue
+      ElasticInferenceAccelerators:
+        - Type: "eia1.medium" # Valid AllowedValue
+      Tenancy: "dedicated" # Valid AllowedValue
   EC2Instance2:
     Type: AWS::EC2::Instance
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -536,6 +536,12 @@ Resources:
           KeyType: "HASH" # Valid AllowedValue
       StreamSpecification:
         StreamViewType: "NEW_AND_OLD_IMAGES" # Valid AllowedValue
+  EC2Host:
+    Type: "AWS::EC2::Host"
+    Properties:
+      AutoPlacement: "on" # Valid allowed Value
+      AvailabilityZone: "eu-west-1a"
+      InstanceType: "m3.medium"
   EC2Instance:
     Type: "AWS::EC2::Instance"
     Properties:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 193)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 197)

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 197)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 198)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Add all the allowed values of the [`AWS::EC2`]( https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-reference-ec2.html) Resources. 

Since EC2 is huge, it's a subset PR containing:
- Host
- Instance

**Further:**
- The `EC2::Host` has different instance types, need to figure out if this can be extracted from the Pricing API. left that one out for now...
- Added the `EC2:Volume` to the "Hardcoded AZ" check

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
