### PR TITLE
AWS CDK template support

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -13692,6 +13692,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -24499,6 +24499,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -21892,6 +21892,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -12664,6 +12664,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -19586,6 +19586,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -21576,6 +21576,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -23718,6 +23718,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -18418,6 +18418,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -23570,6 +23570,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -14447,6 +14447,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -25286,6 +25286,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -20200,6 +20200,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -16684,6 +16684,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -16740,6 +16740,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -25286,6 +25286,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -22662,6 +22662,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -13088,6 +13088,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -13842,6 +13842,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -18841,6 +18841,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -25269,6 +25269,16 @@
         }
       }
     },
+    "AWS::CDK::Metadata": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    },
     "AWS::CertificateManager::Certificate": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html",
       "Properties": {

--- a/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
@@ -291,5 +291,19 @@
         }
       }
     }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::CDK::Metadata",
+    "value": {
+      "Documentation": "https://docs.aws.amazon.com/cdk/latest/guide/tools.html",
+      "Properties": {
+        "Modules": {
+          "PrimitiveType": "String",
+          "Required": true,
+          "UpdateType": "Immutable"
+        }
+      }
+    }
   }
 ]


### PR DESCRIPTION
When AWS CDK synthesizes a CloudFormation template, it places a custom type in the resources section called `AWS::CDK::Metadata` which the linter flags a E3001 about. 

Reference: https://docs.aws.amazon.com/cdk/latest/guide/tools.html
> The AWS::CDK::Metadata resource looks like the following.
```CDKMetadata:
  Type: "AWS::CDK::Metadata"
  Properties:
    Modules: "@aws-cdk/core=0.7.2-beta,@aws-cdk/s3=0.7.2-beta,lodash=4.17.10"```

This PR adds support for it in the custom handling section as well as adding a spec for it. 