### PR TITLE
Switch how subbed parameters exceptions are handled

### DIFF
--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -451,8 +451,8 @@ class Template(object):  # pylint: disable=R0904
             'Outputs',
             'Rules'
         ]
-        self.transform_globals = {}
         self.transform_pre = {}
+        self.transform_pre['Globals'] = {}
         self.transform_pre['Ref'] = self.search_deep_keys('Ref')
         self.transform_pre['Fn::Sub'] = self.search_deep_keys('Fn::Sub')
         self.conditions = cfnlint.conditions.Conditions(self)
@@ -703,7 +703,7 @@ class Template(object):  # pylint: disable=R0904
         results = []
         results.extend(self._search_deep_keys(searchText, self.template, []))
         # Globals are removed during a transform.  They need to be checked manually
-        results.extend(self._search_deep_keys(searchText, self.transform_globals, []))
+        results.extend(self._search_deep_keys(searchText, self.transform_pre.get('Globals'), []))
         return results
 
     def get_condition_values(self, template, path=[]):
@@ -1336,7 +1336,7 @@ class Runner(object):
         # Currently locked in to SAM specific
         if transform_type == 'AWS::Serverless-2016-10-31':
             # Save the Globals section so its available for rule processing
-            self.cfn.transform_globals = self.cfn.template.get('Globals', {})
+            self.cfn.transform_pre['Globals'] = self.cfn.template.get('Globals', {})
             transform = Transform(self.filename, self.cfn.template, self.cfn.regions[0])
             matches = transform.transform_template()
             self.cfn.template = transform.template()

--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -114,9 +114,6 @@ class Transform(object):
             self._template = cfnlint.helpers.convert_dict(
                 sam_translator.translate(sam_template=self._template, parameter_values=self._parameters))
 
-            for p_name in self._parameters:
-                del self._template['Parameters'][p_name]
-
             LOGGER.info('Transformed template: \n%s', cfnlint.helpers.format_json_string(self._template))
         except InvalidDocumentException as e:
             message = 'Error transforming template: {0}'

--- a/test/fixtures/templates/good/transform/auto_publish_alias.yaml
+++ b/test/fixtures/templates/good/transform/auto_publish_alias.yaml
@@ -1,22 +1,38 @@
 ---
-  AWSTemplateFormatVersion: '2010-09-09'
-  Transform: AWS::Serverless-2016-10-31
-  
-  Parameters:
-    Stage:
-      Description: Environment stage (deployment phase)
-      Type: String
-      AllowedValues:
-        - beta
-        - prod
-  
-  Resources:
-    SkillFunction:
-      Type: AWS::Serverless::Function
-      Properties:
-        CodeUri: '.'
-        Handler: main.handler
-        Runtime: python3.7
-        Timeout: 30
-        MemorySize: 128
-        AutoPublishAlias: !Ref Stage
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  Stage1:
+    Description: Environment stage (deployment phase)
+    Type: String
+    AllowedValues:
+      - beta
+      - prod
+  Stage2:
+    Description: Environment stage (deployment phase)
+    Type: String
+    AllowedValues:
+      - beta
+      - prod
+
+Resources:
+  SkillFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: '.'
+      Handler: main.handler
+      Runtime: python3.7
+      Timeout: 30
+      MemorySize: 128
+      AutoPublishAlias: !Ref Stage1
+  SkillFunction2:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: '.'
+      Handler: main.handler
+      Runtime: python3.7
+      Timeout: 30
+      MemorySize: 128
+      FunctionName: !Sub "Stage-${Stage2}-${AWS::Region}"
+      AutoPublishAlias: !Ref Stage2

--- a/test/module/transform/test_transform.py
+++ b/test/module/transform/test_transform.py
@@ -29,7 +29,7 @@ class TestTransform(BaseTestCase):
         template = cfn_yaml.load(filename)
         transformed_template = Transform(filename, template, region)
         transformed_template.transform_template()
-        self.assertDictEqual(transformed_template._parameters, {'Stage': 'Alias'})
+        self.assertDictEqual(transformed_template._parameters, {'Stage1': 'Alias', 'Stage2': 'Alias'})
         self.assertDictEqual(
           transformed_template._template.get('Resources').get('SkillFunctionAliasAlias').get('Properties'),
           {


### PR DESCRIPTION
*Issue #, if available:*
Fix #944
*Description of changes:*
- Don't delete the parameters when we sub them
- Clean up the Transform globals section and standardize it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
