### PR TITLE
Add support to look for parameters exist when a transform removes them

### DIFF
--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -429,6 +429,9 @@ class Template(object):  # pylint: disable=R0904
             'Rules'
         ]
         self.transform_globals = {}
+        self.transform_pre = {}
+        self.transform_pre['Ref'] = self.search_deep_keys('Ref')
+        self.transform_pre['Fn::Sub'] = self.search_deep_keys('Fn::Sub')
         self.conditions = cfnlint.conditions.Conditions(self)
 
     def __deepcopy__(self, memo):

--- a/src/cfnlint/rules/parameters/Used.py
+++ b/src/cfnlint/rules/parameters/Used.py
@@ -48,11 +48,11 @@ class Used(CloudFormationLintRule):
 
         matches = []
 
-        reftrees = cfn.search_deep_keys('Ref')
+        reftrees = cfn.transform_pre.get('Ref')
+        subtrees = cfn.transform_pre.get('Fn::Sub')
         refs = []
         for reftree in reftrees:
             refs.append(reftree[-1])
-        subtrees = cfn.search_deep_keys('Fn::Sub')
         subs = []
         for subtree in subtrees:
             if isinstance(subtree[-1], list):

--- a/src/cfnlint/rules/resources/properties/ListSize.py
+++ b/src/cfnlint/rules/resources/properties/ListSize.py
@@ -59,7 +59,7 @@ class ListSize(CloudFormationLintRule):
                             )
                         else:
                             scenario_text = ' and '.join(['when condition "%s" is %s' % (k, v) for (k, v) in property_set['Scenario'].items()])
-                            message = '{0} has to have between {1} and {2} items specified when {0}'
+                            message = '{0} has to have between {1} and {2} items specified when {3}'
                             matches.append(
                                 RuleMatch(
                                     path + [property_name],

--- a/test/fixtures/templates/bad/parameters/used_transform_removed.yaml
+++ b/test/fixtures/templates/bad/parameters/used_transform_removed.yaml
@@ -1,0 +1,43 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+
+Parameters:
+  ECSStack:
+    Type: String
+  AppStack:
+    Type: String
+  CognitoStackName:
+    Type: String
+  Extra:
+    Type: String
+Resources:
+  MyAPI:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: dev
+      EndpointConfiguration: EDGE
+      DefinitionBody:
+        openapi: 3.0.1
+        paths:
+          /:
+            get:
+              x-amazon-apigateway-integration:
+                connectionId:
+                  Fn::ImportValue:
+                    !Sub ${ECSStack}-VPCLink
+                uri:
+                  Fn::Sub:
+                    - http://${EndpointUri}/
+                    - EndpointUri: !ImportValue
+                        Fn::Sub: ${AppStack}-PrivateDNSEndpoint
+
+          securitySchemes:
+            cognitoAuth:
+              type: apiKey
+              name: Authorization
+              in: header
+              x-amazon-apigateway-authtype: cognito_user_pools
+              x-amazon-apigateway-authorizer:
+                type: cognito_user_pools
+                providerARNs:
+                  - Fn::ImportValue: !Sub ${CognitoStackName}-Arn

--- a/test/fixtures/templates/good/parameters/used_transform_removed.yaml
+++ b/test/fixtures/templates/good/parameters/used_transform_removed.yaml
@@ -1,0 +1,42 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: 'AWS::Serverless-2016-10-31'
+
+Parameters:
+  ECSStack:
+    Type: String
+  AppStack:
+    Type: String
+  CognitoStackName:
+    Type: String
+
+Resources:
+  MyAPI:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: dev
+      EndpointConfiguration: EDGE
+      DefinitionBody:
+        openapi: 3.0.1
+        paths:
+          /:
+            get:
+              x-amazon-apigateway-integration:
+                connectionId:
+                  Fn::ImportValue:
+                    !Sub ${ECSStack}-VPCLink
+                uri:
+                  Fn::Sub:
+                    - http://${EndpointUri}/
+                    - EndpointUri: !ImportValue
+                        Fn::Sub: ${AppStack}-PrivateDNSEndpoint
+
+          securitySchemes:
+            cognitoAuth:
+              type: apiKey
+              name: Authorization
+              in: header
+              x-amazon-apigateway-authtype: cognito_user_pools
+              x-amazon-apigateway-authorizer:
+                type: cognito_user_pools
+                providerARNs:
+                  - Fn::ImportValue: !Sub ${CognitoStackName}-Arn

--- a/test/rules/parameters/test_used.py
+++ b/test/rules/parameters/test_used.py
@@ -25,7 +25,8 @@ class TestParameterUsed(BaseRuleTestCase):
         super(TestParameterUsed, self).setUp()
         self.collection.register(Used())
         self.success_templates = [
-            'test/fixtures/templates/good/parameters/used_transforms.yaml'
+            'test/fixtures/templates/good/parameters/used_transforms.yaml',
+            'test/fixtures/templates/good/parameters/used_transform_removed.yaml'
         ]
 
     def test_file_positive(self):
@@ -35,3 +36,7 @@ class TestParameterUsed(BaseRuleTestCase):
     def test_file_negative(self):
         """Test failure"""
         self.helper_file_negative('test/fixtures/templates/bad/parameters.yaml', 3)
+
+    def test_file_negative_removed(self):
+        """Test failure"""
+        self.helper_file_negative('test/fixtures/templates/bad/parameters/used_transform_removed.yaml', 1)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix core and W2001 to look for Parameters in the pre transformed template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
