### PR TITLE
Update HealthCheckTimeoutSeconds to reflect correct (new) values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -16862,7 +16862,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -22830,7 +22833,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -34247,7 +34247,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -45526,7 +45529,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -30553,7 +30553,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -40933,7 +40936,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -18729,7 +18729,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -25143,7 +25146,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -29185,7 +29185,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -40029,7 +40032,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -30836,7 +30836,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -41610,7 +41613,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -34178,7 +34178,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -45733,7 +45736,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -25910,7 +25910,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -34994,7 +34997,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/cn-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-north-1.json
@@ -18900,7 +18900,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -25051,7 +25054,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
@@ -17703,7 +17703,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -23023,7 +23026,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -34284,7 +34284,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -46132,7 +46135,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -19631,7 +19631,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -27093,7 +27096,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -35789,7 +35789,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -47965,7 +47968,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -29141,7 +29141,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -39413,7 +39416,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -23341,7 +23341,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -31816,7 +31819,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -23694,7 +23694,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -32486,7 +32489,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -35845,7 +35845,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -48040,7 +48043,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -31844,7 +31844,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -42845,7 +42848,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -17590,7 +17590,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -23464,7 +23467,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -18527,7 +18527,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -26006,7 +26009,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -25963,7 +25963,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -35249,7 +35252,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -35772,7 +35772,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthythresholdcount",
           "PrimitiveType": "Integer",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Mutable",
+          "Value": {
+            "ValueType": "TargetGroupHealthyThresholdCount"
+          }
         },
         "Matcher": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-matcher",
@@ -47942,7 +47945,11 @@
       }
     },
     "TargetGroupHealthCheckTimeoutSeconds": {
-      "NumberMax": 60,
+      "NumberMax": 120,
+      "NumberMin": 2
+    },
+    "TargetGroupHealthyThresholdCount": {
+      "NumberMax": 10,
       "NumberMin": 2
     },
     "TransitGatewayEnabled": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -2024,7 +2024,11 @@
         }
       },
       "TargetGroupHealthCheckTimeoutSeconds": {
-        "NumberMax": 60,
+        "NumberMax": 120,
+        "NumberMin": 2
+      },
+      "TargetGroupHealthyThresholdCount": {
+        "NumberMax": 10,
         "NumberMin": 2
       },
       "TransitGatewayEnabled": {

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -1761,6 +1761,13 @@
   },
   {
     "op": "add",
+    "path": "/ResourceTypes/AWS::ElasticLoadBalancingV2::TargetGroup/Properties/HealthyThresholdCount/Value",
+    "value": {
+      "ValueType": "TargetGroupHealthyThresholdCount"
+    }
+  },
+  {
+    "op": "add",
     "path": "/ResourceTypes/AWS::Events::Rule/Properties/State/Value",
     "value": {
       "ValueType": "DefaultEnabledState"


### PR DESCRIPTION
*Issue https://github.com/aws-cloudformation/cfn-python-lint/issues/1075*

Correct the max. value of the `AWS::ElasticLoadBalancingV2::TargetGroup` HealthCheckTimeoutSeconds according to [documentation(https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-healthchecktimeoutseconds)

Also added the min/max of the `HealthyThresholdCount ` while at it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
