### PR TITLE
New rules for Lambda runtime EOL

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -44,7 +44,7 @@ To include these rules, use the `-e/include-experimental` argument when running 
 
 
 ## Rules
-The following **120** rules are applied by this linter:
+The following **121** rules are applied by this linter:
 
 | Rule ID  | Title | Description | Config<br />(Name:Type:Default) | Source | Tags |
 | -------- | ----- | ----------- | ---------- | ------ | ---- |
@@ -93,6 +93,7 @@ The following **120** rules are applied by this linter:
 | E2523<a name="E2523"></a> | Check Properties that need only one of a list of properties | Making sure CloudFormation properties that require only one property from a list. One has to be specified. |  | [Source](https://github.com/aws-cloudformation/cfn-python-lint) | `resources` |
 | E2529<a name="E2529"></a> | Check for duplicate Lambda events | Check if there are any duplicate log groups in the Lambda event trigger element. |  | [Source](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#user-content-cloudwatchlogs) | `resources`,`lambda` |
 | E2530<a name="E2530"></a> | Check Lambda Memory Size Properties | See if Lambda Memory Size is valid |  | [Source](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-MemorySize) | `resources`,`lambda` |
+| E2531<a name="E2531"></a> | Check if EOL Lambda Function Runtimes are used | Check if an EOL Lambda Runtime is specified and give a warning if used.  |  | [Source](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) | `resources`,`lambda`,`runtime` |
 | E2532<a name="E2532"></a> | Check State Machine Definition for proper syntax | Check the State Machine String Definition to make sure its JSON. Validate basic syntax of the file to determine validity. |  | [Source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-stepfunctions-statemachine.html) | `resources`,`stepfunctions` |
 | E2540<a name="E2540"></a> | CodePipeline Stages | See if CodePipeline stages are set correctly |  | [Source](https://docs.aws.amazon.com/codepipeline/latest/userguide/reference-pipeline-structure.html#pipeline-requirements) | `properties`,`codepipeline` |
 | E2541<a name="E2541"></a> | CodePipeline Stage Actions | See if CodePipeline stage actions are set correctly |  | [Source](https://docs.aws.amazon.com/codepipeline/latest/userguide/reference-pipeline-structure.html#pipeline-requirements) | `resources`,`codepipeline` |
@@ -162,7 +163,7 @@ The following **120** rules are applied by this linter:
 | W2509<a name="W2509"></a> | CIDR Parameters have allowed values | Check if a parameter is being used as a CIDR. If it is make sure it has allowed values regex comparisons |  | [Source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html) | `parameters`,`availabilityzone` |
 | W2510<a name="W2510"></a> | Parameter Memory Size attributes should have max and min | Check if a parameter that is used for Lambda memory size  should have a min and max size that matches Lambda constraints |  | [Source](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-MemorySize) | `parameters`,`lambda` |
 | W2511<a name="W2511"></a> | Check IAM Resource Policies syntax | See if the elements inside an IAM Resource policy are configured correctly. |  | [Source](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html) | `properties`,`iam` |
-| W2530<a name="W2530"></a> | Check if EOL Lambda Function Runtimes are used | Check if an EOL Lambda Runtime is specified and give a warning if used.  | check_eol_date:boolean:False | [Source](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) | `resources`,`lambda`,`runtime` |
+| W2531<a name="W2531"></a> | Check if EOL Lambda Function Runtimes are used | Check if an EOL Lambda Runtime is specified and give a warning if used.  |  | [Source](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) | `resources`,`lambda`,`runtime` |
 | W3002<a name="W3002"></a> | Warn when properties are configured to only work with the package command | Some properties can be configured to only work with the CloudFormationpackage command. Warn when this is the case so user is aware. |  | [Source](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/package.html) | `resources` |
 | W3005<a name="W3005"></a> | Check obsolete DependsOn configuration for Resources | Check if DependsOn is specified if not needed. A Ref or a Fn::GetAtt already is an implicit dependency. |  | [Source](https://aws.amazon.com/blogs/devops/optimize-aws-cloudformation-templates/) | `resources`,`dependson` |
 | W3010<a name="W3010"></a> | Availability Zone Parameters should not be hardcoded | Check if an Availability Zone property is hardcoded. |  | [Source](https://github.com/aws-cloudformation/cfn-python-lint) | `parameters`,`availabilityzone` |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -44,7 +44,7 @@ To include these rules, use the `-e/include-experimental` argument when running 
 
 
 ## Rules
-The following **118** rules are applied by this linter:
+The following **120** rules are applied by this linter:
 
 | Rule ID  | Title | Description | Config<br />(Name:Type:Default) | Source | Tags |
 | -------- | ----- | ----------- | ---------- | ------ | ---- |
@@ -123,6 +123,7 @@ The following **118** rules are applied by this linter:
 | E3035<a name="E3035"></a> | Check DeletionPolicy values for Resources | Check that the DeletionPolicy values are valid |  | [Source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) | `resources`,`deletionpolicy` |
 | E3036<a name="E3036"></a> | Check UpdateReplacePolicy values for Resources | Check that the UpdateReplacePolicy values are valid |  | [Source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html) | `resources`,`updatereplacepolicy` |
 | E3037<a name="E3037"></a> | Check if a list has duplicate values | Certain lists don't support duplicate items. Check when duplicates are provided but not supported. |  | [Source](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/docs/cfn-resource-specification.md#allowedvalue) | `resources`,`property`,`list` |
+| E3038<a name="E3038"></a> | Check if Serverless Resources have Serverless Transform | Check that a template with Serverless Resources also includes the Serverless Transform |  | [Source](https://github.com/aws-cloudformation/cfn-python-lint) | `resources`,`transform` |
 | E3050<a name="E3050"></a> | Check if REFing to a IAM resource with path set | Some resources don't support looking up the IAM resource by name. This check validates when a REF is being used and the Path is not '/' |  | [Source](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html) | `properties`,`iam` |
 | E3502<a name="E3502"></a> | Check if a JSON Object is within size limits | Validate properties that are JSON values so that their length is within the limits |  | [Source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html) | `resources`,`limits`,`json` |
 | E4001<a name="E4001"></a> | Metadata Interface have appropriate properties | Metadata Interface properties are properly configured |  | [Source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-interface.html) | `metadata` |
@@ -161,6 +162,7 @@ The following **118** rules are applied by this linter:
 | W2509<a name="W2509"></a> | CIDR Parameters have allowed values | Check if a parameter is being used as a CIDR. If it is make sure it has allowed values regex comparisons |  | [Source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html) | `parameters`,`availabilityzone` |
 | W2510<a name="W2510"></a> | Parameter Memory Size attributes should have max and min | Check if a parameter that is used for Lambda memory size  should have a min and max size that matches Lambda constraints |  | [Source](https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html#SSS-CreateFunction-request-MemorySize) | `parameters`,`lambda` |
 | W2511<a name="W2511"></a> | Check IAM Resource Policies syntax | See if the elements inside an IAM Resource policy are configured correctly. |  | [Source](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html) | `properties`,`iam` |
+| W2530<a name="W2530"></a> | Check if EOL Lambda Function Runtimes are used | Check if an EOL Lambda Runtime is specified and give a warning if used.  | check_eol_date:boolean:False | [Source](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) | `resources`,`lambda`,`runtime` |
 | W3002<a name="W3002"></a> | Warn when properties are configured to only work with the package command | Some properties can be configured to only work with the CloudFormationpackage command. Warn when this is the case so user is aware. |  | [Source](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/package.html) | `resources` |
 | W3005<a name="W3005"></a> | Check obsolete DependsOn configuration for Resources | Check if DependsOn is specified if not needed. A Ref or a Fn::GetAtt already is an implicit dependency. |  | [Source](https://aws.amazon.com/blogs/devops/optimize-aws-cloudformation-templates/) | `resources`,`dependson` |
 | W3010<a name="W3010"></a> | Availability Zone Parameters should not be hardcoded | Check if an Availability Zone property is hardcoded. |  | [Source](https://github.com/aws-cloudformation/cfn-python-lint) | `parameters`,`availabilityzone` |

--- a/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
+++ b/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
@@ -1,0 +1,22 @@
+{
+    "dotnetcore2.0": {
+        "eol": "2019-04-30",
+        "deprecated": "2019-05-30",
+        "successor": "dotnetcore2.0"
+    },
+    "nodejs": {
+        "eol": "2016-10-31",
+        "deprecated": "2016-10-31",
+        "successor": "nodejs10.x"
+    },
+    "nodejs4.3": {
+        "eol": "2018-04-30",
+        "deprecated": "2019-04-30",
+        "successor": "nodejs10.x"
+    },
+    "nodejs6.10": {
+        "eol": "2019-04-30",
+        "deprecated": "2019-06-30",
+        "successor": "nodejs10.x"
+    }
+}

--- a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntime.py
+++ b/src/cfnlint/rules/resources/lmbd/DeprecatedRuntime.py
@@ -32,7 +32,7 @@ class DeprecatedRuntime(CloudFormationLintRule):
         super(DeprecatedRuntime, self).__init__()
         self.config_definition = {
             'check_eol_date': {
-                'default': True,
+                'default': False,
                 'type': 'boolean'
             }
         }

--- a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntime.py
+++ b/src/cfnlint/rules/resources/lmbd/DeprecatedRuntime.py
@@ -1,0 +1,135 @@
+"""
+  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from datetime import datetime
+from cfnlint import CloudFormationLintRule
+from cfnlint import RuleMatch
+
+
+class DeprecatedRuntime(CloudFormationLintRule):
+    """Check if EOL Lambda Function Runtimes are used"""
+    id = 'W2530'
+    shortdesc = 'Check if EOL Lambda Function Runtimes are used'
+    description = 'Check if an EOL Lambda Runtime is specified and give a warning if used. '
+    source_url = 'https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html'
+    tags = ['resources', 'lambda', 'runtime']
+
+    def __init__(self):
+        """Init"""
+        super(DeprecatedRuntime, self).__init__()
+        self.config_definition = {
+            'check_eol_date': {
+                'default': True,
+                'type': 'boolean'
+            }
+        }
+        self.configure()
+
+    current_date = datetime.today()
+
+    deprecated_runtimes = {
+        'dotnetcore2.0': {
+            'eol': '2019-04-30',
+            'deprecated': '2019-05-30',
+            'successor': 'dotnetcore2.0'
+        },
+        'nodejs': {
+            'eol': '2016-10-31',
+            'deprecated': '2016-10-31',
+            'successor': 'nodejs10.x'
+        },
+        'nodejs4.3': {
+            'eol': '2018-04-30',
+            'deprecated': '2019-04-30',
+            'successor': 'nodejs10.x'
+        },
+        'nodejs6.10': {
+            'eol': '2019-04-30',
+            'deprecated': '2019-06-30',
+            'successor': 'nodejs10.x'
+        }
+    }
+
+    def check_runtime(self, runtime_value, path):
+        """ Check if the given runtime is valid"""
+        matches = []
+
+        runtime = self.deprecated_runtimes.get(runtime_value)
+        if runtime:
+            if datetime.strptime(runtime['deprecated'], '%Y-%m-%d') < self.current_date:
+                message = 'Deprecated runtime ({0}) specified. Updating disabled since {1}, please consider to update to {2}'
+                matches.append(
+                    RuleMatch(
+                        path,
+                        message.format(
+                            runtime_value,
+                            runtime['deprecated'],
+                            runtime['successor'])))
+
+            elif self.config['check_eol_date']:
+                if datetime.strptime(runtime['eol'], '%Y-%m-%d') < self.current_date:
+                    message = 'EOL runtime ({0}) specified. Runtime is EOL since {1} and updating will be disabled at {2}, please consider to update to {3}'
+                    matches.append(
+                        RuleMatch(
+                            path,
+                            message.format(
+                                runtime_value,
+                                runtime['eol'],
+                                runtime['deprecated'],
+                                runtime['successor'])))
+        return matches
+
+
+    def check_value(self, value, path):
+        """Check Lambda Runtime value """
+        matches = []
+        matches.extend(self.check_runtime(value, path))
+        return matches
+
+    def check_ref(self, value, path, parameters, resources): # pylint: disable=W0613
+        """Check Lambda Runtime Ref value """
+
+        matches = []
+        if value in parameters:
+            parameter = parameters.get(value, {})
+            param_path = ['Parameters', value]
+
+            # Validate the Default
+            default_value = parameter.get('Default', '')
+            matches.extend(self.check_runtime(default_value, param_path + ['Default']))
+
+            # Validate AllowedValues
+            allowed_values = parameter.get('AllowedValues')
+            if isinstance(allowed_values, list):
+                param_path = param_path + ['AllowedValues']
+                for index, allowed_value in enumerate(allowed_values):
+                    matches.extend(self.check_runtime(allowed_value, param_path + [index]))
+
+        return matches
+
+    def match(self, cfn):
+        """Check if EOL Lambda Function Runtimes are used"""
+
+        matches = []
+        matches.extend(
+            cfn.check_resource_property(
+                'AWS::Lambda::Function', 'Runtime',
+                check_value=self.check_value,
+                check_ref=self.check_ref,
+            )
+        )
+
+        return matches

--- a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEnd.py
+++ b/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEnd.py
@@ -1,0 +1,45 @@
+"""
+  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from datetime import datetime
+from cfnlint.rules.resources.lmbd.DeprecatedRuntime import DeprecatedRuntime
+from cfnlint import RuleMatch
+
+
+class DeprecatedRuntimeEnd(DeprecatedRuntime):
+    """Check if EOL Lambda Function Runtimes are used"""
+    id = 'E2531'
+    shortdesc = 'Check if EOL Lambda Function Runtimes are used'
+    description = 'Check if an EOL Lambda Runtime is specified and give a warning if used. '
+    source_url = 'https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html'
+    tags = ['resources', 'lambda', 'runtime']
+
+    def check_runtime(self, runtime_value, path):
+        """ Check if the given runtime is valid"""
+        matches = []
+
+        runtime = self.deprecated_runtimes.get(runtime_value)
+        if runtime:
+            if datetime.strptime(runtime['deprecated'], '%Y-%m-%d') < self.current_date:
+                message = 'Deprecated runtime ({0}) specified. Updating disabled since {1}, please consider to update to {2}'
+                matches.append(
+                    RuleMatch(
+                        path,
+                        message.format(
+                            runtime_value,
+                            runtime['deprecated'],
+                            runtime['successor'])))
+        return matches

--- a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEol.py
+++ b/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEol.py
@@ -1,0 +1,46 @@
+"""
+  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from datetime import datetime
+from cfnlint.rules.resources.lmbd.DeprecatedRuntime import DeprecatedRuntime
+from cfnlint import RuleMatch
+
+
+class DeprecatedRuntimeEol(DeprecatedRuntime):
+    """Check if EOL Lambda Function Runtimes are used"""
+    id = 'W2531'
+    shortdesc = 'Check if EOL Lambda Function Runtimes are used'
+    description = 'Check if an EOL Lambda Runtime is specified and give a warning if used. '
+    source_url = 'https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html'
+    tags = ['resources', 'lambda', 'runtime']
+
+    def check_runtime(self, runtime_value, path):
+        """ Check if the given runtime is valid"""
+        matches = []
+
+        runtime = self.deprecated_runtimes.get(runtime_value)
+        if runtime:
+            if datetime.strptime(runtime['eol'], '%Y-%m-%d') < self.current_date and datetime.strptime(runtime['deprecated'], '%Y-%m-%d') > self.current_date:
+                message = 'EOL runtime ({0}) specified. Runtime is EOL since {1} and updating will be disabled at {2}, please consider to update to {3}'
+                matches.append(
+                    RuleMatch(
+                        path,
+                        message.format(
+                            runtime_value,
+                            runtime['eol'],
+                            runtime['deprecated'],
+                            runtime['successor'])))
+        return matches

--- a/test/fixtures/results/public/lambda-poller.json
+++ b/test/fixtures/results/public/lambda-poller.json
@@ -1,0 +1,29 @@
+[
+    {
+        "Filename": "test/fixtures/templates/public/lambda-poller.yaml",
+        "Level": "Warning",
+        "Location": {
+            "End": {
+                "ColumnNumber": 14,
+                "LineNumber": 151
+            },
+            "Path": [
+                "Resources",
+                "PollerFunction",
+                "Properties",
+                "Runtime"
+            ],
+            "Start": {
+                "ColumnNumber": 7,
+                "LineNumber": 151
+            }
+        },
+        "Message": "EOL runtime (nodejs6.10) specified. Runtime is EOL since 2019-04-30 and updating will be disabled at 2019-06-30, please consider to update to nodejs10.x",
+        "Rule": {
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2531",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
+        }
+    }
+]

--- a/test/fixtures/results/quickstart/nist_config_rules.json
+++ b/test/fixtures/results/quickstart/nist_config_rules.json
@@ -1,16 +1,8 @@
 [
     {
-        "Rule": {
-            "Id": "W3005",
-            "Description": "Check if DependsOn is specified if not needed. A Ref or a Fn::GetAtt already is an implicit dependency.",
-            "ShortDescription": "Check obsolete DependsOn configuration for Resources",
-            "Source": "https://aws.amazon.com/blogs/devops/optimize-aws-cloudformation-templates/"
-        },
+        "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml",
+        "Level": "Warning",
         "Location": {
-            "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 35
-            },
             "End": {
                 "ColumnNumber": 14,
                 "LineNumber": 35
@@ -19,24 +11,51 @@
                 "Resources",
                 "rAMIComplianceFunction",
                 "DependsOn"
-            ]
+            ],
+            "Start": {
+                "ColumnNumber": 5,
+                "LineNumber": 35
+            }
         },
-        "Level": "Warning",
         "Message": "Obsolete DependsOn on resource (rConfigRulesLambdaRole), dependency already enforced by a \"Fn:GetAtt\" at Resources/rAMIComplianceFunction/Properties/Role/Fn::GetAtt/['rConfigRulesLambdaRole', 'Arn']",
-        "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml"
+        "Rule": {
+            "Description": "Check if DependsOn is specified if not needed. A Ref or a Fn::GetAtt already is an implicit dependency.",
+            "Id": "W3005",
+            "ShortDescription": "Check obsolete DependsOn configuration for Resources",
+            "Source": "https://aws.amazon.com/blogs/devops/optimize-aws-cloudformation-templates/"
+        }
     },
     {
-        "Rule": {
-            "Id": "E3012",
-            "Description": "Checks resource property values with Primitive Types for values that match those types.",
-            "ShortDescription": "Check resource properties values",
-            "Source": "https://github.com/aws-cloudformation/cfn-python-lint"
-        },
+        "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml",
+        "Level": "Warning",
         "Location": {
+            "End": {
+                "ColumnNumber": 14,
+                "LineNumber": 94
+            },
+            "Path": [
+                "Resources",
+                "rAMIComplianceFunction",
+                "Properties",
+                "Runtime"
+            ],
             "Start": {
                 "ColumnNumber": 7,
-                "LineNumber": 95
-            },
+                "LineNumber": 94
+            }
+        },
+        "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31, please consider to update to nodejs10.x",
+        "Rule": {
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2530",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml",
+        "Level": "Error",
+        "Location": {
             "End": {
                 "ColumnNumber": 14,
                 "LineNumber": 95
@@ -46,24 +65,24 @@
                 "rAMIComplianceFunction",
                 "Properties",
                 "Timeout"
-            ]
+            ],
+            "Start": {
+                "ColumnNumber": 7,
+                "LineNumber": 95
+            }
         },
-        "Level": "Error",
         "Message": "Property Resources/rAMIComplianceFunction/Properties/Timeout should be of type Integer",
-        "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml"
+        "Rule": {
+            "Description": "Checks resource property values with Primitive Types for values that match those types.",
+            "Id": "E3012",
+            "ShortDescription": "Check resource properties values",
+            "Source": "https://github.com/aws-cloudformation/cfn-python-lint/blob/master/docs/cfn-resource-specification.md#valueprimitivetype"
+        }
     },
     {
-        "Rule": {
-            "Id": "W3005",
-            "Description": "Check if DependsOn is specified if not needed. A Ref or a Fn::GetAtt already is an implicit dependency.",
-            "ShortDescription": "Check obsolete DependsOn configuration for Resources",
-            "Source": "https://aws.amazon.com/blogs/devops/optimize-aws-cloudformation-templates/"
-        },
+        "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml",
+        "Level": "Warning",
         "Location": {
-            "Start": {
-                "ColumnNumber": 5,
-                "LineNumber": 98
-            },
             "End": {
                 "ColumnNumber": 14,
                 "LineNumber": 98
@@ -72,24 +91,51 @@
                 "Resources",
                 "rCloudTrailValidationFunction",
                 "DependsOn"
-            ]
+            ],
+            "Start": {
+                "ColumnNumber": 5,
+                "LineNumber": 98
+            }
         },
-        "Level": "Warning",
         "Message": "Obsolete DependsOn on resource (rConfigRulesLambdaRole), dependency already enforced by a \"Fn:GetAtt\" at Resources/rCloudTrailValidationFunction/Properties/Role/Fn::GetAtt/['rConfigRulesLambdaRole', 'Arn']",
-        "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml"
+        "Rule": {
+            "Description": "Check if DependsOn is specified if not needed. A Ref or a Fn::GetAtt already is an implicit dependency.",
+            "Id": "W3005",
+            "ShortDescription": "Check obsolete DependsOn configuration for Resources",
+            "Source": "https://aws.amazon.com/blogs/devops/optimize-aws-cloudformation-templates/"
+        }
     },
     {
-        "Rule": {
-            "Id": "E3012",
-            "Description": "Checks resource property values with Primitive Types for values that match those types.",
-            "ShortDescription": "Check resource properties values",
-            "Source": "https://github.com/aws-cloudformation/cfn-python-lint"
-        },
+        "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml",
+        "Level": "Warning",
         "Location": {
+            "End": {
+                "ColumnNumber": 14,
+                "LineNumber": 159
+            },
+            "Path": [
+                "Resources",
+                "rCloudTrailValidationFunction",
+                "Properties",
+                "Runtime"
+            ],
             "Start": {
                 "ColumnNumber": 7,
-                "LineNumber": 160
-            },
+                "LineNumber": 159
+            }
+        },
+        "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31, please consider to update to nodejs10.x",
+        "Rule": {
+            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Id": "W2530",
+            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
+        }
+    },
+    {
+        "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml",
+        "Level": "Error",
+        "Location": {
             "End": {
                 "ColumnNumber": 14,
                 "LineNumber": 160
@@ -99,10 +145,18 @@
                 "rCloudTrailValidationFunction",
                 "Properties",
                 "Timeout"
-            ]
+            ],
+            "Start": {
+                "ColumnNumber": 7,
+                "LineNumber": 160
+            }
         },
-        "Level": "Error",
         "Message": "Property Resources/rCloudTrailValidationFunction/Properties/Timeout should be of type Integer",
-        "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml"
+        "Rule": {
+            "Description": "Checks resource property values with Primitive Types for values that match those types.",
+            "Id": "E3012",
+            "ShortDescription": "Check resource properties values",
+            "Source": "https://github.com/aws-cloudformation/cfn-python-lint/blob/master/docs/cfn-resource-specification.md#valueprimitivetype"
+        }
     }
 ]

--- a/test/fixtures/results/quickstart/nist_config_rules.json
+++ b/test/fixtures/results/quickstart/nist_config_rules.json
@@ -27,7 +27,7 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml",
-        "Level": "Warning",
+        "Level": "Error",
         "Location": {
             "End": {
                 "ColumnNumber": 14,
@@ -47,7 +47,7 @@
         "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31, please consider to update to nodejs10.x",
         "Rule": {
             "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
-            "Id": "W2530",
+            "Id": "E2531",
             "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }
@@ -107,7 +107,7 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml",
-        "Level": "Warning",
+        "Level": "Error",
         "Location": {
             "End": {
                 "ColumnNumber": 14,
@@ -127,7 +127,7 @@
         "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31, please consider to update to nodejs10.x",
         "Rule": {
             "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
-            "Id": "W2530",
+            "Id": "E2531",
             "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
         }

--- a/test/fixtures/templates/bad/resources/lambda/runtimes.yaml
+++ b/test/fixtures/templates/bad/resources/lambda/runtimes.yaml
@@ -10,6 +10,7 @@ Parameters:
     AllowedValues:
       - nodejs10.x
       - nodejs
+      - nodejs6.10
 Resources:
   myLambdaExecutionRole:
     Type: AWS::IAM::Role
@@ -42,6 +43,17 @@ Resources:
         S3Bucket: "lambda-functions"
         S3Key: "amilookup.zip"
       Runtime: "nodejs4.3"
+      Timeout: 25
+      MemorySize: 1536
+  myLambdaNodeFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: "index.handler"
+      Role: !GetAtt myLambdaExecutionRole.Arn
+      Code:
+        S3Bucket: "lambda-functions"
+        S3Key: "amilookup.zip"
+      Runtime: "nodejs6.10"
       Timeout: 25
       MemorySize: 1536
   myLambdaTwo:

--- a/test/fixtures/templates/bad/resources/lambda/runtimes.yaml
+++ b/test/fixtures/templates/bad/resources/lambda/runtimes.yaml
@@ -1,0 +1,55 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Bad Lambda Template
+Parameters:
+  myParameterRuntime:
+    Type: String
+    Description: Runtime
+    Default: nodejs
+    AllowedValues:
+      - nodejs10.x
+      - nodejs
+Resources:
+  myLambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: "/"
+      Policies:
+      - PolicyName: root
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - logs:*
+            Resource: arn:aws:logs:*:*:*
+  myLambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: "index.handler"
+      Role: !GetAtt myLambdaExecutionRole.Arn
+      Code:
+        S3Bucket: "lambda-functions"
+        S3Key: "amilookup.zip"
+      Runtime: "nodejs4.3"
+      Timeout: 25
+      MemorySize: 1536
+  myLambdaTwo:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.handler
+      Role: !GetAtt myLambdaExecutionRole.Arn
+      Code:
+        ZipFile: "amilookup.zip"
+      Runtime: !Ref myParameterRuntime
+      MemorySize: 512

--- a/test/fixtures/templates/good/transform.yaml
+++ b/test/fixtures/templates/good/transform.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       CodeUri: 's3://testBucket/mySourceCode.zip'
   ExampleLayer:
     Type: AWS::Serverless::LayerVersion

--- a/test/fixtures/templates/good/transform_serverless_api.yaml
+++ b/test/fixtures/templates/good/transform_serverless_api.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       CodeUri: 's3://testBucket/mySourceCode.zip'
       AutoPublishAlias: live
       DeploymentPreference:

--- a/test/fixtures/templates/good/transform_serverless_function.yaml
+++ b/test/fixtures/templates/good/transform_serverless_function.yaml
@@ -10,7 +10,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       CodeUri: 's3://testBucket/mySourceCode.zip'
       AutoPublishAlias: live
       DeploymentPreference:

--- a/test/integration/test_good_templates.py
+++ b/test/integration/test_good_templates.py
@@ -64,7 +64,7 @@ class TestQuickStartTemplates(BaseTestCase):
             },
             'transform_serverless_globals': {
                 'filename': 'test/fixtures/templates/good/transform_serverless_globals.yaml',
-                'failures': 0
+                'failures': 1
             }
         }
 

--- a/test/integration/test_quickstart_templates.py
+++ b/test/integration/test_quickstart_templates.py
@@ -32,8 +32,8 @@ class TestQuickStartTemplates(BaseTestCase):
 
         self.filenames = {
             'config_rule': {
-                "filename": 'test/fixtures/templates/public/lambda-poller.yaml',
-                "failures": 0
+                'filename': 'test/fixtures/templates/public/lambda-poller.yaml',
+                'results_filename': 'test/fixtures/results/public/lambda-poller.json'
             },
             'watchmaker': {
                 "filename": 'test/fixtures/templates/public/watchmaker.json',

--- a/test/module/cfn_json/test_cfn_json.py
+++ b/test/module/cfn_json/test_cfn_json.py
@@ -55,7 +55,7 @@ class TestCfnJson(BaseTestCase):
             },
             "poller": {
                 "filename": 'test/fixtures/templates/public/lambda-poller.json',
-                "failures": 0
+                "failures": 1
             }
         }
 
@@ -97,7 +97,7 @@ class TestCfnJson(BaseTestCase):
 
                 matches = []
                 matches.extend(self.rules.run(filename, cfn))
-                assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)
+                assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), values.get('filename'))
 
     def test_fail_run(self):
         """Test failure run"""

--- a/test/module/cfn_json/test_cfn_json.py
+++ b/test/module/cfn_json/test_cfn_json.py
@@ -35,7 +35,7 @@ class TestCfnJson(BaseTestCase):
         self.filenames = {
             "config_rule": {
                 "filename": 'test/fixtures/templates/quickstart/config-rules.json',
-                "failures": 4
+                "failures": 6
             },
             "iam": {
                 "filename": 'test/fixtures/templates/quickstart/iam.json',

--- a/test/module/cfn_yaml/test_yaml.py
+++ b/test/module/cfn_yaml/test_yaml.py
@@ -34,7 +34,7 @@ class TestYamlParse(BaseTestCase):
         self.filenames = {
             "config_rule": {
                 "filename": 'test/fixtures/templates/public/lambda-poller.yaml',
-                "failures": 0
+                "failures": 1
             },
             "generic_bad": {
                 "filename": 'test/fixtures/templates/bad/generic.yaml',

--- a/test/rules/resources/lmbd/test_deprecated_runtime.py
+++ b/test/rules/resources/lmbd/test_deprecated_runtime.py
@@ -1,0 +1,34 @@
+"""
+  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.resources.lmbd.DeprecatedRuntime import DeprecatedRuntime  # pylint: disable=E0401
+from ... import BaseRuleTestCase
+
+
+class TestDeprecatedRuntime(BaseRuleTestCase):
+    """Test Lambda Deprecated Runtime usage"""
+    def setUp(self):
+        """Setup"""
+        super(TestDeprecatedRuntime, self).setUp()
+        self.collection.register(DeprecatedRuntime())
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('test/fixtures/templates/bad/resources/lambda/runtimes.yaml', 3)

--- a/test/rules/resources/lmbd/test_deprecated_runtime_end.py
+++ b/test/rules/resources/lmbd/test_deprecated_runtime_end.py
@@ -14,16 +14,16 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint.rules.resources.lmbd.DeprecatedRuntime import DeprecatedRuntime  # pylint: disable=E0401
+from cfnlint.rules.resources.lmbd.DeprecatedRuntimeEnd import DeprecatedRuntimeEnd  # pylint: disable=E0401
 from ... import BaseRuleTestCase
 
 
-class TestDeprecatedRuntime(BaseRuleTestCase):
+class TestDeprecatedRuntimeEnd(BaseRuleTestCase):
     """Test Lambda Deprecated Runtime usage"""
     def setUp(self):
         """Setup"""
-        super(TestDeprecatedRuntime, self).setUp()
-        self.collection.register(DeprecatedRuntime())
+        super(TestDeprecatedRuntimeEnd, self).setUp()
+        self.collection.register(DeprecatedRuntimeEnd())
 
     def test_file_positive(self):
         """Test Positive"""

--- a/test/rules/resources/lmbd/test_deprecated_runtime_eol.py
+++ b/test/rules/resources/lmbd/test_deprecated_runtime_eol.py
@@ -1,0 +1,34 @@
+"""
+  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from cfnlint.rules.resources.lmbd.DeprecatedRuntimeEol import DeprecatedRuntimeEol  # pylint: disable=E0401
+from ... import BaseRuleTestCase
+
+
+class TestDeprecatedRuntimeEol(BaseRuleTestCase):
+    """Test Lambda Deprecated Runtime usage"""
+    def setUp(self):
+        """Setup"""
+        super(TestDeprecatedRuntimeEol, self).setUp()
+        self.collection.register(DeprecatedRuntimeEol())
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('test/fixtures/templates/bad/resources/lambda/runtimes.yaml', 2)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- New rule E2531 to check if a lambda runtime is deprecated
- New rule W2531 to check if a lambda runtime is EOL

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
