### PR TITLE
Introduce new LogLevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ Optional parameters:
 | -e, --include-experimental | include_experimental | | Whether rules that still in an experimental state should be included in the checks |
 | -c, --include-checks | INCLUDE_CHECKS [INCLUDE_CHECKS ...] | Include rules whose id match these values
 | -x,  --configure-rule | CONFIGURE_RULES [CONFIGURE_RULES ...] | Provide configuration for a rule. Format RuleId:key=value. Example: E3012:strict=false                    
-  -v, --version         Version of cfn-lint
-| -d, --debug |  |  | Specify to enable debug logging |
+| -D, --debug |  |  | Specify to enable debug logging. Debug logging outputs detailed information about rules processing, useful for debugging rules. |
+| -I, --info |  |  | Specify to enable information logging. Information logging outputs informational information about the template processing. |
 | -u, --update-specs | | | Update the CloudFormation Specs.  You may need sudo to run this.  You will need internet access when running this command |
 | -o, --override-spec | | filename | Spec-style file containing custom definitions. Can be used to override CloudFormation specifications. More info [here](#customize-specifications) |
 | -v, --version | | | Version of cfn-lint |

--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -33,15 +33,17 @@ except ImportError:  # pragma: no cover
 LOGGER = logging.getLogger('cfnlint')
 
 
-def configure_logging(debug_logging):
+def configure_logging(debug_logging, info_logging):
     """Setup Logging"""
     ch = logging.StreamHandler()
     ch.setLevel(logging.DEBUG)
 
     if debug_logging:
         LOGGER.setLevel(logging.DEBUG)
-    else:
+    elif info_logging:
         LOGGER.setLevel(logging.INFO)
+    else:
+        LOGGER.setLevel(logging.NOTSET)
     log_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     ch.setFormatter(log_formatter)
 
@@ -324,7 +326,10 @@ class CliArgs(object):
             help='Ignore templates', nargs='+', default=[], action='extend'
         )
         advanced.add_argument(
-            '-d', '--debug', help='Enable debug logging', action='store_true'
+            '-D', '--debug', help='Enable debug logging', action='store_true'
+        )
+        advanced.add_argument(
+            '-I', '--info', help='Enable information logging', action='store_true'
         )
         standard.add_argument(
             '-f', '--format', help='Output Format', choices=['quiet', 'parseable', 'json']
@@ -440,7 +445,7 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs, object):
     def __init__(self, cli_args):
         CliArgs.__init__(self, cli_args)
         # configure debug as soon as we can
-        configure_logging(self.cli_args.debug)
+        configure_logging(self.cli_args.debug, self.cli_args.info)
         ConfigFileArgs.__init__(self)
         TemplateArgs.__init__(self, {})
 

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -100,8 +100,8 @@ def get_rules(rulesdir, ignore_rules, include_rules, configure_rules=None, inclu
 
 def configure_logging(debug_logging):
     """ Backwards compatibility for integrators """
-    LOGGER.debug('Update your integrations to use "cfnlint.config.configure_logging" instead')
-    cfnlint.config.configure_logging(debug_logging)
+    LOGGER.info('Update your integrations to use "cfnlint.config.configure_logging" instead')
+    cfnlint.config.configure_logging(debug_logging, False)
 
 
 def get_args_filenames(cli_args):

--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -225,6 +225,10 @@ def initialize_specs():
 initialize_specs()
 
 
+def format_json_string(json_string):
+    """ Format the given JSON string"""
+    return json.dumps(json_string, indent=2, sort_keys=True, separators=(',', ': '))
+
 def load_plugins(directory):
     """Load plugins"""
     result = []

--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -91,7 +91,7 @@ class Transform(object):
 
         try:
             # Output the SAM Translator version in debug mode
-            LOGGER.debug('SAM Translator: %s', samtranslator.__version__)
+            LOGGER.info('SAM Translator: %s', samtranslator.__version__)
 
             sam_translator = Translator(managed_policy_map=self._managed_policy_map,
                                         sam_parser=self._sam_parser)
@@ -100,13 +100,13 @@ class Transform(object):
 
             # Tell SAM to use the region we're linting in, this has to be controlled using the default AWS mechanisms, see also:
             # https://github.com/awslabs/serverless-application-model/blob/master/samtranslator/translator/arn_generator.py
-            LOGGER.debug('Setting AWS_DEFAULT_REGION to %s', self._region)
+            LOGGER.info('Setting AWS_DEFAULT_REGION to %s', self._region)
             os.environ['AWS_DEFAULT_REGION'] = self._region
 
             self._template = cfnlint.helpers.convert_dict(
                 sam_translator.translate(sam_template=self._template, parameter_values={}))
 
-            LOGGER.debug('Transformed template: %s', self._template)
+            LOGGER.info('Transformed template: \n%s', cfnlint.helpers.format_json_string(self._template))
         except InvalidDocumentException as e:
             message = 'Error transforming template: {0}'
             for cause in e.causes:

--- a/test/module/config/test_logging.py
+++ b/test/module/config/test_logging.py
@@ -31,13 +31,20 @@ class TestLogging(BaseTestCase):
     def test_logging_info(self):
         """Test success run"""
 
-        cfnlint.config.configure_logging(False)
+        cfnlint.config.configure_logging(False, True)
         self.assertEqual(logging.INFO, LOGGER.level)
         self.assertEqual(len(LOGGER.handlers), 1)
 
     def test_logging_debug(self):
         """Test debug level"""
 
-        cfnlint.config.configure_logging(True)
+        cfnlint.config.configure_logging(True, False)
         self.assertEqual(logging.DEBUG, LOGGER.level)
+        self.assertEqual(len(LOGGER.handlers), 1)
+
+    def test_no_logging(self):
+        """Test no logging level"""
+
+        cfnlint.config.configure_logging(False, False)
+        self.assertEqual(logging.NOTSET, LOGGER.level)
         self.assertEqual(len(LOGGER.handlers), 1)


### PR DESCRIPTION
Split logging into 2 loglevels:

* **--debug**: Detailed debug information from a "developing on the linter" POV
* **--info**: Information from a "using the linter" POV

Default loglevel of the linter is now moved to "NOTSET", elevated the loglevel of the SAM transformation to `--info`