### PR TITLE
Change Debug strategy

### DIFF
--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -93,13 +93,8 @@ class CloudFormationLintRule(object):
             matches = []
 
             start = datetime.now()
-            LOGGER.debug('Starting match function for rule %s at %s', self.id, start)
             # pylint: disable=E1102
             results = match_function(self, filename, cfn, *args, **kwargs)
-            LOGGER.debug('Complete match function for rule %s at %s.  Ran in %s',
-                         self.id, datetime.now(), datetime.now() - start)
-            LOGGER.debug('Results from rule %s are %s: ', self.id, results)
-
             if results:
                 for result in results:
                     linenumbers = cfn.get_location_yaml(cfn.template, result.path)
@@ -474,7 +469,6 @@ class Template(object):  # pylint: disable=R0904
             Get Resources
             Filter on type when specified
         """
-        LOGGER.debug('Get resources from template...')
         resources = self.template.get('Resources', {})
         if not isinstance(resources, dict):
             return {}
@@ -491,7 +485,6 @@ class Template(object):  # pylint: disable=R0904
 
     def get_parameters(self):
         """Get Resources"""
-        LOGGER.debug('Get parameters from template...')
         parameters = self.template.get('Parameters', {})
         if not parameters:
             return {}
@@ -500,7 +493,6 @@ class Template(object):  # pylint: disable=R0904
 
     def get_mappings(self):
         """Get Resources"""
-        LOGGER.debug('Get mapping from template...')
         mappings = self.template.get('Mappings', {})
         if not mappings:
             return {}
@@ -509,7 +501,6 @@ class Template(object):  # pylint: disable=R0904
 
     def get_resource_names(self):
         """Get all the Resource Names"""
-        LOGGER.debug('Get the names of all resources from template...')
         results = []
         resources = self.template.get('Resources', {})
         if isinstance(resources, dict):
@@ -520,7 +511,6 @@ class Template(object):  # pylint: disable=R0904
 
     def get_parameter_names(self):
         """Get all Parameter Names"""
-        LOGGER.debug('Get names of all parameters from template...')
         results = []
         parameters = self.template.get('Parameters', {})
         if isinstance(parameters, dict):
@@ -531,7 +521,6 @@ class Template(object):  # pylint: disable=R0904
 
     def get_valid_refs(self):
         """Get all valid Refs"""
-        LOGGER.debug('Get all valid REFs from template...')
         results = {}
         parameters = self.template.get('Parameters', {})
         if parameters:
@@ -569,7 +558,6 @@ class Template(object):  # pylint: disable=R0904
 
     def get_valid_getatts(self):
         """Get all valid GetAtts"""
-        LOGGER.debug('Get valid GetAtts from template...')
         resourcetypes = cfnlint.helpers.RESOURCE_SPECS['us-east-1'].get('ResourceTypes')
         results = {}
         resources = self.template.get('Resources', {})
@@ -582,7 +570,6 @@ class Template(object):  # pylint: disable=R0904
             if 'Type' in value:
                 valtype = value['Type']
                 if valtype.startswith(astrik_types):
-                    LOGGER.debug('Cant build an appropriate getatt list from %s', valtype)
                     results[name] = {'*': {'PrimitiveItemType': 'String'}}
                 else:
                     if value['Type'] in resourcetypes:
@@ -613,7 +600,6 @@ class Template(object):  # pylint: disable=R0904
 
     def _get_sub_resource_properties(self, keys, properties, path):
         """Used for recursive handling of properties in the keys"""
-        LOGGER.debug('Get Sub Resource Properties from %s', keys)
         if not keys:
             result = {}
             result['Path'] = path
@@ -658,7 +644,6 @@ class Template(object):  # pylint: disable=R0904
 
     def get_resource_properties(self, keys):
         """Filter keys of template"""
-        LOGGER.debug('Get Properties from a resource: %s', keys)
         matches = []
         resourcetype = keys.pop(0)
         for resource_name, resource_value in self.get_resources(resourcetype).items():
@@ -703,7 +688,6 @@ class Template(object):  # pylint: disable=R0904
         """
             Search for keys in all parts of the templates
         """
-        LOGGER.debug('Search for key %s as far down as the template goes', searchText)
         results = []
         results.extend(self._search_deep_keys(searchText, self.template, []))
         # Globals are removed during a transform.  They need to be checked manually
@@ -712,7 +696,6 @@ class Template(object):  # pylint: disable=R0904
 
     def get_condition_values(self, template, path=[]):
         """Evaluates conditions and brings back the values"""
-        LOGGER.debug('Get condition values...')
         matches = []
         if not isinstance(template, list):
             return matches
@@ -762,7 +745,6 @@ class Template(object):  # pylint: disable=R0904
             Returns the value if its just a string, int, boolean, etc.
 
         """
-        LOGGER.debug('Get the value for key %s in %s', key, obj)
         matches = []
 
         if not isinstance(obj, dict):
@@ -834,7 +816,6 @@ class Template(object):  # pylint: disable=R0904
 
     def _loc(self, obj):
         """Return location of object"""
-        LOGGER.debug('Get location of object...')
         return (obj.start_mark.line, obj.start_mark.column, obj.end_mark.line, obj.end_mark.column)
 
     def get_sub_parameters(self, sub_string):
@@ -852,7 +833,6 @@ class Template(object):  # pylint: disable=R0904
         """
         Get the location information
         """
-        LOGGER.debug('Get location of path %s', path)
         result = None
         if len(path) > 1:
             try:
@@ -889,7 +869,6 @@ class Template(object):  # pylint: disable=R0904
                                 check_find_in_map=None, check_split=None,
                                 check_join=None, check_sub=None, **kwargs):
         """ Check Resource Properties """
-        LOGGER.debug('Check property %s for %s', resource_property, resource_type)
         matches = []
         resources = self.get_resources(resource_type=resource_type)
         for resource_name, resource_object in resources.items():
@@ -915,7 +894,6 @@ class Template(object):  # pylint: disable=R0904
         """
             Check the value
         """
-        LOGGER.debug('Check value %s for %s', key, obj)
         matches = []
         values_obj = self.get_values(obj=obj, key=key)
         new_path = path[:] + [key]
@@ -1272,7 +1250,6 @@ class Template(object):  # pylint: disable=R0904
                     if its in the True or False part of the path.
                     {'condition': {True}}
         """
-        LOGGER.debug('Get conditions for path %s', path)
         results = {}
 
         def get_condition_name(value, num=None):
@@ -1330,8 +1307,6 @@ class Runner(object):
 
     def transform(self):
         """Transform logic"""
-        LOGGER.debug('Transform templates if needed')
-
         matches = []
         transform_type = self.cfn.template.get('Transform')
 

--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -24,6 +24,7 @@ import copy
 import six
 import jsonschema
 import cfnlint.decode.cfn_yaml
+import cfnlint.helpers
 from cfnlint.version import __version__
 try:  # pragma: no cover
     from pathlib import Path
@@ -121,23 +122,21 @@ class ConfigFileArgs(object):
             CFLINTRC configuration
         """
 
-        LOGGER.debug('Looking for CFLINTRC before attempting to load')
         user_config, project_config = self._find_config()
 
         user_config = self._read_config(user_config)
-        LOGGER.debug('Validating User CFNLINTRC')
         self.validate_config(user_config, self.schema)
 
         project_config = self._read_config(project_config)
-        LOGGER.debug('Validating Project CFNLINTRC')
         self.validate_config(project_config, self.schema)
 
-        LOGGER.debug('User configuration loaded as')
-        LOGGER.debug('%s', user_config)
-        LOGGER.debug('Project configuration loaded as')
-        LOGGER.debug('%s', project_config)
+        if user_config:
+            LOGGER.debug('User configuration loaded as')
+            LOGGER.debug('%s', user_config)
+        if user_config:
+            LOGGER.debug('Project configuration loaded as')
+            LOGGER.debug('%s', project_config)
 
-        LOGGER.debug('Merging configurations...')
         self.file_args = self.merge_config(user_config, project_config)
 
     def validate_config(self, config, schema):
@@ -153,12 +152,13 @@ class ConfigFileArgs(object):
         jsonschema.exceptions.ValidationError
             Returned when cfnlintrc doesn't match schema provided
         """
-        LOGGER.debug('Validating CFNLINTRC config with given JSONSchema')
-        LOGGER.debug('Schema used: %s', schema)
-        LOGGER.debug('Config used: %s', config)
+        if config:
+            LOGGER.debug('Validating CFNLINTRC config with given JSONSchema')
+            LOGGER.debug('Schema used: %s', schema)
+            LOGGER.debug('Config used: %s', config)
 
         jsonschema.validate(config, schema)
-        LOGGER.debug('CFNLINTRC looks valid!')
+
 
     def merge_config(self, user_config, project_config):
         """Merge project and user configuration into a single dictionary

--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -215,6 +215,9 @@ def bool_compare(first, second):
 
     return first is second
 
+def format_json_string(json_string):
+    """ Format the given JSON string"""
+    return json.dumps(json_string, indent=2, sort_keys=True, separators=(',', ': '))
 
 def initialize_specs():
     """ Reload Resource Specs """

--- a/src/cfnlint/rules/resources/Configuration.py
+++ b/src/cfnlint/rules/resources/Configuration.py
@@ -60,7 +60,6 @@ class Configuration(CloudFormationLintRule):
             matches.append(RuleMatch(['Resources'], message))
         else:
             for resource_name, resource_values in cfn.template.get('Resources', {}).items():
-                self.logger.debug('Validating resource %s base configuration', resource_name)
                 if not isinstance(resource_values, dict):
                     message = 'Resource not properly configured at {0}'
                     matches.append(RuleMatch(
@@ -90,7 +89,6 @@ class Configuration(CloudFormationLintRule):
                         message.format(resource_name)
                     ))
                 else:
-                    self.logger.debug('Check resource types by region...')
                     for region, specs in cfnlint.helpers.RESOURCE_SPECS.items():
                         if region in cfn.regions:
                             if resource_type not in specs['ResourceTypes']:

--- a/src/cfnlint/rules/resources/DeletionPolicy.py
+++ b/src/cfnlint/rules/resources/DeletionPolicy.py
@@ -77,7 +77,6 @@ class DeletionPolicy(CloudFormationLintRule):
             if deletion_policies:
                 path = ['Resources', resource_name, 'DeletionPolicy']
                 res_type = resource_values.get('Type')
-                self.logger.debug('Validating DeletionPolicy for %s base configuration', resource_name)
                 if isinstance(deletion_policies, list):
                     message = 'Only one DeletionPolicy allowed per resource at {0}'
                     matches.append(RuleMatch(path, message.format('/'.join(map(str, path)))))

--- a/src/cfnlint/rules/resources/DependsOn.py
+++ b/src/cfnlint/rules/resources/DependsOn.py
@@ -52,7 +52,6 @@ class DependsOn(CloudFormationLintRule):
             depends_ons = resource_values.get('DependsOn')
             if depends_ons:
                 path = ['Resources', resource_name, 'DependsOn']
-                self.logger.debug('Validating DependsOn for %s base configuration', resource_name)
                 if isinstance(depends_ons, list):
                     for index, depends_on in enumerate(depends_ons):
                         matches.extend(self.check_value(depends_on, path[:] + [index], resources))

--- a/src/cfnlint/rules/resources/DependsOnObsolete.py
+++ b/src/cfnlint/rules/resources/DependsOnObsolete.py
@@ -76,7 +76,6 @@ class DependsOnObsolete(CloudFormationLintRule):
             depends_ons = resource_values.get('DependsOn')
             if depends_ons:
                 path = ['Resources', resource_name, 'DependsOn']
-                self.logger.debug('Validating unneeded DependsOn for %s', resource_name)
                 if isinstance(depends_ons, list):
                     for index, depends_on in enumerate(depends_ons):
                         matches.extend(self.check_depends_on(cfn, resource_name, depends_on, path[:] + [index]))

--- a/src/cfnlint/rules/resources/UpdateReplacePolicy.py
+++ b/src/cfnlint/rules/resources/UpdateReplacePolicy.py
@@ -77,7 +77,6 @@ class UpdateReplacePolicy(CloudFormationLintRule):
             if updatereplace_policies:
                 path = ['Resources', resource_name, 'UpdateReplacePolicy']
                 res_type = resource_values.get('Type')
-                self.logger.debug('Validating UpdateReplacePolicy for %s base configuration', resource_name)
                 if isinstance(updatereplace_policies, list):
                     message = 'Only one UpdateReplacePolicy allowed per resource at {0}'
                     matches.append(RuleMatch(path, message.format('/'.join(map(str, path)))))

--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -106,7 +106,7 @@ class Transform(object):
             self._template = cfnlint.helpers.convert_dict(
                 sam_translator.translate(sam_template=self._template, parameter_values={}))
 
-            LOGGER.debug('Transformed template: %s', self._template)
+            LOGGER.debug('Transformed template: \n%s', cfnlint.helpers.format_json_string(self._template))
         except InvalidDocumentException as e:
             message = 'Error transforming template: {0}'
             for cause in e.causes:


### PR DESCRIPTION
_This is PR is open for discussion_

Change the strategy behind the `--debug` argument. The Debug flag has currently (mainly) been implemented as an extended logging of functions, rules and information. As a result the Debug argument returns in soo many output that it becomes "unusable".

This PR looks at the Debug argument from the "cfn-lint **user**" perspective. If I would run the linter, what would I expect from the debug?

From this I came to the following changes:

- Remove all debug from the helper functions and specific rules
- Make debug from the Config "smart" (Only output if there is data)
- Format JSON outputs generated by the Config and the Transformed template (So it's direct usable and readable)
- Print the full error on "suppressed" errors

_Still a WIP since I'm testing multiple templates for the debug output_