### PR TITLE
Exclude dynamic references from the allowed value/pattern rule

### DIFF
--- a/src/cfnlint/rules/resources/properties/AllowedPattern.py
+++ b/src/cfnlint/rules/resources/properties/AllowedPattern.py
@@ -48,11 +48,15 @@ class AllowedPattern(CloudFormationLintRule):
 
         if value_pattern_regex:
             regex = re.compile(value_pattern_regex)
-            if not regex.match(value):
-                full_path = ('/'.join(str(x) for x in path))
 
-                message = '{} contains invalid characters (Pattern: {}) at {}'
-                matches.append(RuleMatch(path, message.format(property_name, value_pattern, full_path)))
+            # Ignore values with dynamic references. Simple check to prevent false-positives
+            # See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html
+            if '{{resolve:' not in value:
+                if not regex.match(value):
+                    full_path = ('/'.join(str(x) for x in path))
+
+                    message = '{} contains invalid characters (Pattern: {}) at {}'
+                    matches.append(RuleMatch(path, message.format(property_name, value_pattern, full_path)))
 
         return matches
 

--- a/src/cfnlint/rules/resources/properties/AllowedValue.py
+++ b/src/cfnlint/rules/resources/properties/AllowedValue.py
@@ -42,10 +42,14 @@ class AllowedValue(CloudFormationLintRule):
         allowed_value_specs = kwargs.get('value_specs', {}).get('AllowedValues', {})
 
         if allowed_value_specs:
-            # Always compare the allowed value as a string, strict typing is not of concern for this rule
-            if str(value) not in allowed_value_specs:
-                message = 'You must specify a valid value for {0} ({1}).\nValid values are {2}'
-                matches.append(RuleMatch(path, message.format(property_name, value, allowed_value_specs)))
+
+            # Ignore values with dynamic references. Simple check to prevent false-positives
+            # See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/dynamic-references.html
+            if '{{resolve:' not in str(value):
+                # Always compare the allowed value as a string, strict typing is not of concern for this rule
+                if str(value) not in allowed_value_specs:
+                    message = 'You must specify a valid value for {0} ({1}).\nValid values are {2}'
+                    matches.append(RuleMatch(path, message.format(property_name, value, allowed_value_specs)))
 
         return matches
 

--- a/test/fixtures/templates/bad/properties_sg_ingress.yaml
+++ b/test/fixtures/templates/bad/properties_sg_ingress.yaml
@@ -47,6 +47,15 @@ Resources:
       -
         IpProtocol: 1
         SourceSecurityGroupId: vpc-1234567
+        CidrIp: '10.0.0.0/8'
+  SecurityGroupRuleSSM:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      GroupId: !Ref mySecurityGroupVpc
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      CidrIp: '{{resolve:ssm:mysubnet}}'
   mySecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -33,7 +33,7 @@ Parameters:
     Type: Number
 Resources:
   LogGroup:
-    Type: AWS::Logs::LogGroup
+    Type: "AWS::Logs::LogGroup"
     Properties:
       RetentionInDays: !Ref LogsRetentionLength
       LogGroupName: '/name'
@@ -60,6 +60,11 @@ Resources:
       EngineType: "ACTIVEMQ" # Valid AllowedValue
       EngineVersion: "5.15.8" # Valid AllowedValue
       Name: "Configuration"
+  ApiGatewayAuthorizerSSM:
+    Type: "AWS::ApiGateway::Authorizer"
+    Properties:
+      RestApiId: !Ref "ApiGatewayRestAPI"
+      Type: "{{resolve:ssm:myparam:1}} xyz" # Excluded AllowedValue
   ApiGatewayAuthorizer:
     Type: "AWS::ApiGateway::Authorizer"
     Properties:


### PR DESCRIPTION
*Issue https://github.com/aws-cloudformation/cfn-python-lint/issues/894, if available:*

Filter out Dynamic References "quick and simple" to prevent invalid errors when they're used.
A simple hotfix for now, this is the N'th place we're "solving" this, we need a more structural solution for this. 

**Note:** _Not used a regex for performance reasons: no need to compile a regex for  this. Left our logic about the `{{resolve:service-name:reference-key}}` format.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
