### PR TITLE
Patched tests for EOL dates for lambda runtimes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ venv.bak/
 
 # vscode
 .vscode/
+
+# osx
+.DS_Store

--- a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEnd.py
+++ b/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEnd.py
@@ -23,7 +23,7 @@ class DeprecatedRuntimeEnd(DeprecatedRuntime):
     """Check if EOL Lambda Function Runtimes are used"""
     id = 'E2531'
     shortdesc = 'Check if EOL Lambda Function Runtimes are used'
-    description = 'Check if an EOL Lambda Runtime is specified and give a warning if used. '
+    description = 'Check if an EOL Lambda Runtime is specified and give an error if used. '
     source_url = 'https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html'
     tags = ['resources', 'lambda', 'runtime']
 

--- a/test/fixtures/results/public/lambda-poller.json
+++ b/test/fixtures/results/public/lambda-poller.json
@@ -1,29 +1,27 @@
-[
-    {
-        "Filename": "test/fixtures/templates/public/lambda-poller.yaml",
-        "Level": "Warning",
-        "Location": {
-            "End": {
-                "ColumnNumber": 14,
-                "LineNumber": 151
-            },
-            "Path": [
-                "Resources",
-                "PollerFunction",
-                "Properties",
-                "Runtime"
-            ],
-            "Start": {
-                "ColumnNumber": 7,
-                "LineNumber": 151
-            }
+[{
+    "Filename": "test/fixtures/templates/public/lambda-poller.yaml",
+    "Level": "Warning",
+    "Location": {
+        "End": {
+            "ColumnNumber": 14,
+            "LineNumber": 151
         },
-        "Message": "EOL runtime (nodejs6.10) specified. Runtime is EOL since 2019-04-30 and updating will be disabled at 2019-06-30, please consider to update to nodejs10.x",
-        "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
-            "Id": "W2531",
-            "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
-            "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
+        "Path": [
+            "Resources",
+            "PollerFunction",
+            "Properties",
+            "Runtime"
+        ],
+        "Start": {
+            "ColumnNumber": 7,
+            "LineNumber": 151
         }
+    },
+    "Message": "EOL runtime (nodejs6.10) specified. Runtime is EOL since 2019-04-30 and updating will be disabled at 2019-06-30, please consider to update to nodejs10.x",
+    "Rule": {
+        "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
+        "Id": "E2531",
+        "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
+        "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
     }
-]
+}]

--- a/test/fixtures/results/quickstart/nist_config_rules.json
+++ b/test/fixtures/results/quickstart/nist_config_rules.json
@@ -1,5 +1,4 @@
-[
-    {
+[{
         "Filename": "test/fixtures/templates/quickstart/nist_config_rules.yaml",
         "Level": "Warning",
         "Location": {
@@ -46,7 +45,7 @@
         },
         "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31, please consider to update to nodejs10.x",
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
             "Id": "E2531",
             "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"
@@ -126,7 +125,7 @@
         },
         "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31, please consider to update to nodejs10.x",
         "Rule": {
-            "Description": "Check if an EOL Lambda Runtime is specified and give a warning if used. ",
+            "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
             "Id": "E2531",
             "ShortDescription": "Check if EOL Lambda Function Runtimes are used",
             "Source": "https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html"

--- a/test/rules/resources/lmbd/test_deprecated_runtime_end.py
+++ b/test/rules/resources/lmbd/test_deprecated_runtime_end.py
@@ -14,16 +14,19 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+from datetime import datetime
 from cfnlint.rules.resources.lmbd.DeprecatedRuntimeEnd import DeprecatedRuntimeEnd  # pylint: disable=E0401
 from ... import BaseRuleTestCase
 
 
 class TestDeprecatedRuntimeEnd(BaseRuleTestCase):
     """Test Lambda Deprecated Runtime usage"""
+
     def setUp(self):
         """Setup"""
         super(TestDeprecatedRuntimeEnd, self).setUp()
         self.collection.register(DeprecatedRuntimeEnd())
+        self.collection.rules[0].current_date = datetime(2019, 6, 29)
 
     def test_file_positive(self):
         """Test Positive"""

--- a/test/rules/resources/lmbd/test_deprecated_runtime_eol.py
+++ b/test/rules/resources/lmbd/test_deprecated_runtime_eol.py
@@ -14,16 +14,19 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+from datetime import datetime
 from cfnlint.rules.resources.lmbd.DeprecatedRuntimeEol import DeprecatedRuntimeEol  # pylint: disable=E0401
 from ... import BaseRuleTestCase
 
 
 class TestDeprecatedRuntimeEol(BaseRuleTestCase):
     """Test Lambda Deprecated Runtime usage"""
+
     def setUp(self):
         """Setup"""
         super(TestDeprecatedRuntimeEol, self).setUp()
         self.collection.register(DeprecatedRuntimeEol())
+        self.collection.rules[0].current_date = datetime(2019, 6, 29)
 
     def test_file_positive(self):
         """Test Positive"""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some Lambda runtimes have moved from warning to errors for EOL. I've updated the tests to reflect this, but we may ultimately need a time sensitive way touch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
