### PR TITLE
Don't check for required attributes when spec doesn't have properties

### DIFF
--- a/src/cfnlint/rules/resources/properties/Required.py
+++ b/src/cfnlint/rules/resources/properties/Required.py
@@ -71,6 +71,10 @@ class Required(CloudFormationLintRule):
                             self.propertycheck(
                                 item, property_type, parenttype, resourcename,
                                 tree[:] + [index], root))
+            else:
+                # this isn't a standard type in the CloudFormation spec so we
+                # can't check required so skip
+                return matches
 
         if not isinstance(text, dict):
             # Covered with Properties not with Required
@@ -116,7 +120,8 @@ class Required(CloudFormationLintRule):
                 if resourcespec[prop]['Required']:
                     if prop not in value:
                         message = 'Property {0} missing at {1}'
-                        matches.append(RuleMatch(path, message.format(prop, '/'.join(map(str, path)))))
+                        matches.append(RuleMatch(path, message.format(
+                            prop, '/'.join(map(str, path)))))
 
             # For all specified properties, check all nested properties
             for prop in value:

--- a/test/fixtures/templates/good/resources/properties/required.yaml
+++ b/test/fixtures/templates/good/resources/properties/required.yaml
@@ -1,0 +1,21 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Deploy resources for the SFTP managed service'
+
+Parameters:
+  SSHPublicKey:
+    Type: String
+    Description: 'SSH public key of the SFTP transfer user'
+
+Resources:
+  SFTPDTRFUser:
+    Type: AWS::Transfer::User
+    Properties:
+      UserName: test
+      ServerId: s-123456
+      Role: arn:aws:iam:etc
+      SshPublicKeys:
+        - !Ref SSHPublicKey  # Don't fail when using a dict on a non standard spec resource
+      Tags:
+        - Key: Issue
+          Value: https://github.com/aws-cloudformation/cfn-python-lint/issues/1088

--- a/test/rules/resources/properties/test_required.py
+++ b/test/rules/resources/properties/test_required.py
@@ -22,10 +22,14 @@ from ... import BaseRuleTestCase
 
 class TestResourceConfiguration(BaseRuleTestCase):
     """Test Resource Properties"""
+
     def setUp(self):
         """Setup"""
         super(TestResourceConfiguration, self).setUp()
         self.collection.register(Required())
+        self.success_templates = [
+            'test/fixtures/templates/good/resources/properties/required.yaml',
+        ]
 
     def test_file_positive(self):
         """Test Positive"""
@@ -42,6 +46,7 @@ class TestResourceConfiguration(BaseRuleTestCase):
 
 class TestSpecifiedCustomResourceRequiredProperties(TestResourceConfiguration):
     """Test Custom Resource Required Properties when override spec is provided"""
+
     def setUp(self):
         """Setup"""
         super(TestSpecifiedCustomResourceRequiredProperties, self).setUp()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Don't check for required attributes when spec doesn't have properties

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
