### PR TITLE
Fix regex to match docs for IAM policy names

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -7895,9 +7895,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -7915,9 +7915,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -7952,9 +7952,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -17599,9 +17599,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -21789,16 +21789,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -21806,6 +21796,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -7894,7 +7894,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -7911,7 +7914,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -7945,7 +7951,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -17589,7 +17598,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -21771,6 +21783,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -15360,7 +15360,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -15377,7 +15380,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -15411,7 +15417,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+     	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -35404,7 +35413,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -44049,6 +44061,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -15363,7 +15363,7 @@
           "UpdateType": "Mutable",
           "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -15383,7 +15383,7 @@
           "UpdateType": "Mutable",
           "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -15418,9 +15418,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-     	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -35416,7 +35416,7 @@
           "UpdateType": "Mutable",
           "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -44067,16 +44067,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -44084,6 +44074,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -13789,7 +13789,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -13806,7 +13809,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -13840,7 +13846,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+ 	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -31326,7 +31335,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -39057,6 +39069,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -13790,9 +13790,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -13810,9 +13810,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -13847,9 +13847,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
- 	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -31336,9 +31336,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -39075,16 +39075,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -39092,6 +39082,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -8554,7 +8554,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -8571,7 +8574,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -8605,7 +8611,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -19129,7 +19138,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -24246,6 +24258,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -8555,9 +8555,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -8575,9 +8575,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -8612,9 +8612,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -19139,9 +19139,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -24264,16 +24264,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -24281,6 +24271,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -13427,9 +13427,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -13447,9 +13447,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -13484,9 +13484,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -30211,9 +30211,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -38356,16 +38356,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -38373,6 +38363,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -13426,7 +13426,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -13443,7 +13446,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -13477,7 +13483,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -30201,7 +30210,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -38338,6 +38350,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -13811,9 +13811,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -13831,9 +13831,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -13868,9 +13868,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -31681,9 +31681,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -39555,16 +39555,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -39572,6 +39562,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -13810,7 +13810,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -13827,7 +13830,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -13861,7 +13867,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -31671,7 +31680,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -39537,6 +39549,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -15323,9 +15323,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -15343,9 +15343,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -15380,9 +15380,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -35079,9 +35079,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -43828,16 +43828,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -43845,6 +43835,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -15322,7 +15322,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -15339,7 +15342,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -15373,7 +15379,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -35069,7 +35078,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -43810,6 +43822,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -12351,9 +12351,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -12371,9 +12371,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -12408,9 +12408,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -26391,9 +26391,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -33173,16 +33173,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -33190,6 +33180,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -12350,7 +12350,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -12367,7 +12370,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -12401,7 +12407,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -26381,7 +26390,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -33155,6 +33167,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -15161,7 +15161,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -15178,7 +15181,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -15212,7 +15218,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -35175,7 +35184,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -44051,6 +44063,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -15162,9 +15162,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -15182,9 +15182,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -15219,9 +15219,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -35185,9 +35185,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -44069,16 +44069,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -44086,6 +44076,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -8589,7 +8589,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -8606,7 +8609,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -8640,7 +8646,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -19787,7 +19796,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -25050,6 +25062,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -8590,9 +8590,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -8610,9 +8610,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -8647,9 +8647,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -19797,9 +19797,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -25068,16 +25068,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -25085,6 +25075,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -15451,7 +15451,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -15468,7 +15471,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -15502,7 +15508,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -36946,7 +36955,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -46495,6 +46507,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -15452,9 +15452,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -15472,9 +15472,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -15509,9 +15509,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -36956,9 +36956,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -46513,16 +46513,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -46530,6 +46520,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -12901,9 +12901,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -12921,9 +12921,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -12958,9 +12958,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -29591,9 +29591,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -37251,16 +37251,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -37268,6 +37258,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -12900,7 +12900,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -12917,7 +12920,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -12951,7 +12957,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -29581,7 +29590,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -37233,6 +37245,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -10747,9 +10747,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -10767,9 +10767,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -10804,9 +10804,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -23537,9 +23537,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -30060,16 +30060,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -30077,6 +30067,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -10746,7 +10746,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -10763,7 +10766,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -10797,7 +10803,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -23527,7 +23536,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -30042,6 +30054,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -10788,9 +10788,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -10808,9 +10808,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -10845,9 +10845,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -23853,9 +23853,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -30319,16 +30319,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -30336,6 +30326,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -10787,7 +10787,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -10804,7 +10807,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -10838,7 +10844,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -23843,7 +23852,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -30301,6 +30313,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -15451,7 +15451,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+	    "ValueType": "IamPolicyName"	
+	  }
         }
       }
     },
@@ -15468,7 +15471,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+          }
         }
       }
     },
@@ -15502,7 +15508,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+          }
         }
       }
     },
@@ -36979,7 +36988,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -46553,6 +46565,16 @@
         ]
       }
     },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -46560,7 +46582,7 @@
           "String"
         ]
       }
-    },
+    }, 
     "IamRole": {
       "GetAtt": {},
       "Ref": {
@@ -46595,7 +46617,7 @@
           "AWS::IAM::Role"
         ]
       }
-    },
+    }, 
     "IamUser.Arn": {
       "GetAtt": {
         "AWS::IAM::User": "Arn"

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -15452,9 +15452,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
-	    "ValueType": "IamPolicyName"	
-	  }
+          "Value": {
+            "ValueType": "IamPolicyName"
+          }
         }
       }
     },
@@ -15472,7 +15472,7 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
           }
         }
@@ -15509,7 +15509,7 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
           }
         }
@@ -36989,7 +36989,7 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
           }
         },
@@ -46565,16 +46565,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -46582,7 +46572,17 @@
           "String"
         ]
       }
-    }, 
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
+    },
     "IamRole": {
       "GetAtt": {},
       "Ref": {
@@ -46617,7 +46617,7 @@
           "AWS::IAM::Role"
         ]
       }
-    }, 
+    },
     "IamUser.Arn": {
       "GetAtt": {
         "AWS::IAM::User": "Arn"

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -14079,7 +14079,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -14096,7 +14099,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -14130,7 +14136,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -32313,7 +32322,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+	    "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -40361,6 +40373,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -14080,9 +14080,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -14100,9 +14100,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -14137,9 +14137,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -32323,9 +32323,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
-	    "ValueType": "IamPolicyName"
-	  }
+          "Value": {
+            "ValueType": "IamPolicyName"
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -40379,16 +40379,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -40396,6 +40386,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -7939,9 +7939,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -7959,9 +7959,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -7996,9 +7996,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -18327,9 +18327,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -22588,16 +22588,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -22605,6 +22595,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -7938,7 +7938,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -7955,7 +7958,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -7989,7 +7995,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -18317,7 +18326,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -22570,6 +22582,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -8072,7 +8072,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -8089,7 +8092,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -8123,7 +8129,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -19455,7 +19464,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -24535,6 +24547,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -8073,9 +8073,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -8093,9 +8093,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -8130,9 +8130,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -19465,9 +19465,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -24553,16 +24553,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -24570,6 +24560,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -12411,9 +12411,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -12431,9 +12431,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -12468,9 +12468,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -26201,9 +26201,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -33192,16 +33192,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -33209,6 +33199,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -12410,7 +12410,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -12427,7 +12430,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -12461,7 +12467,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -26191,7 +26200,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -33174,6 +33186,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -15451,7 +15451,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -15468,7 +15471,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -15502,7 +15508,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         }
       }
     },
@@ -36929,7 +36938,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policyname",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+	  "Value": {
+            "ValueType": "IamPolicyName"
+	  }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -46472,6 +46484,16 @@
     },
     "IamManagedPolicyDocument": {
       "JsonMax": 6144,
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "StringMax": 128,
+      "StringMin": 1,
       "Ref": {
         "Parameters": [
           "String"

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -15452,9 +15452,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -15472,9 +15472,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -15509,9 +15509,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         }
       }
     },
@@ -36939,9 +36939,9 @@
           "PrimitiveType": "String",
           "Required": true,
           "UpdateType": "Mutable",
-	  "Value": {
+          "Value": {
             "ValueType": "IamPolicyName"
-	  }
+          }
         },
         "Roles": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-roles",
@@ -46490,16 +46490,6 @@
         ]
       }
     },
-    "IamPolicyName": {
-      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
-      "StringMax": 128,
-      "StringMin": 1,
-      "Ref": {
-        "Parameters": [
-          "String"
-        ]
-      }
-    },
     "IamPath": {
       "AllowedPatternRegex": "^/(.+/)*$",
       "Ref": {
@@ -46507,6 +46497,16 @@
           "String"
         ]
       }
+    },
+    "IamPolicyName": {
+      "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+      "Ref": {
+        "Parameters": [
+          "String"
+        ]
+      },
+      "StringMax": 128,
+      "StringMin": 1
     },
     "IamRole": {
       "GetAtt": {},

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -675,14 +675,6 @@
           "OPTIONAL"
         ]
       },
-      "CognitoSchemaAttributeDataType": {
-        "AllowedValues": [
-          "Boolean",
-          "DateTime",
-          "Number",
-          "String"
-        ]
-      },
       "CognitoRefreshTokenValidity": {
         "NumberMax": 3650,
         "NumberMin": 0,
@@ -692,6 +684,14 @@
             "Number"
           ]
         }
+      },
+      "CognitoSchemaAttributeDataType": {
+        "AllowedValues": [
+          "Boolean",
+          "DateTime",
+          "Number",
+          "String"
+        ]
       },
       "ConfigFrequency": {
         "AllowedValues": [
@@ -732,6 +732,14 @@
             "String"
           ]
         }
+      },
+      "DHCPOptionsNetbiosNodeType": {
+        "AllowedValues": [
+          "1",
+          "2",
+          "4",
+          "8"
+        ]
       },
       "DLMPolicyResourceType": {
         "AllowedValues": [
@@ -998,14 +1006,6 @@
           "ENABLED"
         ]
       },
-      "DHCPOptionsNetbiosNodeType": {
-        "AllowedValues": [
-          "1",
-          "2",
-          "4",
-          "8"
-        ]
-      },
       "DmsEndpointEngineName": {
         "AllowedValues": [
           "aurora-postgresql",
@@ -1084,6 +1084,30 @@
           "OLD_IMAGE"
         ]
       },
+      "EC2CapacityReservationEndDateType": {
+        "AllowedValues": [
+          "limited",
+          "unlimited"
+        ]
+      },
+      "EC2CapacityReservationInstanceMatchCriteria": {
+        "AllowedValues": [
+          "open",
+          "targeted"
+        ]
+      },
+      "EC2CapacityReservationInstancePlatform": {
+        "AllowedValues": [
+          "Linux/UNIX",
+          "Red Hat Enterprise Linux",
+          "SUSE Linux",
+          "Windows with SQL Server Enterprise",
+          "Windows with SQL Server Standard",
+          "Windows with SQL Server Web",
+          "Windows with SQL Server",
+          "Windows"
+        ]
+      },
       "EC2InstanceInitiatedShutdownBehavior": {
         "AllowedValues": [
           "stop",
@@ -1116,6 +1140,23 @@
           "persistent"
         ]
       },
+      "EFSFileSystemLifecyclePolicy": {
+        "AllowedValues": [
+          "AFTER_30_DAYS"
+        ]
+      },
+      "EFSFileSystemPerformanceMode": {
+        "AllowedValues": [
+          "generalPurpose",
+          "maxIO"
+        ]
+      },
+      "EFSFileSystemThroughputMode": {
+        "AllowedValues": [
+          "bursting",
+          "provisioned"
+        ]
+      },
       "EbsIops": {
         "NumberMax": 20000,
         "NumberMin": 100
@@ -1127,30 +1168,6 @@
           "sc1",
           "st1",
           "standard"
-        ]
-      },
-      "EC2CapacityReservationEndDateType": {
-        "AllowedValues": [
-          "limited",
-          "unlimited"
-        ]
-      },
-      "EC2CapacityReservationInstanceMatchCriteria": {
-        "AllowedValues": [
-          "open",
-          "targeted"
-        ]
-      },
-      "EC2CapacityReservationInstancePlatform": {
-        "AllowedValues": [
-          "Linux/UNIX",
-          "Red Hat Enterprise Linux",
-          "SUSE Linux",
-          "Windows with SQL Server Enterprise",
-          "Windows with SQL Server Standard",
-          "Windows with SQL Server Web",
-          "Windows with SQL Server",
-          "Windows"
         ]
       },
       "Ec2CpuCredits": {
@@ -1165,17 +1182,16 @@
           "vpc"
         ]
       },
+      "Ec2FleetDefaultTargetCapacityType": {
+        "AllowedValues": [
+          "on-demand",
+          "spot"
+        ]
+      },
       "Ec2FleetExcessCapacityTerminationPolicy": {
         "AllowedValues": [
           "no-termination",
           "termination"
-        ]
-      },
-      "Ec2FleetType": {
-        "AllowedValues": [
-          "instant",
-          "maintain",
-          "request"
         ]
       },
       "Ec2FleetOnDemandAllocationStrategy": {
@@ -1197,10 +1213,11 @@
           "terminate"
         ]
       },
-      "Ec2FleetDefaultTargetCapacityType": {
+      "Ec2FleetType": {
         "AllowedValues": [
-          "on-demand",
-          "spot"
+          "instant",
+          "maintain",
+          "request"
         ]
       },
       "Ec2FlowLogDestinationType": {
@@ -1249,12 +1266,6 @@
           "FARGATE"
         ]
       },
-      "EcsSchedulingStrategy": {
-        "AllowedValues": [
-          "DAEMON",
-          "REPLICA"
-        ]
-      },
       "EcsNetworkMode": {
         "AllowedValues": [
           "awsvpc",
@@ -1263,26 +1274,15 @@
           "none"
         ]
       },
+      "EcsSchedulingStrategy": {
+        "AllowedValues": [
+          "DAEMON",
+          "REPLICA"
+        ]
+      },
       "EcsTaskDefinitionProxyType": {
         "AllowedValues": [
           "APPMESH"
-        ]
-      },
-      "EFSFileSystemLifecyclePolicy": {
-        "AllowedValues": [
-          "AFTER_30_DAYS"
-        ]
-      },
-      "EFSFileSystemPerformanceMode": {
-        "AllowedValues": [
-          "generalPurpose",
-          "maxIO"
-        ]
-      },
-      "EFSFileSystemThroughputMode": {
-        "AllowedValues": [
-          "bursting",
-          "provisioned"
         ]
       },
       "ElasticInferenceAccelerator": {
@@ -1492,6 +1492,16 @@
           ]
         }
       },
+      "IamPolicyName": {
+        "AllowedPatternRegex": "^[a-zA-Z0-9+=,.@\\-_]+$",
+        "Ref": {
+          "Parameters": [
+            "String"
+          ]
+        },
+        "StringMax": 128,
+        "StringMin": 1
+      },
       "IamRole": {
         "GetAtt": {
         },
@@ -1637,16 +1647,6 @@
           "volume"
         ]
       },
-      "LoadBalancerPort": {
-        "NumberMax": 65535,
-        "NumberMin": 1,
-        "Ref": {
-          "Parameters": [
-            "String",
-            "Number"
-          ]
-        }
-      },
       "LoadBalancerName": {
         "GetAtt": {
         },
@@ -1665,6 +1665,16 @@
         "Ref": {
           "Parameters": [
             "Strings"
+          ]
+        }
+      },
+      "LoadBalancerPort": {
+        "NumberMax": 65535,
+        "NumberMin": 1,
+        "Ref": {
+          "Parameters": [
+            "String",
+            "Number"
           ]
         }
       },

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -2574,5 +2574,33 @@
     "value": {
       "ValueType": "KmsKey.Arn"
     }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::IAM::Group.Policy/Properties/PolicyName/Value",
+    "value": {
+      "ValueType": "IamPolicyName"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::IAM::Role.Policy/Properties/PolicyName/Value",
+    "value": {
+      "ValueType": "IamPolicyName"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::IAM::User.Policy/Properties/PolicyName/Value",
+    "value": {
+      "ValueType": "IamPolicyName"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::IAM::Policy/Properties/PolicyName/Value",
+    "value": {
+      "ValueType": "IamPolicyName"
+    }
   }
 ]


### PR DESCRIPTION
*Issue #, if available:*
#996
*Description of changes:*

Added "ValueType" IamPolicyName that matches the defined regex and string length from [aws documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iam-policy.html#cfn-iam-policies-policyname). Makes sure that only alphanumeric or +=,.@-_ characters are in the policy name.

Tested locally by manually changing policy names and running against the linter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.