### PR TITLE
Add EC2 allowed values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -21905,6 +21905,44 @@
         "vpc"
       ]
     },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
+      ]
+    },
     "Ec2FlowLogDestinationType": {
       "AllowedValues": [
         "cloud-watch-logs",

--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -13522,7 +13522,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -21505,6 +21508,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -13489,7 +13489,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -21500,6 +21503,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -6918,7 +6918,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -6976,7 +6979,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -6987,13 +6993,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -7045,7 +7057,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -25329,7 +25344,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -25379,7 +25397,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -37557,6 +37578,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -25284,7 +25284,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -37160,6 +37163,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -25317,7 +25317,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -37180,6 +37183,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -6706,7 +6706,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -6764,7 +6767,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -6775,13 +6781,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -6833,7 +6845,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -22546,7 +22561,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -22596,7 +22614,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -33318,6 +33339,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -22534,7 +22534,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -32941,6 +32944,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -22501,7 +22501,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -32936,6 +32939,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -2809,7 +2809,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -2867,7 +2870,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -2878,13 +2884,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -2936,7 +2948,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -13729,7 +13744,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -13779,7 +13797,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -22215,6 +22236,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -13684,7 +13684,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -21833,6 +21836,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -13717,7 +13717,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -21838,6 +21841,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -5976,7 +5976,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -6034,7 +6037,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -6045,13 +6051,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -6103,7 +6115,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -20848,7 +20863,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -20898,7 +20916,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -31627,6 +31648,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -20836,7 +20836,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -31250,6 +31253,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -20803,7 +20803,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -31230,6 +31233,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -6338,7 +6338,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -6396,7 +6399,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -6407,13 +6413,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -6465,7 +6477,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -21953,7 +21968,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -22003,7 +22021,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -32953,6 +32974,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -21941,7 +21941,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -32576,6 +32579,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -21908,7 +21908,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -32556,6 +32559,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -6847,7 +6847,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -6905,7 +6908,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -6916,13 +6922,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -6974,7 +6986,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -24099,7 +24114,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -24149,7 +24167,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -35691,6 +35712,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -24054,7 +24054,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -35294,6 +35297,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -24087,7 +24087,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -35314,6 +35317,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -5810,7 +5810,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -5868,7 +5871,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -5879,13 +5885,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -5937,7 +5949,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -19637,7 +19652,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -19687,7 +19705,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -29886,6 +29907,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -19625,7 +19625,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -29509,6 +29512,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -19592,7 +19592,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -29504,6 +29507,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -24692,7 +24692,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -36206,6 +36209,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -24659,7 +24659,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -36191,6 +36194,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -6772,7 +6772,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -6830,7 +6833,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -6841,13 +6847,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -6899,7 +6911,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -24704,7 +24719,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -24754,7 +24772,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -36591,6 +36612,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -14758,7 +14758,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -23334,6 +23337,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -23739,6 +23739,44 @@
         "vpc"
       ]
     },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
+      ]
+    },
     "Ec2FlowLogDestinationType": {
       "AllowedValues": [
         "cloud-watch-logs",

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -14791,7 +14791,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -23339,6 +23342,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -6975,7 +6975,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -7033,7 +7036,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -7044,13 +7050,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -7102,7 +7114,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -27365,7 +27380,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -27415,7 +27433,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -40175,6 +40196,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -27320,7 +27320,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -39770,6 +39773,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -27353,7 +27353,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -39790,6 +39793,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -20560,7 +20560,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -30908,6 +30911,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -6261,7 +6261,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -6319,7 +6322,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -6330,13 +6336,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -6388,7 +6400,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -20605,7 +20620,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -20655,7 +20673,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -31290,6 +31311,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -20593,7 +20593,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -30913,6 +30916,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -4512,7 +4512,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -4570,7 +4573,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -4581,13 +4587,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -4639,7 +4651,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -17456,7 +17471,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -17506,7 +17524,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -27319,6 +27340,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -17411,7 +17411,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -26937,6 +26940,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -17444,7 +17444,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -26942,6 +26945,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -18453,7 +18453,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -27867,6 +27870,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -5013,7 +5013,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -5071,7 +5074,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -5082,13 +5088,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -5140,7 +5152,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -18465,7 +18480,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -18515,7 +18533,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -28244,6 +28265,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -18420,7 +18420,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -27847,6 +27850,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -6915,7 +6915,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -6973,7 +6976,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -6984,13 +6990,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -7042,7 +7054,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -27293,7 +27308,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -27343,7 +27361,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -40108,6 +40129,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -27248,7 +27248,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -39703,6 +39706,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -27281,7 +27281,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -39723,6 +39726,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -6806,7 +6806,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -6864,7 +6867,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -6875,13 +6881,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -6933,7 +6945,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -24865,7 +24880,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -24915,7 +24933,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -36778,6 +36799,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -24853,7 +24853,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -36393,6 +36396,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -24820,7 +24820,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -36378,6 +36381,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -14100,7 +14100,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -22492,6 +22495,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -22897,6 +22897,44 @@
         "vpc"
       ]
     },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
+      ]
+    },
     "Ec2FlowLogDestinationType": {
       "AllowedValues": [
         "cloud-watch-logs",

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -14133,7 +14133,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -22497,6 +22500,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -14176,7 +14176,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -22821,6 +22824,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -14209,7 +14209,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -22826,6 +22829,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -23226,6 +23226,44 @@
         "vpc"
       ]
     },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
+      ]
+    },
     "Ec2FlowLogDestinationType": {
       "AllowedValues": [
         "cloud-watch-logs",

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -6008,7 +6008,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -6066,7 +6069,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -6077,13 +6083,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -6135,7 +6147,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -20207,7 +20222,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -20257,7 +20275,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -30660,6 +30681,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -20162,7 +20162,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -30263,6 +30266,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -20195,7 +20195,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -30283,6 +30286,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -27326,7 +27326,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-customer-gateway.html#cfn-ec2-customergateway-type",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "CustomerGatewayType"
+          }
         }
       }
     },
@@ -39776,6 +39779,11 @@
       "AllowedValues": [
         "AWS",
         "CUSTOM_LAMBDA"
+      ]
+    },
+    "CustomerGatewayType": {
+      "AllowedValues": [
+        "ipsec.1"
       ]
     },
     "DAXInstanceType": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -6975,7 +6975,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-instancetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "MaxPrice": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest.html#cfn-ec2-ec2fleet-fleetlaunchtemplateoverridesrequest-maxprice",
@@ -7033,7 +7036,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-ondemandoptionsrequest.html#cfn-ec2-ec2fleet-ondemandoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+          }
         }
       }
     },
@@ -7044,13 +7050,19 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-allocationstrategy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotAllocationStrategy"
+          }
         },
         "InstanceInterruptionBehavior": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instanceinterruptionbehavior",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetSpotInterruptionBehavior"
+          }
         },
         "InstancePoolsToUseCount": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-spotoptionsrequest.html#cfn-ec2-ec2fleet-spotoptionsrequest-instancepoolstousecount",
@@ -7102,7 +7114,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-defaulttargetcapacitytype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetDefaultTargetCapacityType"
+          }
         },
         "OnDemandTargetCapacity": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ec2fleet-targetcapacityspecificationrequest.html#cfn-ec2-ec2fleet-targetcapacityspecificationrequest-ondemandtargetcapacity",
@@ -27371,7 +27386,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-excesscapacityterminationpolicy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+          }
         },
         "LaunchTemplateConfigs": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-launchtemplateconfigs",
@@ -27421,7 +27439,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-type",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2FleetType"
+          }
         },
         "ValidFrom": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-ec2fleet.html#cfn-ec2-ec2fleet-validfrom",
@@ -40181,6 +40202,44 @@
       "AllowedValues": [
         "standard",
         "vpc"
+      ]
+    },
+    "Ec2FleetDefaultTargetCapacityType": {
+      "AllowedValues": [
+        "on-demand",
+        "spot"
+      ]
+    },
+    "Ec2FleetExcessCapacityTerminationPolicy": {
+      "AllowedValues": [
+        "no-termination",
+        "termination"
+      ]
+    },
+    "Ec2FleetOnDemandAllocationStrategy": {
+      "AllowedValues": [
+        "lowest-price",
+        "prioritized"
+      ]
+    },
+    "Ec2FleetSpotAllocationStrategy": {
+      "AllowedValues": [
+        "diversified",
+        "lowest-price"
+      ]
+    },
+    "Ec2FleetSpotInterruptionBehavior": {
+      "AllowedValues": [
+        "hibernate",
+        "stop",
+        "terminate"
+      ]
+    },
+    "Ec2FleetType": {
+      "AllowedValues": [
+        "instant",
+        "maintain",
+        "request"
       ]
     },
     "Ec2FlowLogDestinationType": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -27359,7 +27359,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-netbiosnodetype",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "DHCPOptionsNetbiosNodeType"
+          }
         },
         "NtpServers": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-dhcp-options.html#cfn-ec2-dhcpoptions-ntpservers",
@@ -39796,6 +39799,14 @@
           "String"
         ]
       }
+    },
+    "DHCPOptionsNetbiosNodeType": {
+      "AllowedValues": [
+        "1",
+        "2",
+        "4",
+        "8"
+      ]
     },
     "DLMPolicyResourceType": {
       "AllowedValues": [

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -685,6 +685,11 @@
           "CUSTOM_LAMBDA"
         ]
       },
+      "CustomerGatewayType": {
+        "AllowedValues": [
+          "ipsec.1"
+        ]
+      },
       "DAXInstanceType": {
         "Ref": {
           "Parameters": [

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -956,6 +956,14 @@
           "ENABLED"
         ]
       },
+      "DHCPOptionsNetbiosNodeType": {
+        "AllowedValues": [
+          "1",
+          "2",
+          "4",
+          "8"
+        ]
+      },
       "DmsEndpointEngineName": {
         "AllowedValues": [
           "aurora-postgresql",

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1092,6 +1092,44 @@
           "vpc"
         ]
       },
+      "Ec2FleetExcessCapacityTerminationPolicy": {
+        "AllowedValues": [
+          "no-termination",
+          "termination"
+        ]
+      },
+      "Ec2FleetType": {
+        "AllowedValues": [
+          "instant",
+          "maintain",
+          "request"
+        ]
+      },
+      "Ec2FleetOnDemandAllocationStrategy": {
+        "AllowedValues": [
+          "lowest-price",
+          "prioritized"
+        ]
+      },
+      "Ec2FleetSpotAllocationStrategy": {
+        "AllowedValues": [
+          "diversified",
+          "lowest-price"
+        ]
+      },
+      "Ec2FleetSpotInterruptionBehavior": {
+        "AllowedValues": [
+          "hibernate",
+          "stop",
+          "terminate"
+        ]
+      },
+      "Ec2FleetDefaultTargetCapacityType": {
+        "AllowedValues": [
+          "on-demand",
+          "spot"
+        ]
+      },
       "Ec2FlowLogDestinationType": {
         "AllowedValues": [
           "cloud-watch-logs",

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -1267,6 +1267,13 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::CustomerGateway/Properties/Type/Value",
+    "value": {
+      "ValueType": "CustomerGatewayType"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::EC2::DHCPOptions/Properties/NetbiosNodeType/Value",
     "value": {
       "ValueType": "DHCPOptionsNetbiosNodeType"

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -463,6 +463,41 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::EC2::EC2Fleet.FleetLaunchTemplateOverridesRequest/Properties/InstanceType/Value",
+    "value": {
+      "ValueType": "Ec2InstanceType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::EC2::EC2Fleet.OnDemandOptionsRequest/Properties/AllocationStrategy/Value",
+    "value": {
+      "ValueType": "Ec2FleetOnDemandAllocationStrategy"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::EC2::EC2Fleet.SpotOptionsRequest/Properties/AllocationStrategy/Value",
+    "value": {
+      "ValueType": "Ec2FleetSpotAllocationStrategy"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::EC2::EC2Fleet.SpotOptionsRequest/Properties/InstanceInterruptionBehavior/Value",
+    "value": {
+      "ValueType": "Ec2FleetSpotInterruptionBehavior"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::EC2::EC2Fleet.TargetCapacitySpecificationRequest/Properties/DefaultTargetCapacityType/Value",
+    "value": {
+      "ValueType": "Ec2FleetDefaultTargetCapacityType"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::EC2::Instance.CreditSpecification/Properties/CPUCredits/Value",
     "value": {
       "ValueType": "Ec2CpuCredits"
@@ -1305,6 +1340,20 @@
     "path": "/ResourceTypes/AWS::EC2::EIPAssociation/Properties/AllocationId/Value",
     "value": {
       "ValueType": "AllocationId"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::EC2Fleet/Properties/ExcessCapacityTerminationPolicy/Value",
+    "value": {
+      "ValueType": "Ec2FleetExcessCapacityTerminationPolicy"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::EC2Fleet/Properties/Type/Value",
+    "value": {
+      "ValueType": "Ec2FleetType"
     }
   },
   {

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -1267,6 +1267,13 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::DHCPOptions/Properties/NetbiosNodeType/Value",
+    "value": {
+      "ValueType": "DHCPOptionsNetbiosNodeType"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::DirectoryService::MicrosoftAD/Properties/Edition/Value",
     "value": {
       "ValueType": "MicrosoftADEdition"

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -442,6 +442,12 @@ Resources:
       ConfigSnapshotDeliveryProperties:
         DeliveryFrequency: "Minute" # Invalid AllowedValue
       S3BucketName: !Ref "S3Bucket"
+  CustomerGateway:
+    Type: "AWS::EC2::CustomerGateway"
+    Properties:
+      BgpAsn: 65000
+      IpAddress: "127.0.0.1"
+      Type: "ipsec.1 " # Invalid AllowedValue
   DAXCluster:
     Type: "AWS::DAX::Cluster"
     Properties:

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -448,6 +448,10 @@ Resources:
       IAMRoleARN: "iam"
       NodeType: "t2.small" # Invalid AllowedValue
       ReplicationFactor: 1
+  DHCPOptions:
+    Type: "AWS::EC2::DHCPOptions"
+    Properties:
+      NetbiosNodeType: 5 # Invalid AllowedValue
   DirectoryServiceMicrosoftAD:
     Type: "AWS::DirectoryService::MicrosoftAD"
     Properties:

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -516,6 +516,22 @@ Resources:
     Type: "AWS::EC2::EIP"
     Properties:
       Domain: "VPC" # Invalid AllowedValue
+  EC2Fleet:
+    Type: "AWS::EC2::EC2Fleet"
+    Properties:
+      ExcessCapacityTerminationPolicy: "terminator" # Invalid AllowedValue
+      LaunchTemplateConfigs:
+        - Overrides:
+            - InstanceType: "t1.large" # Invalid AllowedValue
+      OnDemandOptions:
+        AllocationStrategy: "Prioritized" # Invalid AllowedValue
+      SpotOptions:
+        AllocationStrategy: "special" # Invalid AllowedValue
+        InstanceInterruptionBehavior: "reboot" # Invalid AllowedValue
+      TargetCapacitySpecification:
+        DefaultTargetCapacityType: "ondemand" # Invalid AllowedValue
+        TotalTargetCapacity: 1
+      Type: "maintainain" # Invalid AllowedValue
   EC2FlowLog:
     Type: "AWS::EC2::FlowLog"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -475,6 +475,10 @@ Resources:
       IAMRoleARN: "iam"
       NodeType: "dax.t2.small" # Valid AllowedValue
       ReplicationFactor: 1
+  DHCPOptions:
+    Type: "AWS::EC2::DHCPOptions"
+    Properties:
+      NetbiosNodeType: 4 # Valid AllowedValue
   DirectoryServiceMicrosoftAD:
     Type: "AWS::DirectoryService::MicrosoftAD"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -469,6 +469,12 @@ Resources:
       ConfigSnapshotDeliveryProperties:
         DeliveryFrequency: "Six_Hours" # Valid AllowedValue
       S3BucketName: !Ref "S3Bucket"
+  CustomerGateway:
+    Type: "AWS::EC2::CustomerGateway"
+    Properties:
+      BgpAsn: 65000
+      IpAddress: "127.0.0.1"
+      Type: "ipsec.1" # Valid AllowedValue
   DAXCluster:
     Type: "AWS::DAX::Cluster"
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -543,6 +543,22 @@ Resources:
     Type: "AWS::EC2::EIP"
     Properties:
       Domain: "vpc" # Valid AllowedValue
+  EC2Fleet:
+    Type: "AWS::EC2::EC2Fleet"
+    Properties:
+      ExcessCapacityTerminationPolicy: "termination" # Valid AllowedValue
+      LaunchTemplateConfigs:
+        - Overrides:
+            - InstanceType: "t2.large" # Valid AllowedValue
+      OnDemandOptions:
+        AllocationStrategy: "prioritized" # Valid AllowedValue
+      SpotOptions:
+        AllocationStrategy: "diversified" # Valid AllowedValue
+        InstanceInterruptionBehavior: "hibernate" # Valid AllowedValue
+      TargetCapacitySpecification:
+        DefaultTargetCapacityType: "on-demand" # Valid AllowedValue
+        TotalTargetCapacity: 1
+      Type: "maintain" # Valid AllowedValue
   EC2FlowLog:
     Type: "AWS::EC2::FlowLog"
     Properties:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 202)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 209)

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 209)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 210)

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 210)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 211)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Add all the allowed values of the [`AWS::EC2`]( https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/AWS_EC2.html) Resources. 

Since EC2 is huge, it's a subset PR containing:
- CustomerGateway
- DHCPOptions
- EC2Fleet

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
