### PR TITLE
Transform when Transform is a list of 1 and its serverless

### DIFF
--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -1334,7 +1334,15 @@ class Runner(object):
         # Don't call transformation if Transform is not specified to prevent
         # useless execution of the transformation.
         # Currently locked in to SAM specific
-        if transform_type == 'AWS::Serverless-2016-10-31':
+        if transform_type:
+            if isinstance(transform_type, list):
+                if len(transform_type) != 1:
+                    return matches
+                if transform_type[0] != 'AWS::Serverless-2016-10-31':
+                    return matches
+            if transform_type != 'AWS::Serverless-2016-10-31':
+                return matches
+
             # Save the Globals section so its available for rule processing
             self.cfn.transform_pre['Globals'] = self.cfn.template.get('Globals', {})
             transform = Transform(self.filename, self.cfn.template, self.cfn.regions[0])

--- a/test/fixtures/templates/good/transform/list_transform.yaml
+++ b/test/fixtures/templates/good/transform/list_transform.yaml
@@ -1,0 +1,23 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Transform:
+  - AWS::Serverless-2016-10-31
+
+Parameters:
+  Stage1:
+    Description: Environment stage (deployment phase)
+    Type: String
+    AllowedValues:
+      - beta
+      - prod
+
+Resources:
+  SkillFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: '.'
+      Handler: main.handler
+      Runtime: python3.7
+      Timeout: 30
+      MemorySize: 128
+      AutoPublishAlias: !Ref Stage1

--- a/test/fixtures/templates/good/transform/list_transform_many.yaml
+++ b/test/fixtures/templates/good/transform/list_transform_many.yaml
@@ -1,0 +1,24 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Transform:
+  - AWS::Serverless-2016-10-31
+  - TestTransform
+
+Parameters:
+  Stage1:
+    Description: Environment stage (deployment phase)
+    Type: String
+    AllowedValues:
+      - beta
+      - prod
+
+Resources:
+  SkillFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: '.'
+      Handler: main.handler
+      Runtime: python3.7
+      Timeout: 30
+      MemorySize: 128
+      AutoPublishAlias: !Ref Stage1

--- a/test/fixtures/templates/good/transform/list_transform_not_sam.yaml
+++ b/test/fixtures/templates/good/transform/list_transform_not_sam.yaml
@@ -1,0 +1,16 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Transform:
+  - TestTransform
+
+Resources:
+  SkillFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        ZipFile: '.'
+      Handler: main.handler
+      Runtime: python3.7
+      Timeout: 30
+      MemorySize: 128
+      Role: arn:aws:iam::123456789012:role/role-name

--- a/test/integration/test_good_templates.py
+++ b/test/integration/test_good_templates.py
@@ -65,6 +65,18 @@ class TestQuickStartTemplates(BaseTestCase):
             'transform_serverless_globals': {
                 'filename': 'test/fixtures/templates/good/transform_serverless_globals.yaml',
                 'failures': 1
+            },
+            'transform_list': {
+                'filename': 'test/fixtures/templates/good/transform/list_transform.yaml',
+                'failures': 0
+            },
+            'transform_list_many': {
+                'filename': 'test/fixtures/templates/good/transform/list_transform_many.yaml',
+                'failures': 0
+            },
+            'transform_list_not_sam': {
+                'filename': 'test/fixtures/templates/good/transform/list_transform_not_sam.yaml',
+                'failures': 0
             }
         }
 


### PR DESCRIPTION
*Issue #, if available:*
Fix #1033
*Description of changes:*
- Support Transforming a template when the transform is a list of 1 and that 1 is serverless

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
