### PR TITLE
me-south-1 availability zones

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -72,7 +72,8 @@ AVAILABILITY_ZONES = [
     'us-gov-west-1a', 'us-gov-west-1b', 'us-gov-west-1c',
     'us-gov-east-1a', 'us-gov-east-1b', 'us-gov-east-1c',
     'eu-north-1a', 'eu-north-1b', 'eu-north-1c',
-    'ap-east-1a', 'ap-east-1b', 'ap-east-1c'
+    'ap-east-1a', 'ap-east-1b', 'ap-east-1c',
+    'me-south-1a', 'me-south-1b', 'me-south-1c'
 ]
 
 FUNCTIONS = [


### PR DESCRIPTION
```shell
aws ec2 describe-availability-zones --region me-south-1 | grep '"ZoneName"'
            "ZoneName": "me-south-1a",
            "ZoneName": "me-south-1b",
            "ZoneName": "me-south-1c",
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
