### PR TITLE
Correctly identify AWS::NotificationARNs as a list

### DIFF
--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -49,6 +49,9 @@ class Properties(CloudFormationLintRule):
         """
 
         matches = []
+        if isinstance(value, list) or value == {'Ref': 'AWS::NotificationARNs'}:
+            message = 'Property should be of type %s not List at %s' % (primtype, '/'.join(map(str, proppath)))
+            matches.append(RuleMatch(proppath, message))
         if isinstance(value, dict) and primtype == 'Json':
             return matches
         if isinstance(value, dict):
@@ -71,9 +74,6 @@ class Properties(CloudFormationLintRule):
             else:
                 message = 'Property is an object instead of %s at %s' % (primtype, '/'.join(map(str, proppath)))
                 matches.append(RuleMatch(proppath, message))
-        elif isinstance(value, list):
-            message = 'Property should be of type %s not List at %s' % (primtype, '/'.join(map(str, proppath)))
-            matches.append(RuleMatch(proppath, message))
 
         return matches
 
@@ -275,6 +275,8 @@ class Properties(CloudFormationLintRule):
                             elif isinstance(text[prop], dict):
                                 if 'Ref' in text[prop]:
                                     ref = text[prop]['Ref']
+                                    if ref == 'AWS::NotificationARNs':
+                                        continue
                                     if ref in parameternames:
                                         param_type = self.cfn.template['Parameters'][ref]['Type']
                                         if param_type:

--- a/test/fixtures/templates/bad/resource_properties.yaml
+++ b/test/fixtures/templates/bad/resource_properties.yaml
@@ -32,5 +32,6 @@ Resources:
         - DeviceIndex:
           - "1"
           BadKey: true
+      UserData: !Ref AWS::NotificationARNs
       Tags:
       - Key: Test

--- a/test/fixtures/templates/good/resource_properties.yaml
+++ b/test/fixtures/templates/good/resource_properties.yaml
@@ -679,6 +679,13 @@ Resources:
         Fn::ImportValue: "MyServiceToken"
       String: "envvar1=1, envvar2=2"
 
+  ### Test AWS::NotificationARNs Psuedo Parameter
+  SubStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: https://example.com
+      NotificationARNs: !Ref AWS::NotificationARNs
+
   ProjectBuild:
     Type: AWS::CodeBuild::Project
     Properties:

--- a/test/rules/resources/properties/test_properties.py
+++ b/test/rules/resources/properties/test_properties.py
@@ -45,7 +45,7 @@ class TestResourceProperties(BaseRuleTestCase):
 
     def test_file_negative_3(self):
         """Failure test"""
-        self.helper_file_negative('test/fixtures/templates/bad/resource_properties.yaml', 4)
+        self.helper_file_negative('test/fixtures/templates/bad/resource_properties.yaml', 5)
 
     def test_E3012_in_bad_template(self):
         """Test E3012 in known-bad template"""


### PR DESCRIPTION
*Issue #: 848*

*Description of changes:*
Adding support for identifying `AWS::NotificationARNs` as a list.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-notificationarns

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.