### PR TITLE
Add new minor version for Amazon MQ

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -20774,7 +20774,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -36236,7 +36236,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -32096,7 +32096,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -21061,7 +21061,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -30398,7 +30398,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -31715,7 +31715,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -34466,7 +34466,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -28672,7 +28672,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -35259,7 +35259,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -22507,7 +22507,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -38870,7 +38870,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -30068,7 +30068,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -26105,7 +26105,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -27015,7 +27015,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -38850,7 +38850,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -35461,7 +35461,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -21590,7 +21590,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -21937,7 +21937,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -29418,7 +29418,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -38870,7 +38870,8 @@
       "AllowedValues": [
         "5.15.0",
         "5.15.6",
-        "5.15.8"
+        "5.15.8",
+        "5.15.9"
       ]
     },
     "AmazonMQHostInstanceType": {


### PR DESCRIPTION
Amazon MQ nows supports version 5.15.9. Adding this to all regions.

https://aws.amazon.com/about-aws/whats-new/2019/04/amazon-mq-now-supports-activemq-minor-version-5-15-9/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.