### PR TITLE
cn-northwest-1 availability zones

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -67,6 +67,7 @@ AVAILABILITY_ZONES = [
     'ap-southeast-2a', 'ap-southeast-2b', 'ap-southeast-2c',
     'ap-south-1a', 'ap-south-1b', 'ap-south-1c',
     'cn-north-1a', 'cn-north-1b',
+    'cn-northwest-1a', 'cn-northwest-1b', 'cn-northwest-1c',
     'eu-west-3a', 'eu-west-3b', 'eu-west-3c',
     'us-gov-west-1a', 'us-gov-west-1b', 'us-gov-west-1c',
     'us-gov-east-1a', 'us-gov-east-1b', 'us-gov-east-1c',


### PR DESCRIPTION
```shell
export AWS_DEFAULT_REGION=cn-north-1
aws ec2 describe-regions | pcregrep -o1 '"RegionName": "(.*)"' | xargs -L1 bash -c 'aws ec2 describe-availability-zones --region $0 | grep "ZoneName"' | grep "cn-"

            "ZoneName": "cn-north-1a",
            "ZoneName": "cn-north-1b",
            "ZoneName": "cn-northwest-1a",
            "ZoneName": "cn-northwest-1b",
            "ZoneName": "cn-northwest-1c",
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
