### PR TITLE
Improve AWS::EC2::LaunchTemplate linting

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
+++ b/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
@@ -7,6 +7,12 @@
         "NoDevice"
       ]
     ],
+    "AWS::AutoScaling::AutoScalingGroup.LaunchTemplateSpecification": [
+      [
+        "LaunchTemplateId",
+        "LaunchTemplateName"
+      ]
+    ],
     "AWS::CloudFront::Distribution.Origin": [
       [
         "CustomOriginConfig",

--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -3435,13 +3435,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -13778,7 +13781,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -21748,6 +21754,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -8391,13 +8391,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -29606,7 +29609,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -43009,6 +43015,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -7975,13 +7975,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -26074,7 +26077,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -38076,6 +38082,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -23697,6 +23697,18 @@
         ]
       }
     },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
+    },
     "LoadBalancerName": {
       "GetAtt": {},
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -7463,13 +7463,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -24951,7 +24954,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -37357,6 +37363,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -7687,13 +7687,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -26097,7 +26100,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -38226,6 +38232,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -8669,13 +8669,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -29777,7 +29780,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -43285,6 +43291,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -7085,13 +7085,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -21868,7 +21871,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -32954,6 +32960,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -8578,13 +8578,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -29795,7 +29798,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -43426,6 +43432,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -4111,13 +4111,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -15760,7 +15763,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -24333,6 +24339,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -8798,13 +8798,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -31566,7 +31569,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -45877,6 +45883,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -7616,13 +7616,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -24979,7 +24982,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -36975,6 +36981,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -5751,13 +5751,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -19495,7 +19498,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -30046,6 +30052,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -6170,13 +6170,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -19469,7 +19472,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -29654,6 +29660,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -8798,13 +8798,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -31566,7 +31569,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -45929,6 +45935,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -8511,13 +8511,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -27893,7 +27896,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -40412,6 +40418,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -20612,6 +20612,18 @@
         ]
       }
     },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
+    },
     "LoadBalancerName": {
       "GetAtt": {},
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -3553,13 +3553,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -15267,7 +15270,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -24611,6 +24617,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -7145,13 +7145,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -21647,7 +21650,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -32934,6 +32940,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -8798,13 +8798,16 @@
         "ResourceType": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype",
           "PrimitiveType": "String",
-          "Required": false,
-          "UpdateType": "Mutable"
+          "Required": true,
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "LaunchTemplateTagSpecificationResourceType"
+          }
         },
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-tags",
           "ItemType": "Tag",
-          "Required": false,
+          "Required": true,
           "Type": "List",
           "UpdateType": "Mutable"
         }
@@ -31549,7 +31552,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "LaunchTemplateName"
+          }
         }
       }
     },
@@ -45854,6 +45860,18 @@
           "AWS::AutoScaling::LaunchConfiguration"
         ]
       }
+    },
+    "LaunchTemplateName": {
+      "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "StringMax": 128,
+      "StringMin": 3
+    },
+    "LaunchTemplateTagSpecificationResourceType": {
+      "AllowedValues": [
+        "instance",
+        "volume"
+      ]
     },
     "LoadBalancerName": {
       "GetAtt": {},

--- a/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
@@ -14,6 +14,16 @@
   },
   {
     "op": "replace",
+    "path": "/PropertyTypes/AWS::EC2::LaunchTemplate.TagSpecification/Properties/ResourceType/Required",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/PropertyTypes/AWS::EC2::LaunchTemplate.TagSpecification/Properties/Tags/Required",
+    "value": true
+  },
+  {
+    "op": "replace",
     "path": "/PropertyTypes/AWS::CloudFront::Distribution.DistributionConfig/Properties/DefaultCacheBehavior/Required",
     "value": true
   },

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -1607,6 +1607,18 @@
           ]
         }
       },
+      "LaunchTemplateName": {
+        "AllowedPattern": "[a-zA-Z0-9().-/_]+",
+        "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+        "StringMax": 128,
+        "StringMin": 3
+      },
+      "LaunchTemplateTagSpecificationResourceType": {
+        "AllowedValues": [
+          "instance",
+          "volume"
+        ]
+      },
       "LoadBalancerPort": {
         "NumberMax": 65535,
         "NumberMin": 1,

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -598,6 +598,13 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::EC2::LaunchTemplate.TagSpecification/Properties/ResourceType/Value",
+    "value": {
+      "ValueType": "LaunchTemplateTagSpecificationResourceType"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::EC2::SpotFleet.LaunchTemplateOverrides/Properties/AvailabilityZone/Value",
     "value": {
       "ValueType": "AvailabilityZone"
@@ -2139,6 +2146,13 @@
     "path": "/ResourceTypes/AWS::EC2::Instance/Properties/InstanceType/Value",
     "value": {
       "ValueType": "Ec2InstanceType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::EC2::LaunchTemplate/Properties/LaunchTemplateName/Value",
+    "value": {
+      "ValueType": "LaunchTemplateName"
     }
   },
   {


### PR DESCRIPTION
*Issue https://github.com/aws-cloudformation/cfn-python-lint/issues/975, if available:*

This PR improves the linting of [`AWS::EC2::LaunchTemplate`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html):

- Added `LaunchTemplateId` / `LaunchTemplateName` of the AutoScalingGroup to the OnlyOne ([source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-launchtemplatespecification.html))
- Spec-patched `TagSpecifications` ([source](https://github.com/aws-cloudformation/cfn-python-lint/issues/975))
- Added min/max/pattern to the LaunchTemplateName ([source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-launchtemplatename))
- Allowed AllowedValues to the Tag resourceTypes. There are "more" types in the documentation, but since these 2 are the only valid ones, only allowed these ([source](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype))
