### PR TITLE
Appropriately escape - inside a regex bracket

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -20772,7 +20772,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -21913,7 +21913,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -42852,7 +42852,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -44188,7 +44188,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -37932,7 +37932,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -39199,7 +39199,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -23153,7 +23153,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -24388,7 +24388,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -37230,7 +37230,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -38480,7 +38480,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -38349,7 +38349,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -39678,7 +39678,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -42627,7 +42627,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -43950,7 +43950,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -32068,7 +32068,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -33297,7 +33297,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -42870,7 +42870,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -44190,7 +44190,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -23991,7 +23991,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -25191,7 +25191,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -45270,7 +45270,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -46634,7 +46634,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -36135,7 +36135,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -37374,7 +37374,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -28958,7 +28958,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -30180,7 +30180,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -29209,7 +29209,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -30445,7 +30445,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -45303,7 +45303,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -46686,7 +46686,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -39167,7 +39167,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -40501,7 +40501,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -21504,7 +21504,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -22711,7 +22711,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -23396,7 +23396,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -24676,7 +24676,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -32022,7 +32022,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -33313,7 +33313,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -45235,7 +45235,7 @@
       ]
     },
     "CodeCommitRepositoryName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
       "StringMax": 100,
       "StringMin": 1
     },
@@ -46611,7 +46611,7 @@
     },
     "LaunchTemplateName": {
       "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-      "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+      "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
       "StringMax": 128,
       "StringMin": 3
     },

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -545,7 +545,7 @@
         ]
       },
       "CodeCommitRepositoryName": {
-        "AllowedPatternRegex": "^[a-zA-Z0-9._-]+(?<!\\.git)$",
+        "AllowedPatternRegex": "^[a-zA-Z0-9._\\-]+(?<!\\.git)$",
         "StringMax": 100,
         "StringMin": 1
       },
@@ -1627,7 +1627,7 @@
       },
       "LaunchTemplateName": {
         "AllowedPattern": "[a-zA-Z0-9().-/_]+",
-        "AllowedPatternRegex": "^[a-zA-Z0-9().-/_]+$",
+        "AllowedPatternRegex": "^[a-zA-Z0-9().\\-/_]+$",
         "StringMax": 128,
         "StringMin": 3
       },


### PR DESCRIPTION
*Issue #, if available:*
Fix #997
*Description of changes:*
- Fixing a few cases where `-` was inside a regex bracket and needed to be escaped

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
