### PR TITLE
Uncap requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     install_requires=[
         'pyyaml',
         'six~=1.11',
-        'requests>=2.15.0,<=2.21.0',
+        'requests>=2.15.0',
         'aws-sam-translator>=1.10.0',
         'jsonpatch',
         'jsonschema~=2.6',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

urllib3 1.25.x is fully supported since botocore 1.12.156, so there is no need to have an upper bound for requests. See https://github.com/boto/botocore/pull/1735 and https://github.com/boto/botocore/pull/1737.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
