### PR TITLE
Remove OnlyOnly on AWS::ServiceDiscovery::Service

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/Exclusive.json
+++ b/src/cfnlint/data/AdditionalSpecs/Exclusive.json
@@ -72,6 +72,11 @@
         "ExtendedStatistic"
       ]
     },
+    "AWS::ServiceDiscovery::Service": {
+      "HealthCheckConfig": [
+        "HealthCheckCustomConfig"
+      ]
+    },
     "AWS::EC2::Instance": {
       "NetworkInterfaces": [
         "SubnetId"

--- a/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
+++ b/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
@@ -94,12 +94,6 @@
         "HostedZoneName"
       ]
     ],
-    "AWS::ServiceDiscovery::Service": [
-      [
-        "HealthCheckConfig",
-        "HealthCheckCustomConfig"
-      ]
-    ],
     "AWS::ElasticLoadBalancingV2::LoadBalancer": [
       [
         "SubnetMappings",


### PR DESCRIPTION
*Issue https://github.com/aws-cloudformation/cfn-python-lint/issues/893, if available:*

Remove the OnlyOne configuration of the `AWS::ServiceDiscovery::Service` health check configuration.

Re-reading the documentation I'm really confused:

On `HealthCheckCustomConfig ` it mentions:

```If you specify a health check configuration, you can specify either HealthCheckCustomConfig or HealthCheckConfig but not both.```

So from that case it seems the OnlyOne makes sense.. But what is "a health check configuration" in this case?

Looking at the documentation of `HealthCheckConfig` I'm lost. Remove this...


 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
