### PR TITLE
Only check for stdin if templates isn't defined in the config

### DIFF
--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -140,7 +140,7 @@ def get_args_filenames(cli_args):
         print(rules)
         exit(0)
 
-    if not sys.stdin.isatty():
+    if not sys.stdin.isatty() and not config.templates:
         return(config, [None], formatter)
 
     if not config.templates:

--- a/test/module/core/test_run_cli.py
+++ b/test/module/core/test_run_cli.py
@@ -92,6 +92,10 @@ class TestCli(BaseTestCase):
             (_, filenames, _) = cfnlint.core.get_args_filenames([])
             assert filenames == [None]
 
+        with patch('sys.stdin', StringIO(file_content)):
+            (_, filenames, _) = cfnlint.core.get_args_filenames(['--template', filename])
+            assert filenames == [filename]
+
     @patch('cfnlint.config.ConfigFileArgs._read_config', create=True)
     def test_template_config(self, yaml_mock):
         """Test template config"""


### PR DESCRIPTION
*Issue #, if available:*
Fix #1080
*Description of changes:*
- Only check stdin for a template to lint if templates aren't a supplied parameter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
