### PR TITLE
Fix a flaky test

### DIFF
--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -545,7 +545,7 @@ class ConfigMixIn(TemplateArgs, CliArgs, ConfigFileArgs, object):
                     if add_filename not in ignore_templates:
                         all_filenames.append(add_filename)
 
-        return all_filenames
+        return sorted(all_filenames)
 
     def _ignore_templates(self):
         """ templates """


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

test_config_expand_paths sometimes fails with:
```
======================================================================
FAIL: test_config_expand_paths (module.config.test_config_mixin.TestConfigMixIn)
Test precedence in
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/yen/var/syncthing/Projects/cfn-python-lint/.tox/py37/lib/python3.7/site-packages/mock/mock.py", line 1330, in patched
    return func(*args, **keywargs)
  File "/home/yen/var/syncthing/Projects/cfn-python-lint/test/module/config/test_config_mixin.py", line 97, in test_config_expand_paths
    'test/fixtures/templates/public/rds-cluster.yaml'])
AssertionError: Lists differ: ['tes[23 chars]blic/rds-cluster.yaml', 'test/fixtures/templat[25 chars]aml'] != ['tes[23 chars]blic/lambda-poller.yaml', 'test/fixtures/templ[25 chars]aml']

First differing element 0:
'test/fixtures/templates/public/rds-cluster.yaml'
'test/fixtures/templates/public/lambda-poller.yaml'

- ['test/fixtures/templates/public/rds-cluster.yaml',
-  'test/fixtures/templates/public/lambda-poller.yaml']
? ^                                                   ^

+ ['test/fixtures/templates/public/lambda-poller.yaml',
? ^                                                   ^

+  'test/fixtures/templates/public/rds-cluster.yaml']

----------------------------------------------------------------------
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
