### PR TITLE
Add EC2::CapacityReservation allowed values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -23276,6 +23276,30 @@
         "OLD_IMAGE"
       ]
     },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
+      ]
+    },
     "EC2InstanceInitiatedShutdownBehavior": {
       "AllowedValues": [
         "stop",

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -27230,7 +27230,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-enddatetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationEndDateType"
+          }
         },
         "EphemeralStorage": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-ephemeralstorage",
@@ -27248,19 +27251,28 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancematchcriteria",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+          }
         },
         "InstancePlatform": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstancePlatform"
+          }
         },
         "InstanceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "TagSpecifications": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications",
@@ -27273,7 +27285,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         }
       }
     },
@@ -40041,6 +40056,30 @@
         "NEW_AND_OLD_IMAGES",
         "NEW_IMAGE",
         "OLD_IMAGE"
+      ]
+    },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -24423,7 +24423,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-enddatetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationEndDateType"
+          }
         },
         "EphemeralStorage": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-ephemeralstorage",
@@ -24441,19 +24444,28 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancematchcriteria",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+          }
         },
         "InstancePlatform": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstancePlatform"
+          }
         },
         "InstanceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "TagSpecifications": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications",
@@ -24466,7 +24478,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         }
       }
     },
@@ -35778,6 +35793,30 @@
         "NEW_AND_OLD_IMAGES",
         "NEW_IMAGE",
         "OLD_IMAGE"
+      ]
+    },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -22361,6 +22361,30 @@
         "OLD_IMAGE"
       ]
     },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
+      ]
+    },
     "EC2InstanceInitiatedShutdownBehavior": {
       "AllowedValues": [
         "stop",

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -21478,7 +21478,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-enddatetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationEndDateType"
+          }
         },
         "EphemeralStorage": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-ephemeralstorage",
@@ -21496,19 +21499,28 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancematchcriteria",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+          }
         },
         "InstancePlatform": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstancePlatform"
+          }
         },
         "InstanceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "TagSpecifications": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications",
@@ -21521,7 +21533,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         }
       }
     },
@@ -32708,6 +32723,30 @@
         "NEW_AND_OLD_IMAGES",
         "NEW_IMAGE",
         "OLD_IMAGE"
+      ]
+    },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -23568,7 +23568,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-enddatetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationEndDateType"
+          }
         },
         "EphemeralStorage": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-ephemeralstorage",
@@ -23586,19 +23589,28 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancematchcriteria",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+          }
         },
         "InstancePlatform": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstancePlatform"
+          }
         },
         "InstanceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "TagSpecifications": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications",
@@ -23611,7 +23623,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         }
       }
     },
@@ -35102,6 +35117,30 @@
         "NEW_AND_OLD_IMAGES",
         "NEW_IMAGE",
         "OLD_IMAGE"
+      ]
+    },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -26059,7 +26059,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-enddatetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationEndDateType"
+          }
         },
         "EphemeralStorage": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-ephemeralstorage",
@@ -26077,19 +26080,28 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancematchcriteria",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+          }
         },
         "InstancePlatform": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstancePlatform"
+          }
         },
         "InstanceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "TagSpecifications": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications",
@@ -26102,7 +26114,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         }
       }
     },
@@ -38365,6 +38380,30 @@
         "NEW_AND_OLD_IMAGES",
         "NEW_IMAGE",
         "OLD_IMAGE"
+      ]
+    },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -20310,7 +20310,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-enddatetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationEndDateType"
+          }
         },
         "EphemeralStorage": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-ephemeralstorage",
@@ -20328,19 +20331,28 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancematchcriteria",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+          }
         },
         "InstancePlatform": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstancePlatform"
+          }
         },
         "InstanceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "TagSpecifications": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications",
@@ -20353,7 +20365,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         }
       }
     },
@@ -31118,6 +31133,30 @@
         "NEW_AND_OLD_IMAGES",
         "NEW_IMAGE",
         "OLD_IMAGE"
+      ]
+    },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -26158,7 +26158,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-enddatetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationEndDateType"
+          }
         },
         "EphemeralStorage": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-ephemeralstorage",
@@ -26176,19 +26179,28 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancematchcriteria",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+          }
         },
         "InstancePlatform": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstancePlatform"
+          }
         },
         "InstanceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "TagSpecifications": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications",
@@ -26201,7 +26213,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         }
       }
     },
@@ -38695,6 +38710,30 @@
         "NEW_AND_OLD_IMAGES",
         "NEW_IMAGE",
         "OLD_IMAGE"
+      ]
+    },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -25237,6 +25237,30 @@
         "OLD_IMAGE"
       ]
     },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
+      ]
+    },
     "EC2InstanceInitiatedShutdownBehavior": {
       "AllowedValues": [
         "stop",

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -28120,7 +28120,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-enddatetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationEndDateType"
+          }
         },
         "EphemeralStorage": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-ephemeralstorage",
@@ -28138,19 +28141,28 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancematchcriteria",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+          }
         },
         "InstancePlatform": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstancePlatform"
+          }
         },
         "InstanceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "TagSpecifications": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications",
@@ -28163,7 +28175,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         }
       }
     },
@@ -41500,6 +41515,30 @@
         "NEW_AND_OLD_IMAGES",
         "NEW_IMAGE",
         "OLD_IMAGE"
+      ]
+    },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -22497,7 +22497,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-enddatetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationEndDateType"
+          }
         },
         "EphemeralStorage": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-ephemeralstorage",
@@ -22515,19 +22518,28 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancematchcriteria",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+          }
         },
         "InstancePlatform": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstancePlatform"
+          }
         },
         "InstanceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "TagSpecifications": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications",
@@ -22540,7 +22552,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         }
       }
     },
@@ -33963,6 +33978,30 @@
         "NEW_AND_OLD_IMAGES",
         "NEW_IMAGE",
         "OLD_IMAGE"
+      ]
+    },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -18129,7 +18129,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-enddatetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationEndDateType"
+          }
         },
         "EphemeralStorage": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-ephemeralstorage",
@@ -18147,19 +18150,28 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancematchcriteria",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+          }
         },
         "InstancePlatform": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstancePlatform"
+          }
         },
         "InstanceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "TagSpecifications": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications",
@@ -18172,7 +18184,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         }
       }
     },
@@ -28551,6 +28566,30 @@
         "NEW_AND_OLD_IMAGES",
         "NEW_IMAGE",
         "OLD_IMAGE"
+      ]
+    },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -28444,6 +28444,30 @@
         "OLD_IMAGE"
       ]
     },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
+      ]
+    },
     "EC2InstanceInitiatedShutdownBehavior": {
       "AllowedValues": [
         "stop",

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -28120,7 +28120,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-enddatetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationEndDateType"
+          }
         },
         "EphemeralStorage": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-ephemeralstorage",
@@ -28138,19 +28141,28 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancematchcriteria",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+          }
         },
         "InstancePlatform": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstancePlatform"
+          }
         },
         "InstanceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "TagSpecifications": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications",
@@ -28163,7 +28175,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         }
       }
     },
@@ -41540,6 +41555,30 @@
         "NEW_AND_OLD_IMAGES",
         "NEW_IMAGE",
         "OLD_IMAGE"
+      ]
+    },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -25353,7 +25353,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-enddatetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationEndDateType"
+          }
         },
         "EphemeralStorage": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-ephemeralstorage",
@@ -25371,19 +25374,28 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancematchcriteria",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+          }
         },
         "InstancePlatform": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstancePlatform"
+          }
         },
         "InstanceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "TagSpecifications": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications",
@@ -25396,7 +25408,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         }
       }
     },
@@ -37656,6 +37671,30 @@
         "NEW_AND_OLD_IMAGES",
         "NEW_IMAGE",
         "OLD_IMAGE"
+      ]
+    },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -23028,6 +23028,30 @@
         "OLD_IMAGE"
       ]
     },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
+      ]
+    },
     "EC2InstanceInitiatedShutdownBehavior": {
       "AllowedValues": [
         "stop",

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -24107,6 +24107,30 @@
         "OLD_IMAGE"
       ]
     },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
+      ]
+    },
     "EC2InstanceInitiatedShutdownBehavior": {
       "AllowedValues": [
         "stop",

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -20920,7 +20920,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-enddatetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationEndDateType"
+          }
         },
         "EphemeralStorage": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-ephemeralstorage",
@@ -20938,19 +20941,28 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancematchcriteria",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+          }
         },
         "InstancePlatform": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstancePlatform"
+          }
         },
         "InstanceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "TagSpecifications": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications",
@@ -20963,7 +20975,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         }
       }
     },
@@ -32016,6 +32031,30 @@
         "NEW_AND_OLD_IMAGES",
         "NEW_IMAGE",
         "OLD_IMAGE"
+      ]
+    },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -28103,7 +28103,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-enddatetype",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationEndDateType"
+          }
         },
         "EphemeralStorage": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-ephemeralstorage",
@@ -28121,19 +28124,28 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancematchcriteria",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+          }
         },
         "InstancePlatform": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "EC2CapacityReservationInstancePlatform"
+          }
         },
         "InstanceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instancetype",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "Ec2InstanceType"
+          }
         },
         "TagSpecifications": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tagspecifications",
@@ -28146,7 +28158,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-tenancy",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "PlacementTenancy"
+          }
         }
       }
     },
@@ -41465,6 +41480,30 @@
         "NEW_AND_OLD_IMAGES",
         "NEW_IMAGE",
         "OLD_IMAGE"
+      ]
+    },
+    "EC2CapacityReservationEndDateType": {
+      "AllowedValues": [
+        "limited",
+        "unlimited"
+      ]
+    },
+    "EC2CapacityReservationInstanceMatchCriteria": {
+      "AllowedValues": [
+        "open",
+        "targeted"
+      ]
+    },
+    "EC2CapacityReservationInstancePlatform": {
+      "AllowedValues": [
+        "Linux/UNIX",
+        "Red Hat Enterprise Linux",
+        "SUSE Linux",
+        "Windows with SQL Server Enterprise",
+        "Windows with SQL Server Standard",
+        "Windows with SQL Server Web",
+        "Windows with SQL Server",
+        "Windows"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1092,6 +1092,30 @@
           "standard"
         ]
       },
+      "EC2CapacityReservationEndDateType": {
+        "AllowedValues": [
+          "limited",
+          "unlimited"
+        ]
+      },
+      "EC2CapacityReservationInstanceMatchCriteria": {
+        "AllowedValues": [
+          "open",
+          "targeted"
+        ]
+      },
+      "EC2CapacityReservationInstancePlatform": {
+        "AllowedValues": [
+          "Linux/UNIX",
+          "Red Hat Enterprise Linux",
+          "SUSE Linux",
+          "Windows with SQL Server Enterprise",
+          "Windows with SQL Server Standard",
+          "Windows with SQL Server Web",
+          "Windows with SQL Server",
+          "Windows"
+        ]
+      },
       "Ec2CpuCredits": {
         "AllowedValues": [
           "standard",

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -1337,6 +1337,41 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::CapacityReservation/Properties/EndDateType/Value",
+    "value": {
+      "ValueType": "EC2CapacityReservationEndDateType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::CapacityReservation/Properties/InstanceMatchCriteria/Value",
+    "value": {
+      "ValueType": "EC2CapacityReservationInstanceMatchCriteria"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::CapacityReservation/Properties/InstancePlatform/Value",
+    "value": {
+      "ValueType": "EC2CapacityReservationInstancePlatform"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::CapacityReservation/Properties/InstanceType/Value",
+    "value": {
+      "ValueType": "Ec2InstanceType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::CapacityReservation/Properties/Tenancy/Value",
+    "value": {
+      "ValueType": "PlacementTenancy"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::EC2::Volume/Properties/VolumeType/Value",
     "value": {
       "ValueType": "EbsVolumeType"

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -5,6 +5,9 @@ Description: >
   Minimal configuration for each resource to be "valid", apart from the properties
   that are part of the AllowedValues check.
 Parameters:
+  AvailabilityZone:
+    Type: "AWS::EC2::AvailabilityZone::Name"
+    Default: "eu-west-1a"
   Password:
     Type: String
     NoEcho: True
@@ -522,6 +525,16 @@ Resources:
           KeyType: "hash" # Invalid AllowedValue
       StreamSpecification:
         StreamViewType: "NEW_AND_OLD" # Invalid AllowedValue
+  EC2CapacityReservation:
+    Type: "AWS::EC2::CapacityReservation"
+    Properties:
+      AvailabilityZone: !Ref "AvailabilityZone"
+      EndDateType: "asap" # Invalid AllowedValue
+      InstanceCount: 1
+      InstanceMatchCriteria: "Targeted" # Invalid AllowedValue
+      InstancePlatform: "Linux" # Invalid AllowedValue
+      InstanceType: "t.medium" # Invalid AllowedValue
+      Tenancy: "Default" # Invalid AllowedValue
   EC2ElasticIp:
     Type: "AWS::EC2::EIP"
     Properties:
@@ -553,7 +566,7 @@ Resources:
     Type: "AWS::EC2::Host"
     Properties:
       AutoPlacement: "On" # Invalid allowed Value
-      AvailabilityZone: "eu-west-1a"
+      AvailabilityZone: !Ref "AvailabilityZone"
       InstanceType: "t3.medium"
   EC2Instance:
     Type: "AWS::EC2::Instance"
@@ -809,7 +822,7 @@ Resources:
   Volume:
     Type: "AWS::EC2::Volume"
     Properties:
-      AvailabilityZone: "eu-west-1a"
+      AvailabilityZone: !Ref "AvailabilityZone"
       VolumeType: "sssd" # Invalid AllowedValue
   Vpc:
     Type: "AWS::EC2::VPC"

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -554,6 +554,16 @@ Resources:
           KeyType: "HASH" # Valid AllowedValue
       StreamSpecification:
         StreamViewType: "NEW_AND_OLD_IMAGES" # Valid AllowedValue
+  EC2CapacityReservation:
+    Type: "AWS::EC2::CapacityReservation"
+    Properties:
+      AvailabilityZone: !Ref "AvailabilityZone"
+      EndDateType: "unlimited" # Valid AllowedValue
+      InstanceCount: 1
+      InstanceMatchCriteria: "targeted" # Valid AllowedValue
+      InstancePlatform: "Linux/UNIX" # Valid AllowedValue
+      InstanceType: "t2.medium" # Valid AllowedValue
+      Tenancy: "default" # Valid AllowedValue
   EC2ElasticIp:
     Type: "AWS::EC2::EIP"
     Properties:

--- a/test/rules/resources/properties/test_allowed_value.py
+++ b/test/rules/resources/properties/test_allowed_value.py
@@ -34,4 +34,4 @@ class TestAllowedValue(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 211)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/allowed_values.yaml', 216)


### PR DESCRIPTION
*Issue https://github.com/awslabs/cfn-python-lint/issues/50, if available:*

Add all the allowed values of the [`AWS::EC2`]( https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/AWS_EC2.html) Resources. 

Last one from the EC2 part: 🎉 
- CapacityReservation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
