### PR TITLE
Add SSM Parameter Type Values for Rule 2510.

### DIFF
--- a/src/cfnlint/rules/resources/ectwo/Subnet.py
+++ b/src/cfnlint/rules/resources/ectwo/Subnet.py
@@ -42,7 +42,8 @@ class Subnet(CloudFormationLintRule):
         matches = []
         allowed_types = [
             'AWS::EC2::AvailabilityZone::Name',
-            'String'
+            'String',
+            'AWS::SSM::Parameter::Value<AWS::EC2::AvailabilityZone::Name>'
         ]
         if value in resources:
             message = 'AvailabilityZone can\'t use a Ref to a resource for {0}'


### PR DESCRIPTION
According to https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html

AWS::SSM::Parameter::Value<AWS-specific parameter type>
A Systems Manager parameter whose value is an AWS-specific parameter type. For example, the following specifies the AWS::EC2::KeyPair::KeyName type:

AWS::SSM::Parameter::Value<AWS::EC2::KeyPair::KeyPairName>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
