### PR TITLE
Surround example regex with single quotes

### DIFF
--- a/src/cfnlint/rules/parameters/Cidr.py
+++ b/src/cfnlint/rules/parameters/Cidr.py
@@ -70,7 +70,7 @@ class Cidr(CloudFormationLintRule):
                     param_path = ['Parameters', value]
                     full_param_path = '/'.join(param_path)
                     message = 'AllowedPattern and/or AllowedValues for Parameter should be specified at {1}. ' \
-                              'Example for AllowedPattern: "{0}"'
+                              'Example for AllowedPattern: \'{0}\''
                     matches.append(RuleMatch(param_path, message.format(REGEX_CIDR.pattern, full_param_path)))
 
         return matches


### PR DESCRIPTION
YAML strings in double quotes use backslash as an escape character. Help out people copying and pasting from this error message into a YAML template by enclosing the example regex in single quotes instead.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
