### PR TITLE
Remove PrimitiveType from MaintenanceWindowTarget

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -20568,7 +20568,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -34720,7 +34720,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -30739,7 +30739,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -20822,7 +20822,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -29041,7 +29041,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -30358,7 +30358,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -33092,7 +33092,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -27364,7 +27364,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -33959,7 +33959,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -21911,7 +21911,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -37282,7 +37282,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -28760,7 +28760,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -25036,7 +25036,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -25976,7 +25976,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -37243,7 +37243,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -34051,7 +34051,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -21474,7 +21474,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -21684,7 +21684,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -28144,7 +28144,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -37288,7 +37288,6 @@
         "Targets": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
           "ItemType": "Target",
-          "PrimitiveType": "String",
           "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"

--- a/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
@@ -209,7 +209,6 @@
         "Targets": {
           "Required": true,
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-maintenancewindowtarget.html#cfn-ssm-maintenancewindowtarget-targets",
-          "PrimitiveType": "String",
           "Type": "List",
           "ItemType": "Target",
           "UpdateType": "Mutable"

--- a/src/cfnlint/rules/resources/properties/ValuePrimitiveType.py
+++ b/src/cfnlint/rules/resources/properties/ValuePrimitiveType.py
@@ -138,6 +138,10 @@ class ValuePrimitiveType(CloudFormationLintRule):
                     if not isinstance(map_value, dict):
                         matches.extend(self.check_primitive_type(map_value, primitive_type, path + [map_key]))
         else:
+            # some properties support primitive types and objects
+            # skip in the case it could be an object and the value is a object
+            if item_type and isinstance(value, dict):
+                return matches
             matches.extend(self.check_primitive_type(value, primitive_type, path))
 
         return matches

--- a/test/fixtures/templates/good/resources/properties/primitive_types.yaml
+++ b/test/fixtures/templates/good/resources/properties/primitive_types.yaml
@@ -1,0 +1,23 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  BaselinePatchDailySSMMaintenanceWindow:
+    Type: AWS::SSM::MaintenanceWindow
+    Properties:
+      Name: Test
+      Cutoff: 0
+      Schedule: 'rate(1 days)'
+      AllowUnassociatedTargets: false
+      Duration: 1
+  BaselinePatchDailySSMMaintenanceWindowTarget:
+    Type: AWS::SSM::MaintenanceWindowTarget
+    Properties:
+      Name: BaselinePatchDailyTarget
+      Description: Systems with Tag Key=Patch,Value=Daily.
+      WindowId: !Ref BaselinePatchDailySSMMaintenanceWindow
+      ResourceType: INSTANCE
+      Targets:
+      - Key: tag:Patch
+        Values:
+        - Daily
+        - daily

--- a/test/rules/resources/properties/test_value_primitive_type.py
+++ b/test/rules/resources/properties/test_value_primitive_type.py
@@ -28,7 +28,7 @@ class TestResourceValuePrimitiveType(BaseRuleTestCase):
     success_templates = [
         'test/fixtures/templates/good/generic.yaml',
         'test/fixtures/templates/good/resource_properties.yaml',
-        'test/fixtures/templates/good/resources/properties/primitive_type.yaml',
+        'test/fixtures/templates/good/resources/properties/primitive_types.yaml',
     ]
 
     def test_file_positive(self):

--- a/test/rules/resources/properties/test_value_primitive_type.py
+++ b/test/rules/resources/properties/test_value_primitive_type.py
@@ -28,6 +28,7 @@ class TestResourceValuePrimitiveType(BaseRuleTestCase):
     success_templates = [
         'test/fixtures/templates/good/generic.yaml',
         'test/fixtures/templates/good/resource_properties.yaml',
+        'test/fixtures/templates/good/resources/properties/primitive_type.yaml',
     ]
 
     def test_file_positive(self):


### PR DESCRIPTION
*Issue #, if available:*
Fix #863
*Description of changes:*
- Remove PrimitiveType from MaintenanceWindowTarget Targets

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
