### PR TITLE
When ref no value don't error for bad property

### DIFF
--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -239,6 +239,8 @@ class Properties(CloudFormationLintRule):
                             proppath + cond_value['Path'], root))
                 elif text.is_function_returning_object():
                     self.logger.debug('Ran into function "%s".  Skipping remaining checks', prop)
+                elif len(text) == 1 and prop in 'Ref' and text.get(prop) == 'AWS::NoValue':
+                    pass
                 elif not supports_additional_properties:
                     message = 'Invalid Property %s' % ('/'.join(map(str, proppath)))
                     matches.append(RuleMatch(proppath, message))

--- a/test/fixtures/templates/bad/generic.yaml
+++ b/test/fixtures/templates/bad/generic.yaml
@@ -200,6 +200,15 @@ Resources:
       GroupDescription: test
       SecurityGroupIngress:
       - Fn::FindInMap: [ runtime, !Ref 'AWS::Region', production ]
+  PermitAllInbound:
+    Type: AWS::EC2::NetworkAclEntry
+    Properties:
+      CidrBlock: 10.0.0.0/16
+      Icmp: !Ref AWS::NoValue
+      NetworkAclId: '1'
+      RuleNumber: 1
+      Protocol: 1
+      RuleAction: allow
 Outputs:
   myOutput:
     Value: !GetAtt ElasticLoadBalancer.CanonicalHostedZoneName


### PR DESCRIPTION
*Issue #, if available:*
Fix #1031

*Description of changes:*
- Don't fail on rule E3002 when property has a value of !Ref: AWS::NoValue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
