### PR TITLE
Require setuptools for runtime as it is needed for pkg_resource

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,8 @@ setup(
         'aws-sam-translator>=1.10.0',
         'jsonpatch',
         'jsonschema~=2.6',
-        'pathlib2>=2.3.0;python_version<"3.4"'
+        'pathlib2>=2.3.0;python_version<"3.4"',
+        'setuptools',
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     entry_points={


### PR DESCRIPTION
*Issue #, if available:*
Fix #880
*Description of changes:*
- Setuptools is a runtime requirement as it is needed for pkg_resources

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
