### PR TITLE
Add new Lambda Runtime (nodejs10.x)

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -22315,6 +22315,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -38061,6 +38061,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -33788,6 +33788,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -22665,6 +22665,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -32077,6 +32077,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -33468,6 +33468,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -36194,6 +36194,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -30328,6 +30328,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -37083,6 +37083,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -24149,6 +24149,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -40713,6 +40713,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -31730,6 +31730,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -27757,6 +27757,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -28686,6 +28686,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -40651,6 +40651,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -37281,6 +37281,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -23284,6 +23284,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -23716,6 +23716,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -31138,6 +31138,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -40724,6 +40724,7 @@
         "nodejs4.3",
         "nodejs6.10",
         "nodejs8.10",
+        "nodejs10.x",
         "provided",
         "python2.7",
         "python3.6",

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1451,6 +1451,7 @@
           "nodejs4.3",
           "nodejs6.10",
           "nodejs8.10",
+          "nodejs10.x",
           "provided",
           "python2.7",
           "python3.6",


### PR DESCRIPTION
New Lamba runtime is released: https://docs.aws.amazon.com/lambda/latest/dg/history.html

(See also: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
Add it to the AllowedValues