### PR TITLE
Ignore an error when the string is all

### DIFF
--- a/src/cfnlint/rules/resources/properties/AvailabilityZone.py
+++ b/src/cfnlint/rules/resources/properties/AvailabilityZone.py
@@ -63,9 +63,11 @@ class AvailabilityZone(CloudFormationLintRule):
         """Check ref for VPC"""
         matches = []
 
-        if path[-1] != 'Fn::GetAZs':
-            message = 'Don\'t hardcode {0} for AvailabilityZones'
-            matches.append(RuleMatch(path, message.format(value)))
+        # value of `all` is a valide exception in AWS::ElasticLoadBalancingV2::TargetGroup
+        if value not in ['all']:
+            if path[-1] != ['Fn::GetAZs']:
+                message = 'Don\'t hardcode {0} for AvailabilityZones'
+                matches.append(RuleMatch(path, message.format(value)))
 
         return matches
 

--- a/test/fixtures/templates/good/resources/properties/az.yaml
+++ b/test/fixtures/templates/good/resources/properties/az.yaml
@@ -1,0 +1,24 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  DefaultTargetGroup:
+    Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
+    Properties:
+      VpcId: hello
+      Port: 80
+      Protocol: HTTP
+      HealthCheckIntervalSeconds: 30
+      HealthCheckPath: "/"
+      HealthCheckPort: "80"
+      HealthCheckProtocol: "HTTP"
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 5
+      TargetType: ip
+      Targets:
+        - Id: "10.31.33.28"
+          AvailabilityZone: all
+      Matcher:
+        HttpCode: "200"
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: "20"

--- a/test/rules/resources/properties/test_availability_zone.py
+++ b/test/rules/resources/properties/test_availability_zone.py
@@ -24,6 +24,9 @@ class TestPropertyAvailabilityZone(BaseRuleTestCase):
         """Setup"""
         super(TestPropertyAvailabilityZone, self).setUp()
         self.collection.register(AvailabilityZone())
+        self.success_templates = [
+            'test/fixtures/templates/good/resources/properties/az.yaml'
+        ]
 
     def test_file_positive(self):
         """Success test"""


### PR DESCRIPTION
*Issue #, if available:*
Fix #869
*Description of changes:*
- Fix rule W3010 to not error when the availability zone is all

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
