### PR TITLE
Convert datetime to string when dumping transformed templates

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -19,6 +19,7 @@ import fnmatch
 import json
 import os
 import imp
+import datetime
 import logging
 import re
 import inspect
@@ -227,7 +228,11 @@ initialize_specs()
 
 def format_json_string(json_string):
     """ Format the given JSON string"""
-    return json.dumps(json_string, indent=2, sort_keys=True, separators=(',', ': '))
+    def converter(o):  # pylint: disable=R1710
+        """ Help convert date/time into strings """
+        if isinstance(o, datetime.datetime):
+            return o.__str__()
+    return json.dumps(json_string, indent=2, sort_keys=True, separators=(',', ': '), default=converter)
 
 def load_plugins(directory):
     """Load plugins"""

--- a/test/module/helpers/test_format_json.py
+++ b/test/module/helpers/test_format_json.py
@@ -1,0 +1,49 @@
+"""
+  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import json
+import datetime
+from cfnlint.helpers import format_json_string
+from testlib.testcase import BaseTestCase
+
+
+class TestFormatJson(BaseTestCase):
+    """Test Dumping JSON objects """
+
+    def test_success_run(self):
+        """Test success run"""
+        obj = {
+            'Key': {
+                'SubKey': 'Value',
+                'Date': datetime.datetime(2010, 9, 9)
+            },
+            'List': [
+                {'SubKey': 'AnotherValue'}
+            ]
+        }
+        success = """{
+  "Key": {
+    "Date": "2010-09-09 00:00:00",
+    "SubKey": "Value"
+  },
+  "List": [
+    {
+      "SubKey": "AnotherValue"
+    }
+  ]
+}"""
+        results = format_json_string(obj)
+        self.assertEqual(success, results)


### PR DESCRIPTION
*Issue #, if available:*
Fix #928 
*Description of changes:*
- Transform datetime into strings when dumping the json

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
