### PR TITLE
Add a lot more special characters to DNS records

### DIFF
--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -28,7 +28,8 @@ class RecordSet(CloudFormationLintRule):
     source_url = 'https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html'
     tags = ['resources', 'route53', 'record_set']
 
-    REGEX_DOMAINNAME = re.compile(r'^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])(.)$')
+    # Regex generated from https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html
+    REGEX_DOMAINNAME = re.compile(r'^[a-zA-Z0-9\!\"\#\$\%\&\'\(\)\*\+\,-\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~\.]+$')
     REGEX_TXT = re.compile(r'^("[^"]{1,255}" *)*"[^"]{1,255}"$')
     REGEX_CNAME_VALIDATIONS = re.compile(r'^.*\.acm-validations\.aws\.?$')
 

--- a/test/fixtures/templates/bad/route53.yaml
+++ b/test/fixtures/templates/bad/route53.yaml
@@ -97,26 +97,6 @@ Resources:
       ResourceRecords:
         - "127.0.0.1"
         - "10 my domain"
-  MyNSRecordSet:
-    Type: "AWS::Route53::RecordSet"
-    Properties:
-      Comment: "A valid NS Record"
-      HostedZoneId: !Ref "MyHostedZone"
-      Name: "www.example.com"
-      Type: "NS"
-      TTL: "300"
-      ResourceRecords:
-        - "127.0.0.1"
-  MyPTRRecordSet:
-    Type: "AWS::Route53::RecordSet"
-    Properties:
-      Comment: "A valid NS Record"
-      HostedZoneId: !Ref "MyHostedZone"
-      Name: "www.example.com"
-      Type: "PTR"
-      TTL: "300"
-      ResourceRecords:
-        - "127.0.0.1"
   MyRecordSetGroup:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:
@@ -170,16 +150,6 @@ Resources:
           ResourceRecords:
             - "mx1.example.com"
             - "65536 mx2.example.com"
-  MySecondRecordSetGroup:
-    Type: "AWS::Route53::RecordSetGroup"
-    Properties:
-      HostedZoneId: !Ref "MyHostedZone"
-      RecordSets:
-        - Name: "z.example.com"
-          Type: "TXT"
-          TTL: "300"
-          ResourceRecords:
-            - "\"henk\""
   PoorlyConfiguredRoute53:
     Type: "AWS::Route53::RecordSetGroup"
     Properties:

--- a/test/fixtures/templates/good/route53.yaml
+++ b/test/fixtures/templates/good/route53.yaml
@@ -81,6 +81,16 @@ Resources:
       TTL: "300"
       ResourceRecords:
         - "hostname.example.com"
+  MyCNAMERecordSpecialCharactersSet:
+    Type: "AWS::Route53::RecordSet"
+    Properties:
+      Comment: "A valid CNAME Record"
+      HostedZoneId: !Ref "MyHostedZone"
+      Name: "*test.&.example.com-"
+      Type: "CNAME"
+      TTL: "300"
+      ResourceRecords:
+        - "hostname.example.com"
   MyCNAME2RecordSet:
     Type: "AWS::Route53::RecordSet"
     Properties:

--- a/test/rules/resources/route53/test_recordsets.py
+++ b/test/rules/resources/route53/test_recordsets.py
@@ -34,4 +34,4 @@ class TestRoute53RecordSets(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/route53.yaml', 32)
+        self.helper_file_negative('test/fixtures/templates/bad/route53.yaml', 30)


### PR DESCRIPTION
*Issue #, if available:*
Fix #906
*Description of changes:*
- Update rule E3020 to include the special characters as defined here https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
