### PR TITLE
Move Rules classes into the rules directory from init

### DIFF
--- a/docs/getting_started/rules.md
+++ b/docs/getting_started/rules.md
@@ -56,8 +56,8 @@ Use the following skeleton code as a starting point of your new rule:
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class MyNewRule(CloudFormationLintRule):

--- a/examples/rules/PropertiesTagsIncluded.py
+++ b/examples/rules/PropertiesTagsIncluded.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 import cfnlint.helpers
 
 

--- a/examples/rules/PropertiesTagsRequired.py
+++ b/examples/rules/PropertiesTagsRequired.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class PropertiesTagsRequired(CloudFormationLintRule):

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -18,7 +18,7 @@ import logging
 import os
 import sys
 from jsonschema.exceptions import ValidationError
-from cfnlint import RulesCollection
+from cfnlint.rules import RulesCollection
 import cfnlint.config
 import cfnlint.formatters
 import cfnlint.decode

--- a/src/cfnlint/decode/cfn_json.py
+++ b/src/cfnlint/decode/cfn_json.py
@@ -74,9 +74,9 @@ class JSONDecodeError(ValueError):
         self.pos = pos
         self.lineno = lineno
         self.colno = colno
-        self.match = cfnlint.Match(
+        self.match = cfnlint.rules.Match(
             lineno, colno + 1, lineno,
-            colno + 1 + len(key), '', cfnlint.ParseError(), message=msg)
+            colno + 1 + len(key), '', cfnlint.rules.ParseError(), message=msg)
 
     def __reduce__(self):
         return self.__class__, (self.msg, self.doc, self.pos)

--- a/src/cfnlint/decode/cfn_yaml.py
+++ b/src/cfnlint/decode/cfn_yaml.py
@@ -47,6 +47,7 @@ class CfnParseError(ConstructorError):
     """
     Error thrown when the template contains Cfn Error
     """
+
     def __init__(self, filename, message, line_number, column_number, key=' '):
 
         # Call the base class constructor with the parameters it needs
@@ -57,9 +58,9 @@ class CfnParseError(ConstructorError):
         self.line_number = line_number
         self.column_number = column_number
         self.message = message
-        self.match = cfnlint.Match(
+        self.match = cfnlint.rules.Match(
             line_number + 1, column_number + 1, line_number + 1,
-            column_number + 1 + len(key), filename, cfnlint.ParseError(), message=message)
+            column_number + 1 + len(key), filename, cfnlint.rules.ParseError(), message=message)
 
 
 class NodeConstructor(SafeConstructor):
@@ -91,7 +92,8 @@ class NodeConstructor(SafeConstructor):
             if key in mapping:
                 raise CfnParseError(
                     self.filename,
-                    'Duplicate resource found "{}" (line {})'.format(key, key_node.start_mark.line + 1),
+                    'Duplicate resource found "{}" (line {})'.format(
+                        key, key_node.start_mark.line + 1),
                     key_node.start_mark.line, key_node.start_mark.column, key)
             mapping[key] = value
 
@@ -112,7 +114,8 @@ class NodeConstructor(SafeConstructor):
         """Throw a null error"""
         raise CfnParseError(
             self.filename,
-            'Null value at line {0} column {1}'.format(node.start_mark.line + 1, node.start_mark.column + 1),
+            'Null value at line {0} column {1}'.format(
+                node.start_mark.line + 1, node.start_mark.column + 1),
             node.start_mark.line, node.start_mark.column, ' ')
 
 
@@ -138,6 +141,7 @@ class MarkedLoader(Reader, Scanner, Parser, Composer, NodeConstructor, Resolver)
     Class for marked loading YAML
     """
     # pylint: disable=non-parent-init-called,super-init-not-called
+
     def __init__(self, stream, filename):
         Reader.__init__(self, stream)
         Scanner.__init__(self)

--- a/src/cfnlint/formatters/__init__.py
+++ b/src/cfnlint/formatters/__init__.py
@@ -15,7 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import json
-from cfnlint import Match
+from cfnlint.rules import Match
+
 
 class BaseFormatter(object):
     """Base Formatter class"""

--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -292,7 +292,7 @@ def load_plugins(directory):
                 mod = imp.load_module(pluginname, fh, filename, desc)
                 for _, clazz in inspect.getmembers(mod, inspect.isclass):
                     method_resolution = inspect.getmro(clazz)
-                    if [clz for clz in method_resolution[1:] if clz.__module__ == 'cfnlint' and clz.__name__ == 'CloudFormationLintRule']:
+                    if [clz for clz in method_resolution[1:] if clz.__module__ in ('cfnlint', 'cfnlint.rules') and clz.__name__ == 'CloudFormationLintRule']:
                         # create and instance of subclasses of CloudFormationLintRule
                         obj = clazz()
                         result.append(obj)

--- a/src/cfnlint/maintenance.py
+++ b/src/cfnlint/maintenance.py
@@ -117,17 +117,17 @@ def update_documentation(rules):
         rule_output = '| {0}<a name="{0}"></a> | {1} | {2} | {3} | [Source]({4}) | {5} |\n'
 
         # Add system Errors (hardcoded)
-        parseerror = cfnlint.ParseError()
+        parseerror = cfnlint.rules.ParseError()
         tags = ','.join('`{0}`'.format(tag) for tag in parseerror.tags)
         new_file.write(rule_output.format(
             parseerror.id, parseerror.shortdesc, parseerror.description, '', '', tags))
 
-        transformerror = cfnlint.TransformError()
+        transformerror = cfnlint.rules.TransformError()
         tags = ','.join('`{0}`'.format(tag) for tag in transformerror.tags)
         new_file.write(rule_output.format(
             transformerror.id, transformerror.shortdesc, transformerror.description, '', '', tags))
 
-        ruleerror = cfnlint.RuleError()
+        ruleerror = cfnlint.rules.RuleError()
         tags = ','.join('`{0}`'.format(tag) for tag in ruleerror.tags)
         new_file.write(
             rule_output.format(ruleerror.id, ruleerror.shortdesc, ruleerror.description, '', '', tags))

--- a/src/cfnlint/rules/__init__.py
+++ b/src/cfnlint/rules/__init__.py
@@ -14,3 +14,435 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+import os
+import logging
+from datetime import datetime
+import traceback
+import cfnlint.helpers
+from cfnlint.decode.node import TemplateAttributeError
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CloudFormationLintRule(object):
+    """CloudFormation linter rules"""
+
+    id = ''
+    shortdesc = ''
+    description = ''
+    source_url = ''
+    tags = []
+    experimental = False
+
+    logger = logging.getLogger(__name__)
+
+    def __init__(self):
+        self.resource_property_types = []
+        self.resource_sub_property_types = []
+        self.config = {}  # `-X E3012:strict=false`... Show more
+        self.config_definition = {}
+
+    def __repr__(self):
+        return '%s: %s' % (self.id, self.shortdesc)
+
+    def verbose(self):
+        """Verbose output"""
+        return '%s: %s\n%s' % (self.id, self.shortdesc, self.description)
+
+    def initialize(self, cfn):
+        """Initialize the rule"""
+
+    def configure(self, configs=None):
+        """ Set the configuration """
+
+        # set defaults
+        if isinstance(self.config_definition, dict):
+            for config_name, config_values in self.config_definition.items():
+                self.config[config_name] = config_values['default']
+
+        if isinstance(configs, dict):
+            for key, value in configs.items():
+                if key in self.config_definition:
+                    if self.config_definition[key]['type'] == 'boolean':
+                        self.config[key] = cfnlint.helpers.bool_compare(value, True)
+                    elif self.config_definition[key]['type'] == 'string':
+                        self.config[key] = str(value)
+                    elif self.config_definition[key]['type'] == 'integer':
+                        self.config[key] = int(value)
+
+    match = None
+    match_resource_properties = None
+    match_resource_sub_properties = None
+
+    # pylint: disable=E0213
+    def matching(match_type):
+        """ Does Logging for match functions """
+        def decorator(match_function):
+            """ The Actual Decorator """
+            def wrapper(self, filename, cfn, *args, **kwargs):
+                """Wrapper"""
+                matches = []
+
+                if not getattr(self, match_type):
+                    return []
+
+                if match_type == 'match_resource_properties':
+                    if args[1] not in self.resource_property_types:
+                        return []
+                elif match_type == 'match_resource_sub_properties':
+                    if args[1] not in self.resource_sub_property_types:
+                        return []
+
+                start = datetime.now()
+                LOGGER.debug('Starting match function for rule %s at %s', self.id, start)
+                # pylint: disable=E1102
+                results = match_function(self, filename, cfn, *args, **kwargs)
+                LOGGER.debug('Complete match function for rule %s at %s.  Ran in %s',
+                             self.id, datetime.now(), datetime.now() - start)
+                LOGGER.debug('Results from rule %s are %s: ', self.id, results)
+
+                if results:
+                    for result in results:
+                        linenumbers = cfn.get_location_yaml(cfn.template, result.path)
+                        if linenumbers:
+                            matches.append(Match(
+                                linenumbers[0] + 1, linenumbers[1] + 1,
+                                linenumbers[2] + 1, linenumbers[3] + 1,
+                                filename, self, result.message, result))
+                        else:
+                            matches.append(Match(
+                                1, 1,
+                                1, 1,
+                                filename, self, result.message, result))
+
+                return matches
+            return wrapper
+        return decorator
+
+    @matching('match')
+    # pylint: disable=W0613
+    def matchall(self, filename, cfn):
+        """Match the entire file"""
+        return self.match(cfn)  # pylint: disable=E1102
+
+    @matching('match_resource_properties')
+    # pylint: disable=W0613
+    def matchall_resource_properties(self, filename, cfn, resource_properties, property_type, path):
+        """ Check for resource properties type """
+        return self.match_resource_properties(resource_properties, property_type, path, cfn)  # pylint: disable=E1102
+
+    @matching('match_resource_sub_properties')
+    # pylint: disable=W0613
+    def matchall_resource_sub_properties(self, filename, cfn, resource_properties, property_type, path):
+        """ Check for resource properties type """
+        return self.match_resource_sub_properties(resource_properties, property_type, path, cfn)  # pylint: disable=E1102
+
+
+class RulesCollection(object):
+    """Collection of rules"""
+
+    def __init__(self, ignore_rules=None, include_rules=None, configure_rules=None, include_experimental=False):
+        self.rules = []
+
+        # Whether "experimental" rules should be added
+        self.include_experimental = include_experimental
+
+        # Make Ignore Rules not required
+        self.ignore_rules = ignore_rules or []
+        self.include_rules = include_rules or []
+        self.configure_rules = configure_rules or []
+        # by default include 'W' and 'E'
+        # 'I' has to be included manually for backwards compabitility
+        self.include_rules.extend(['W', 'E'])
+
+    def register(self, rule):
+        """Register rules"""
+        if self.is_rule_enabled(rule.id, rule.experimental):
+            self.rules.append(rule)
+            if rule.id in self.configure_rules:
+                rule.configure(self.configure_rules[rule.id])
+
+    def __iter__(self):
+        return iter(self.rules)
+
+    def __len__(self):
+        return len(self.rules)
+
+    def extend(self, more):
+        """Extend rules"""
+        for rule in more:
+            if self.is_rule_enabled(rule.id, rule.experimental):
+                self.rules.append(rule)
+                if rule.id in self.configure_rules:
+                    rule.configure(self.configure_rules[rule.id])
+
+    def __repr__(self):
+        return '\n'.join([rule.verbose()
+                          for rule in sorted(self.rules, key=lambda x: x.id)])
+
+    def is_rule_enabled(self, rule_id, experimental):
+        """ Cheks if an individual rule is valid """
+        # Evaluate experimental rules
+        if experimental and not self.include_experimental:
+            return False
+
+        # Evaluate includes first:
+        include_filter = False
+        for include_rule in self.include_rules:
+            if rule_id.startswith(include_rule):
+                include_filter = True
+        if not include_filter:
+            return False
+        # Allowing ignoring of rules based on prefix to ignore checks
+        for ignore_rule in self.ignore_rules:
+            if rule_id.startswith(ignore_rule) and ignore_rule:
+                return False
+
+        return True
+
+    def run_check(self, check, filename, rule_id, *args):
+        """ Run a check """
+        try:
+            return check(*args)
+        except TemplateAttributeError as err:
+            LOGGER.debug(str(err))
+            return []
+        except Exception as err:  # pylint: disable=W0703
+            if self.is_rule_enabled('E0002', False):
+                # In debug mode, print the error include complete stack trace
+                if LOGGER.getEffectiveLevel() == logging.DEBUG:
+                    error_message = traceback.format_exc()
+                else:
+                    error_message = str(err)
+                message = 'Unknown exception while processing rule {}: {}'
+                return [
+                    Match(
+                        1, 1, 1, 1,
+                        filename, RuleError(), message.format(rule_id, error_message))]
+
+    def resource_property(self, filename, cfn, path, properties, resource_type, property_type):
+        """Run loops in resource checks for embedded properties"""
+        matches = []
+        property_spec = cfnlint.helpers.RESOURCE_SPECS['us-east-1'].get('PropertyTypes')
+        if property_type == 'Tag':
+            property_spec_name = 'Tag'
+        else:
+            property_spec_name = '%s.%s' % (resource_type, property_type)
+
+        if property_spec_name in property_spec:
+            for rule in self.rules:
+                matches.extend(
+                    self.run_check(
+                        rule.matchall_resource_sub_properties, filename, rule.id,
+                        filename, cfn, properties, property_spec_name, path
+                    )
+                )
+
+            resource_spec_properties = property_spec.get(property_spec_name, {}).get('Properties')
+            if not resource_spec_properties:
+                if property_spec.get(property_spec_name, {}).get('Type') == 'List':
+                    if isinstance(properties, list):
+                        property_type = property_spec.get(property_spec_name, {}).get('ItemType')
+                        for index, item in enumerate(properties):
+                            matches.extend(self.resource_property(
+                                filename, cfn,
+                                path[:] + [index],
+                                item, resource_type, property_type))
+                return matches
+            if isinstance(properties, dict):
+                for resource_property, resource_property_value in properties.items():
+                    property_path = path[:] + [resource_property]
+                    resource_spec_property = resource_spec_properties.get(resource_property, {})
+                    if resource_property not in resource_spec_properties:
+                        if resource_property == 'Fn::If':
+                            if isinstance(resource_property_value, list):
+                                if len(resource_property_value) == 3:
+                                    for index, c_value in enumerate(resource_property_value[1:]):
+                                        matches.extend(self.resource_property(
+                                            filename, cfn,
+                                            property_path[:] + [index + 1],
+                                            c_value, resource_type, property_type))
+                        continue
+                    if (resource_spec_property.get('Type') == 'List' and
+                            not resource_spec_properties.get('PrimitiveItemType')):
+                        if isinstance(resource_property_value, (list)):
+                            for index, value in enumerate(resource_property_value):
+                                matches.extend(self.resource_property(
+                                    filename, cfn,
+                                    property_path[:] + [index],
+                                    value, resource_type, resource_spec_property.get('ItemType')
+                                ))
+                    elif resource_spec_property.get('Type'):
+                        if isinstance(resource_property_value, (dict)):
+                            matches.extend(self.resource_property(
+                                filename, cfn,
+                                property_path,
+                                resource_property_value,
+                                resource_type, resource_spec_property.get('Type')
+                            ))
+
+        return matches
+
+    def run_resource(self, filename, cfn, resource_type, resource_properties, path):
+        """Run loops in resource checks for embedded properties"""
+        matches = []
+        resource_spec = cfnlint.helpers.RESOURCE_SPECS['us-east-1'].get('ResourceTypes')
+        if resource_properties and resource_type in resource_spec:
+            resource_spec_properties = resource_spec.get(resource_type, {}).get('Properties')
+            for resource_property, resource_property_value in resource_properties.items():
+                resource_spec_property = resource_spec_properties.get(resource_property, {})
+                if resource_property not in resource_spec_properties:
+                    if resource_property == 'Fn::If':
+                        if isinstance(resource_property_value, list):
+                            if len(resource_property_value) == 3:
+                                for index, c_resource_properties in enumerate(resource_property_value[1:]):
+                                    matches.extend(self.run_resource(
+                                        filename, cfn, resource_type, c_resource_properties,
+                                        path[:] + [resource_property, index + 1]))
+                    continue
+                if (resource_spec_property.get('Type') == 'List' and
+                        not resource_spec_properties.get('PrimitiveItemType')):
+                    if isinstance(resource_property_value, (list)):
+                        for index, value in enumerate(resource_property_value):
+                            matches.extend(self.resource_property(
+                                filename, cfn,
+                                path[:] + [resource_property, index],
+                                value, resource_type, resource_spec_property.get('ItemType')
+                            ))
+                elif resource_spec_property.get('Type'):
+                    if isinstance(resource_property_value, (dict)):
+                        matches.extend(
+                            self.resource_property(
+                                filename, cfn,
+                                path[:] + [resource_property],
+                                resource_property_value,
+                                resource_type, resource_spec_property.get('Type')
+                            ))
+
+        return matches
+
+    def run(self, filename, cfn):
+        """Run rules"""
+        matches = []
+        for rule in self.rules:
+            rule.initialize(cfn)
+
+        for rule in self.rules:
+            matches.extend(
+                self.run_check(
+                    rule.matchall, filename, rule.id, filename, cfn
+                )
+            )
+
+        for resource_name, resource_attributes in cfn.get_resources().items():
+            resource_type = resource_attributes.get('Type')
+            resource_properties = resource_attributes.get('Properties', {})
+            path = ['Resources', resource_name, 'Properties']
+            for rule in self.rules:
+                matches.extend(
+                    self.run_check(
+                        rule.matchall_resource_properties, filename, rule.id,
+                        filename, cfn, resource_properties, resource_type, path
+                    )
+                )
+
+            matches.extend(
+                self.run_resource(
+                    filename, cfn, resource_type, resource_properties, path))
+
+        return matches
+
+    def create_from_directory(self, rulesdir):
+        """Create rules from directory"""
+        result = []
+        if rulesdir != '':
+            result = cfnlint.helpers.load_plugins(os.path.expanduser(rulesdir))
+
+        for rule in result:
+            if rule.id in self.configure_rules:
+                rule.configure(self.configure_rules[rule.id])
+
+        self.extend(result)
+
+
+class RuleMatch(object):
+    """Rules Error"""
+
+    def __init__(self, path, message, **kwargs):
+        """Init"""
+        self.path = path
+        self.path_string = '/'.join(map(str, path))
+        self.message = message
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    def __eq__(self, item):
+        """Override unique"""
+        return ((self.path, self.message) == (item.path, item.message))
+
+    def __hash__(self):
+        """Hash for comparisons"""
+        return hash((self.path, self.message))
+
+
+class Match(object):  # pylint: disable=R0902
+    """Match Classes"""
+
+    def __init__(
+            self, linenumber, columnnumber, linenumberend,
+            columnnumberend, filename, rule, message=None, rulematch_obj=None):
+        """Init"""
+        self.linenumber = linenumber
+        self.columnnumber = columnnumber
+        self.linenumberend = linenumberend
+        self.columnnumberend = columnnumberend
+        self.filename = filename
+        self.rule = rule
+        self.message = message  # or rule.shortdesc
+        if rulematch_obj:
+            for k, v in vars(rulematch_obj).items():
+                if not hasattr(self, k):
+                    setattr(self, k, v)
+
+    def __repr__(self):
+        """Represent"""
+        formatstr = u'[{0}] ({1}) matched {2}:{3}'
+        return formatstr.format(self.rule, self.message,
+                                self.filename, self.linenumber)
+
+    def __eq__(self, item):
+        """Override equal to compare matches"""
+        return (
+            (
+                self.linenumber, self.columnnumber, self.rule.id, self.message
+            ) ==
+            (
+                item.linenumber, item.columnnumber, item.rule.id, item.message
+            ))
+
+
+class ParseError(CloudFormationLintRule):
+    """Parse Lint Rule"""
+    id = 'E0000'
+    shortdesc = 'Parsing error found when parsing the template'
+    description = 'Checks for Null values and Duplicate values in resources'
+    source_url = 'https://github.com/aws-cloudformation/cfn-python-lint'
+    tags = ['base']
+
+
+class TransformError(CloudFormationLintRule):
+    """Transform Lint Rule"""
+    id = 'E0001'
+    shortdesc = 'Error found when transforming the template'
+    description = 'Errors found when performing transformation on the template'
+    source_url = 'https://github.com/aws-cloudformation/cfn-python-lint'
+    tags = ['base', 'transform']
+
+
+class RuleError(CloudFormationLintRule):
+    """Rule processing Error"""
+    id = 'E0002'
+    shortdesc = 'Error processing rule on the template'
+    description = 'Errors found when processing a rule on the template'
+    source_url = 'https://github.com/aws-cloudformation/cfn-python-lint'
+    tags = ['base', 'rule']

--- a/src/cfnlint/rules/conditions/And.py
+++ b/src/cfnlint/rules/conditions/And.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class And(CloudFormationLintRule):

--- a/src/cfnlint/rules/conditions/Configuration.py
+++ b/src/cfnlint/rules/conditions/Configuration.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Configuration(CloudFormationLintRule):

--- a/src/cfnlint/rules/conditions/Equals.py
+++ b/src/cfnlint/rules/conditions/Equals.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Equals(CloudFormationLintRule):

--- a/src/cfnlint/rules/conditions/Exists.py
+++ b/src/cfnlint/rules/conditions/Exists.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Exists(CloudFormationLintRule):

--- a/src/cfnlint/rules/conditions/Not.py
+++ b/src/cfnlint/rules/conditions/Not.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Not(CloudFormationLintRule):

--- a/src/cfnlint/rules/conditions/Or.py
+++ b/src/cfnlint/rules/conditions/Or.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Or(CloudFormationLintRule):

--- a/src/cfnlint/rules/conditions/Used.py
+++ b/src/cfnlint/rules/conditions/Used.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Used(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/Base64.py
+++ b/src/cfnlint/rules/functions/Base64.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Base64(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/Cidr.py
+++ b/src/cfnlint/rules/functions/Cidr.py
@@ -16,8 +16,8 @@
 """
 import re
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 from cfnlint.helpers import REGEX_CIDR
 

--- a/src/cfnlint/rules/functions/DynamicReferenceSecureString.py
+++ b/src/cfnlint/rules/functions/DynamicReferenceSecureString.py
@@ -16,8 +16,8 @@
 """
 import re
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 import cfnlint.helpers
 
 

--- a/src/cfnlint/rules/functions/FindInMap.py
+++ b/src/cfnlint/rules/functions/FindInMap.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class FindInMap(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/FindInMapKeys.py
+++ b/src/cfnlint/rules/functions/FindInMapKeys.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class FindInMapKeys(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/GetAtt.py
+++ b/src/cfnlint/rules/functions/GetAtt.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 import cfnlint.helpers
 
 

--- a/src/cfnlint/rules/functions/GetAz.py
+++ b/src/cfnlint/rules/functions/GetAz.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class GetAz(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/If.py
+++ b/src/cfnlint/rules/functions/If.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class If(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/ImportValue.py
+++ b/src/cfnlint/rules/functions/ImportValue.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class ImportValue(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/Join.py
+++ b/src/cfnlint/rules/functions/Join.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import RESOURCE_SPECS
 
 

--- a/src/cfnlint/rules/functions/Not.py
+++ b/src/cfnlint/rules/functions/Not.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Not(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/Ref.py
+++ b/src/cfnlint/rules/functions/Ref.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Ref(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/RefExist.py
+++ b/src/cfnlint/rules/functions/RefExist.py
@@ -16,8 +16,8 @@
 """
 import re
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class RefExist(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/RefInCondition.py
+++ b/src/cfnlint/rules/functions/RefInCondition.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class RefInCondition(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/RelationshipConditions.py
+++ b/src/cfnlint/rules/functions/RelationshipConditions.py
@@ -16,8 +16,8 @@
 """
 import six
 from cfnlint.helpers import PSEUDOPARAMS
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class RelationshipConditions(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/Select.py
+++ b/src/cfnlint/rules/functions/Select.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Select(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/Split.py
+++ b/src/cfnlint/rules/functions/Split.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Split(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/Sub.py
+++ b/src/cfnlint/rules/functions/Sub.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Sub(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/SubNeeded.py
+++ b/src/cfnlint/rules/functions/SubNeeded.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 class SubNeeded(CloudFormationLintRule):
     """Check if a substitution string exists without a substitution function"""

--- a/src/cfnlint/rules/functions/SubParametersUsed.py
+++ b/src/cfnlint/rules/functions/SubParametersUsed.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class SubParametersUsed(CloudFormationLintRule):

--- a/src/cfnlint/rules/functions/SubUnneeded.py
+++ b/src/cfnlint/rules/functions/SubUnneeded.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class SubUnneeded(CloudFormationLintRule):

--- a/src/cfnlint/rules/mappings/Configuration.py
+++ b/src/cfnlint/rules/mappings/Configuration.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Configuration(CloudFormationLintRule):

--- a/src/cfnlint/rules/mappings/KeyName.py
+++ b/src/cfnlint/rules/mappings/KeyName.py
@@ -16,8 +16,8 @@
 """
 import re
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import REGEX_ALPHANUMERIC
 
 

--- a/src/cfnlint/rules/mappings/LimitAttributes.py
+++ b/src/cfnlint/rules/mappings/LimitAttributes.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import LIMITS
 
 

--- a/src/cfnlint/rules/mappings/LimitName.py
+++ b/src/cfnlint/rules/mappings/LimitName.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import LIMITS
 
 

--- a/src/cfnlint/rules/mappings/LimitNumber.py
+++ b/src/cfnlint/rules/mappings/LimitNumber.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import LIMITS
 
 

--- a/src/cfnlint/rules/mappings/Name.py
+++ b/src/cfnlint/rules/mappings/Name.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import REGEX_ALPHANUMERIC
 
 

--- a/src/cfnlint/rules/mappings/Used.py
+++ b/src/cfnlint/rules/mappings/Used.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Used(CloudFormationLintRule):

--- a/src/cfnlint/rules/metadata/InterfaceConfiguration.py
+++ b/src/cfnlint/rules/metadata/InterfaceConfiguration.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class InterfaceConfiguration(CloudFormationLintRule):

--- a/src/cfnlint/rules/metadata/InterfaceParameterExists.py
+++ b/src/cfnlint/rules/metadata/InterfaceParameterExists.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class InterfaceParameterExists(CloudFormationLintRule):

--- a/src/cfnlint/rules/outputs/Configuration.py
+++ b/src/cfnlint/rules/outputs/Configuration.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Configuration(CloudFormationLintRule):

--- a/src/cfnlint/rules/outputs/Description.py
+++ b/src/cfnlint/rules/outputs/Description.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Description(CloudFormationLintRule):

--- a/src/cfnlint/rules/outputs/ImportValue.py
+++ b/src/cfnlint/rules/outputs/ImportValue.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class ImportValue(CloudFormationLintRule):

--- a/src/cfnlint/rules/outputs/LimitDescription.py
+++ b/src/cfnlint/rules/outputs/LimitDescription.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import LIMITS
 
 

--- a/src/cfnlint/rules/outputs/LimitName.py
+++ b/src/cfnlint/rules/outputs/LimitName.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import LIMITS
 
 

--- a/src/cfnlint/rules/outputs/LimitNumber.py
+++ b/src/cfnlint/rules/outputs/LimitNumber.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import LIMITS
 
 

--- a/src/cfnlint/rules/outputs/Name.py
+++ b/src/cfnlint/rules/outputs/Name.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import REGEX_ALPHANUMERIC
 
 

--- a/src/cfnlint/rules/outputs/Required.py
+++ b/src/cfnlint/rules/outputs/Required.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Required(CloudFormationLintRule):

--- a/src/cfnlint/rules/outputs/Value.py
+++ b/src/cfnlint/rules/outputs/Value.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import RESOURCE_SPECS
 
 

--- a/src/cfnlint/rules/parameters/AllowedValue.py
+++ b/src/cfnlint/rules/parameters/AllowedValue.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 from cfnlint.helpers import RESOURCE_SPECS
 

--- a/src/cfnlint/rules/parameters/Cidr.py
+++ b/src/cfnlint/rules/parameters/Cidr.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 from cfnlint.helpers import REGEX_CIDR
 

--- a/src/cfnlint/rules/parameters/CidrAllowedValues.py
+++ b/src/cfnlint/rules/parameters/CidrAllowedValues.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 from cfnlint.helpers import REGEX_CIDR
 

--- a/src/cfnlint/rules/parameters/Configuration.py
+++ b/src/cfnlint/rules/parameters/Configuration.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Configuration(CloudFormationLintRule):

--- a/src/cfnlint/rules/parameters/Default.py
+++ b/src/cfnlint/rules/parameters/Default.py
@@ -16,8 +16,8 @@
 """
 import re
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Default(CloudFormationLintRule):

--- a/src/cfnlint/rules/parameters/DefaultRef.py
+++ b/src/cfnlint/rules/parameters/DefaultRef.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class DefaultRef(CloudFormationLintRule):

--- a/src/cfnlint/rules/parameters/LambdaMemorySize.py
+++ b/src/cfnlint/rules/parameters/LambdaMemorySize.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class LambdaMemorySize(CloudFormationLintRule):

--- a/src/cfnlint/rules/parameters/LimitName.py
+++ b/src/cfnlint/rules/parameters/LimitName.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import LIMITS
 
 

--- a/src/cfnlint/rules/parameters/LimitNumber.py
+++ b/src/cfnlint/rules/parameters/LimitNumber.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import LIMITS
 
 

--- a/src/cfnlint/rules/parameters/LimitValue.py
+++ b/src/cfnlint/rules/parameters/LimitValue.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import LIMITS
 
 

--- a/src/cfnlint/rules/parameters/Name.py
+++ b/src/cfnlint/rules/parameters/Name.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import REGEX_ALPHANUMERIC
 
 

--- a/src/cfnlint/rules/parameters/Types.py
+++ b/src/cfnlint/rules/parameters/Types.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Types(CloudFormationLintRule):

--- a/src/cfnlint/rules/parameters/Used.py
+++ b/src/cfnlint/rules/parameters/Used.py
@@ -17,8 +17,8 @@
 from __future__ import unicode_literals
 import re
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Used(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/CircularDependency.py
+++ b/src/cfnlint/rules/resources/CircularDependency.py
@@ -16,8 +16,8 @@
 """
 import re
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class CircularDependency(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/Configuration.py
+++ b/src/cfnlint/rules/resources/Configuration.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 import cfnlint.helpers
 
 

--- a/src/cfnlint/rules/resources/DeletionPolicy.py
+++ b/src/cfnlint/rules/resources/DeletionPolicy.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class DeletionPolicy(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/DependsOn.py
+++ b/src/cfnlint/rules/resources/DependsOn.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class DependsOn(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/DependsOnObsolete.py
+++ b/src/cfnlint/rules/resources/DependsOnObsolete.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class DependsOnObsolete(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/LimitName.py
+++ b/src/cfnlint/rules/resources/LimitName.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import LIMITS
 
 

--- a/src/cfnlint/rules/resources/LimitNumber.py
+++ b/src/cfnlint/rules/resources/LimitNumber.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import LIMITS
 
 

--- a/src/cfnlint/rules/resources/Name.py
+++ b/src/cfnlint/rules/resources/Name.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import REGEX_ALPHANUMERIC
 
 

--- a/src/cfnlint/rules/resources/ServerlessTransform.py
+++ b/src/cfnlint/rules/resources/ServerlessTransform.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class ServerlessTransform(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/UpdateReplacePolicy.py
+++ b/src/cfnlint/rules/resources/UpdateReplacePolicy.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class UpdateReplacePolicy(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/cloudfront/Aliases.py
+++ b/src/cfnlint/rules/resources/cloudfront/Aliases.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import FUNCTIONS
 
 

--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
@@ -16,8 +16,8 @@
 """
 import re
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class CodepipelineStageActions(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStages.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStages.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class CodepipelineStages(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/dynamodb/BillingMode.py
+++ b/src/cfnlint/rules/resources/dynamodb/BillingMode.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class BillingMode(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/dynamodb/TableDeletionPolicy.py
+++ b/src/cfnlint/rules/resources/dynamodb/TableDeletionPolicy.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class TableDeletionPolicy(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/ectwo/Ebs.py
+++ b/src/cfnlint/rules/resources/ectwo/Ebs.py
@@ -16,8 +16,8 @@
 """
 import re
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Ebs(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/ectwo/RouteTableAssociation.py
+++ b/src/cfnlint/rules/resources/ectwo/RouteTableAssociation.py
@@ -16,8 +16,8 @@
 """
 from collections import defaultdict
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 import cfnlint.helpers
 
 

--- a/src/cfnlint/rules/resources/ectwo/SecurityGroupIngress.py
+++ b/src/cfnlint/rules/resources/ectwo/SecurityGroupIngress.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class SecurityGroupIngress(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/ectwo/Subnet.py
+++ b/src/cfnlint/rules/resources/ectwo/Subnet.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import AVAILABILITY_ZONES, REGEX_CIDR
 
 

--- a/src/cfnlint/rules/resources/ectwo/Vpc.py
+++ b/src/cfnlint/rules/resources/ectwo/Vpc.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 import cfnlint.helpers
 

--- a/src/cfnlint/rules/resources/elasticache/CacheClusterFailover.py
+++ b/src/cfnlint/rules/resources/elasticache/CacheClusterFailover.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 from cfnlint.helpers import bool_compare
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class CacheClusterFailover(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/elb/Elb.py
+++ b/src/cfnlint/rules/resources/elb/Elb.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Elb(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/events/RuleScheduleExpression.py
+++ b/src/cfnlint/rules/resources/events/RuleScheduleExpression.py
@@ -12,8 +12,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class RuleScheduleExpression(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/events/RuleTargetsLimit.py
+++ b/src/cfnlint/rules/resources/events/RuleTargetsLimit.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class RuleTargetsLimit(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/iam/Permissions.py
+++ b/src/cfnlint/rules/resources/iam/Permissions.py
@@ -17,8 +17,8 @@
 import json
 import six
 from cfnlint.helpers import convert_dict
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 import cfnlint.helpers
 

--- a/src/cfnlint/rules/resources/iam/Policy.py
+++ b/src/cfnlint/rules/resources/iam/Policy.py
@@ -18,8 +18,8 @@ import json
 from datetime import date
 import six
 from cfnlint.helpers import convert_dict
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Policy(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/iam/PolicyVersion.py
+++ b/src/cfnlint/rules/resources/iam/PolicyVersion.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 from datetime import date
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class PolicyVersion(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/iam/RefWithPath.py
+++ b/src/cfnlint/rules/resources/iam/RefWithPath.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class RefWithPath(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntime.py
+++ b/src/cfnlint/rules/resources/lmbd/DeprecatedRuntime.py
@@ -16,7 +16,7 @@
 """
 from datetime import datetime
 from cfnlint.helpers import load_resources
-from cfnlint import CloudFormationLintRule
+from cfnlint.rules import CloudFormationLintRule
 
 
 class DeprecatedRuntime(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEnd.py
+++ b/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEnd.py
@@ -16,7 +16,7 @@
 """
 from datetime import datetime
 from cfnlint.rules.resources.lmbd.DeprecatedRuntime import DeprecatedRuntime
-from cfnlint import RuleMatch
+from cfnlint.rules import RuleMatch
 
 
 class DeprecatedRuntimeEnd(DeprecatedRuntime):

--- a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEol.py
+++ b/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEol.py
@@ -16,7 +16,7 @@
 """
 from datetime import datetime
 from cfnlint.rules.resources.lmbd.DeprecatedRuntime import DeprecatedRuntime
-from cfnlint import RuleMatch
+from cfnlint.rules import RuleMatch
 
 
 class DeprecatedRuntimeEol(DeprecatedRuntime):

--- a/src/cfnlint/rules/resources/lmbd/EventsLogGroupName.py
+++ b/src/cfnlint/rules/resources/lmbd/EventsLogGroupName.py
@@ -12,8 +12,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class EventsLogGroupName(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/lmbd/FunctionMemorySize.py
+++ b/src/cfnlint/rules/resources/lmbd/FunctionMemorySize.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class FunctionMemorySize(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/properties/AllowedPattern.py
+++ b/src/cfnlint/rules/resources/properties/AllowedPattern.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 from cfnlint.helpers import RESOURCE_SPECS
 

--- a/src/cfnlint/rules/resources/properties/AllowedValue.py
+++ b/src/cfnlint/rules/resources/properties/AllowedValue.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 from cfnlint.helpers import RESOURCE_SPECS
 

--- a/src/cfnlint/rules/resources/properties/AtLeastOne.py
+++ b/src/cfnlint/rules/resources/properties/AtLeastOne.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 import cfnlint.helpers
 
 

--- a/src/cfnlint/rules/resources/properties/AvailabilityZone.py
+++ b/src/cfnlint/rules/resources/properties/AvailabilityZone.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class AvailabilityZone(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/properties/Exclusive.py
+++ b/src/cfnlint/rules/resources/properties/Exclusive.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 import cfnlint.helpers
 
 

--- a/src/cfnlint/rules/resources/properties/ImageId.py
+++ b/src/cfnlint/rules/resources/properties/ImageId.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class ImageId(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/properties/Inclusive.py
+++ b/src/cfnlint/rules/resources/properties/Inclusive.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 import cfnlint.helpers
 
 

--- a/src/cfnlint/rules/resources/properties/JsonSize.py
+++ b/src/cfnlint/rules/resources/properties/JsonSize.py
@@ -19,8 +19,8 @@ import json
 import re
 import six
 import cfnlint.helpers
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import RESOURCE_SPECS
 
 

--- a/src/cfnlint/rules/resources/properties/ListDuplicates.py
+++ b/src/cfnlint/rules/resources/properties/ListDuplicates.py
@@ -16,8 +16,8 @@
 """
 import hashlib
 import json
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 from cfnlint.helpers import RESOURCE_SPECS
 

--- a/src/cfnlint/rules/resources/properties/ListDuplicatesAllowed.py
+++ b/src/cfnlint/rules/resources/properties/ListDuplicatesAllowed.py
@@ -16,8 +16,8 @@
 """
 import hashlib
 import json
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 from cfnlint.helpers import RESOURCE_SPECS
 

--- a/src/cfnlint/rules/resources/properties/ListSize.py
+++ b/src/cfnlint/rules/resources/properties/ListSize.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 from cfnlint.helpers import RESOURCE_SPECS
 

--- a/src/cfnlint/rules/resources/properties/NumberSize.py
+++ b/src/cfnlint/rules/resources/properties/NumberSize.py
@@ -14,8 +14,8 @@
 """
 import sys
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 from cfnlint.helpers import RESOURCE_SPECS
 

--- a/src/cfnlint/rules/resources/properties/OnlyOne.py
+++ b/src/cfnlint/rules/resources/properties/OnlyOne.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 import cfnlint.helpers
 
 

--- a/src/cfnlint/rules/resources/properties/Password.py
+++ b/src/cfnlint/rules/resources/properties/Password.py
@@ -16,8 +16,8 @@
 """
 import re
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import REGEX_DYN_REF_SSM, REGEX_DYN_REF
 
 

--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 import cfnlint.helpers
 
 

--- a/src/cfnlint/rules/resources/properties/PropertiesTemplated.py
+++ b/src/cfnlint/rules/resources/properties/PropertiesTemplated.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class PropertiesTemplated(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/properties/Required.py
+++ b/src/cfnlint/rules/resources/properties/Required.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 import cfnlint.helpers
 
 

--- a/src/cfnlint/rules/resources/properties/StringSize.py
+++ b/src/cfnlint/rules/resources/properties/StringSize.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 from cfnlint.helpers import RESOURCE_SPECS
 

--- a/src/cfnlint/rules/resources/properties/ValuePrimitiveType.py
+++ b/src/cfnlint/rules/resources/properties/ValuePrimitiveType.py
@@ -16,8 +16,8 @@
 """
 import sys
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 import cfnlint.helpers
 
 

--- a/src/cfnlint/rules/resources/properties/ValueRefGetAtt.py
+++ b/src/cfnlint/rules/resources/properties/ValueRefGetAtt.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import RESOURCE_SPECS
 import cfnlint.helpers
 

--- a/src/cfnlint/rules/resources/rds/InstanceSize.py
+++ b/src/cfnlint/rules/resources/rds/InstanceSize.py
@@ -16,8 +16,8 @@
 """
 import six
 import cfnlint.helpers
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class InstanceSize(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/route53/HealthCheck.py
+++ b/src/cfnlint/rules/resources/route53/HealthCheck.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class HealthCheck(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import re
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import REGEX_IPV4, REGEX_IPV6, REGEX_ALPHANUMERIC
 
 

--- a/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
@@ -16,8 +16,8 @@
 """
 import json
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class StateMachine(CloudFormationLintRule):

--- a/src/cfnlint/rules/resources/updatepolicy/Configuration.py
+++ b/src/cfnlint/rules/resources/updatepolicy/Configuration.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Configuration(CloudFormationLintRule):

--- a/src/cfnlint/rules/templates/Base.py
+++ b/src/cfnlint/rules/templates/Base.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Base(CloudFormationLintRule):

--- a/src/cfnlint/rules/templates/Description.py
+++ b/src/cfnlint/rules/templates/Description.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import six
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 
 
 class Description(CloudFormationLintRule):

--- a/src/cfnlint/rules/templates/LimitDescription.py
+++ b/src/cfnlint/rules/templates/LimitDescription.py
@@ -14,8 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import LIMITS
 
 

--- a/src/cfnlint/rules/templates/LimitSize.py
+++ b/src/cfnlint/rules/templates/LimitSize.py
@@ -15,8 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import os
-from cfnlint import CloudFormationLintRule
-from cfnlint import RuleMatch
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
 from cfnlint.helpers import LIMITS
 try:  # pragma: no cover
     from pathlib import Path

--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -22,12 +22,15 @@ from samtranslator.parser import parser
 from samtranslator.translator.translator import Translator
 from samtranslator.public.exceptions import InvalidDocumentException
 
-import cfnlint.helpers
+from cfnlint.helpers import load_resources, convert_dict, format_json_string
+from cfnlint.rules import Match, TransformError
 LOGGER = logging.getLogger('cfnlint')
+
 
 class Transform(object):
     """
-    Application Serverless Module tranform Wrappor. Based on code from AWS SAM CLI:
+    Application Serverless Module tranform Wrappor.
+    Based on code from AWS SAM CLI:
     https://github.com/awslabs/aws-sam-cli/blob/develop/samcli/commands/validate/lib/sam_template_validator.py
     """
 
@@ -52,13 +55,15 @@ class Transform(object):
         Load the ManagedPolicies locally, based on the AWS-CLI:
         https://github.com/awslabs/aws-sam-cli/blob/develop/samcli/lib/samlib/default_managed_policies.json
         """
-        return cfnlint.helpers.load_resources('data/Serverless/ManagedPolicies.json')
+        return load_resources('data/Serverless/ManagedPolicies.json')
 
     def _replace_local_codeuri(self):
         """
-        Replaces the CodeUri in AWS::Serverless::Function and DefinitionUri in AWS::Serverless::Api to a fake
-        S3 Uri. This is to support running the SAM Translator with valid values for these fields. If this in not done,
-        the template is invalid in the eyes of SAM Translator (the translator does not support local paths)
+        Replaces the CodeUri in AWS::Serverless::Function and DefinitionUri in
+        AWS::Serverless::Api to a fake S3 Uri. This is to support running the
+        SAM Translator with valid values for these fields. If this in not done,
+        the template is invalid in the eyes of SAM Translator (the translator
+        does not support local paths)
         """
 
         all_resources = self._template.get('Resources', {})
@@ -86,7 +91,8 @@ class Transform(object):
                     resource_dict['Location'] = ''
                     Transform._update_to_s3_uri('Location', resource_dict)
             if resource_type == 'AWS::Serverless::Api':
-                if 'DefinitionBody' not in resource_dict and 'Auth' not in resource_dict:
+                if ('DefinitionBody' not in resource_dict and
+                        'Auth' not in resource_dict):
                     Transform._update_to_s3_uri('DefinitionUri', resource_dict)
                 else:
                     resource_dict['DefinitionBody'] = ''
@@ -101,35 +107,41 @@ class Transform(object):
             # Output the SAM Translator version in debug mode
             LOGGER.info('SAM Translator: %s', samtranslator.__version__)
 
-            sam_translator = Translator(managed_policy_map=self._managed_policy_map,
-                                        sam_parser=self._sam_parser)
+            sam_translator = Translator(
+                managed_policy_map=self._managed_policy_map,
+                sam_parser=self._sam_parser)
 
             self._replace_local_codeuri()
 
-            # Tell SAM to use the region we're linting in, this has to be controlled using the default AWS mechanisms, see also:
+            # Tell SAM to use the region we're linting in, this has to be
+            # controlled using the default AWS mechanisms, see also:
             # https://github.com/awslabs/serverless-application-model/blob/master/samtranslator/translator/arn_generator.py
             LOGGER.info('Setting AWS_DEFAULT_REGION to %s', self._region)
             os.environ['AWS_DEFAULT_REGION'] = self._region
 
-            self._template = cfnlint.helpers.convert_dict(
-                sam_translator.translate(sam_template=self._template, parameter_values=self._parameters))
+            self._template = convert_dict(
+                sam_translator.translate(sam_template=self._template,
+                                         parameter_values=self._parameters))
 
-            LOGGER.info('Transformed template: \n%s', cfnlint.helpers.format_json_string(self._template))
+            LOGGER.info('Transformed template: \n%s',
+                        format_json_string(self._template))
         except InvalidDocumentException as e:
             message = 'Error transforming template: {0}'
             for cause in e.causes:
-                matches.append(cfnlint.Match(
+                matches.append(Match(
                     1, 1,
                     1, 1,
-                    self._filename, cfnlint.TransformError(), message.format(cause.message)))
+                    self._filename,
+                    TransformError(), message.format(cause.message)))
         except Exception as e:  # pylint: disable=W0703
             LOGGER.debug('Error transforming template: %s', str(e))
             LOGGER.debug('Stack trace: %s', e, exc_info=True)
             message = 'Error transforming template: {0}'
-            matches.append(cfnlint.Match(
+            matches.append(Match(
                 1, 1,
                 1, 1,
-                self._filename, cfnlint.TransformError(), message.format(str(e))))
+                self._filename,
+                TransformError(), message.format(str(e))))
 
         return matches
 
@@ -149,11 +161,14 @@ class Transform(object):
         return isinstance(uri, six.string_types) and uri.startswith('s3://')
 
     @staticmethod
-    def _update_to_s3_uri(property_key, resource_property_dict, s3_uri_value='s3://bucket/value'):
+    def _update_to_s3_uri(
+            property_key, resource_property_dict,
+            s3_uri_value='s3://bucket/value'):
         """
-        Updates the 'property_key' in the 'resource_property_dict' to the value of 's3_uri_value'
-        Note: The function will mutate the resource_property_dict that is pass in
-        Parameters
+        Updates the 'property_key' in the 'resource_property_dict' to the
+        value of 's3_uri_value'
+        Note: The function will mutate the resource_property_dict that is pass
+        in Parameters
         ----------
         property_key str, required
             Key in the resource_property_dict

--- a/test/integration/test_directives.py
+++ b/test/integration/test_directives.py
@@ -14,7 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import Template, RulesCollection, Runner  # pylint: disable=E0401
+from cfnlint import Template, Runner  # pylint: disable=E0401
+from cfnlint.rules import RulesCollection
 from cfnlint.core import DEFAULT_RULESDIR  # pylint: disable=E0401
 import cfnlint.decode.cfn_yaml  # pylint: disable=E0401
 from testlib.testcase import BaseTestCase
@@ -22,6 +23,7 @@ from testlib.testcase import BaseTestCase
 
 class TestDirectives(BaseTestCase):
     """Test Directives """
+
     def setUp(self):
         """ SetUp template object"""
         self.rules = RulesCollection(include_rules=['I'])
@@ -40,4 +42,5 @@ class TestDirectives(BaseTestCase):
         matches.extend(runner.transform())
         if not matches:
             matches.extend(runner.run())
-        assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)
+        assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(
+            failures, len(matches), filename)

--- a/test/integration/test_good_templates.py
+++ b/test/integration/test_good_templates.py
@@ -14,7 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import Template, RulesCollection, Runner  # pylint: disable=E0401
+from cfnlint import Template, Runner  # pylint: disable=E0401
+from cfnlint.rules import RulesCollection
 from cfnlint.core import DEFAULT_RULESDIR  # pylint: disable=E0401
 import cfnlint.decode.cfn_yaml  # pylint: disable=E0401
 from testlib.testcase import BaseTestCase
@@ -22,6 +23,7 @@ from testlib.testcase import BaseTestCase
 
 class TestQuickStartTemplates(BaseTestCase):
     """Test QuickStart Templates Parsing """
+
     def setUp(self):
         """ SetUp template object"""
         self.rules = RulesCollection(include_rules=['I'])
@@ -92,4 +94,5 @@ class TestQuickStartTemplates(BaseTestCase):
             matches.extend(runner.transform())
             if not matches:
                 matches.extend(runner.run())
-            assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)
+            assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(
+                failures, len(matches), filename)

--- a/test/integration/test_quickstart_templates.py
+++ b/test/integration/test_quickstart_templates.py
@@ -15,7 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import json
-from cfnlint import Template, RulesCollection, Runner  # pylint: disable=E0401
+from cfnlint import Template, Runner  # pylint: disable=E0401
+from cfnlint.rules import RulesCollection
 from cfnlint.core import DEFAULT_RULESDIR  # pylint: disable=E0401
 import cfnlint.decode.cfn_yaml  # pylint: disable=E0401
 from testlib.testcase import BaseTestCase
@@ -23,6 +24,7 @@ from testlib.testcase import BaseTestCase
 
 class TestQuickStartTemplates(BaseTestCase):
     """Test QuickStart Templates Parsing """
+
     def setUp(self):
         """ SetUp template object"""
         self.rules = RulesCollection(include_rules=['I'], include_experimental=True)
@@ -99,7 +101,8 @@ class TestQuickStartTemplates(BaseTestCase):
                 with open(results_filename) as json_data:
                     correct = json.load(json_data)
 
-                assert len(matches) == len(correct), 'Expected {} failures, got {} on {}'.format(len(correct), len(matches), filename)
+                assert len(matches) == len(correct), 'Expected {} failures, got {} on {}'.format(
+                    len(correct), len(matches), filename)
                 for c in correct:
                     matched = False
                     for match in matches:
@@ -109,10 +112,12 @@ class TestQuickStartTemplates(BaseTestCase):
                                 c['Rule']['Id'] == match.rule.id:
                             matched = True
                     assert matched is True, 'Expected error {} at line {}, column {}, path {} in matches for {}'.format(
-                            c['Rule']['Id'],
-                            c['Location']['Start']['LineNumber'],
-                            c['Location']['Start']['ColumnNumber'],
-                            "/".join(map(str, c['Location']['Path'])) if c['Location']['Path'] else "null",
-                            filename)
+                        c['Rule']['Id'],
+                        c['Location']['Start']['LineNumber'],
+                        c['Location']['Start']['ColumnNumber'],
+                        "/".join(map(str, c['Location']['Path'])
+                                 ) if c['Location']['Path'] else "null",
+                        filename)
             else:
-                assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)
+                assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(
+                    failures, len(matches), filename)

--- a/test/integration/test_quickstart_templates_non_strict.py
+++ b/test/integration/test_quickstart_templates_non_strict.py
@@ -15,7 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import json
-from cfnlint import RulesCollection, Runner  # pylint: disable=E0401
+from cfnlint import Runner  # pylint: disable=E0401
+from cfnlint.rules import RulesCollection
 from cfnlint.core import DEFAULT_RULESDIR  # pylint: disable=E0401
 import cfnlint.decode.cfn_yaml  # pylint: disable=E0401
 from testlib.testcase import BaseTestCase
@@ -23,6 +24,7 @@ from testlib.testcase import BaseTestCase
 
 class TestQuickStartTemplatesNonStrict(BaseTestCase):
     """Test QuickStart Templates Parsing """
+
     def setUp(self):
         """ SetUp template object"""
         self.rules = RulesCollection(
@@ -71,7 +73,8 @@ class TestQuickStartTemplatesNonStrict(BaseTestCase):
                 with open(results_filename) as json_data:
                     correct = json.load(json_data)
 
-                assert len(matches) == len(correct), 'Expected {} failures, got {} on {}'.format(len(correct), len(matches), filename)
+                assert len(matches) == len(correct), 'Expected {} failures, got {} on {}'.format(
+                    len(correct), len(matches), filename)
                 for c in correct:
                     matched = False
                     for match in matches:
@@ -79,6 +82,8 @@ class TestQuickStartTemplatesNonStrict(BaseTestCase):
                                 c['Location']['Start']['ColumnNumber'] == match.columnnumber and \
                                 c['Rule']['Id'] == match.rule.id:
                             matched = True
-                    assert matched is True, 'Expected error {} at line {}, column {} in matches for {}'.format(c['Rule']['Id'], c['Location']['Start']['LineNumber'], c['Location']['Start']['ColumnNumber'], filename)
+                    assert matched is True, 'Expected error {} at line {}, column {} in matches for {}'.format(
+                        c['Rule']['Id'], c['Location']['Start']['LineNumber'], c['Location']['Start']['ColumnNumber'], filename)
             else:
-                assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)
+                assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(
+                    failures, len(matches), filename)

--- a/test/module/cfn_json/test_cfn_json.py
+++ b/test/module/cfn_json/test_cfn_json.py
@@ -17,7 +17,8 @@
 import sys
 from mock import patch
 from six import StringIO
-from cfnlint import Template, RulesCollection  # pylint: disable=E0401
+from cfnlint import Template  # pylint: disable=E0401
+from cfnlint.rules import RulesCollection
 from cfnlint.core import DEFAULT_RULESDIR  # pylint: disable=E0401
 import cfnlint.decode.cfn_json  # pylint: disable=E0401
 from testlib.testcase import BaseTestCase
@@ -25,6 +26,7 @@ from testlib.testcase import BaseTestCase
 
 class TestCfnJson(BaseTestCase):
     """Test JSON Parsing """
+
     def setUp(self):
         """ SetUp template object"""
         self.rules = RulesCollection(include_experimental=True)
@@ -70,7 +72,8 @@ class TestCfnJson(BaseTestCase):
 
             matches = []
             matches.extend(self.rules.run(filename, cfn))
-            assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)
+            assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(
+                failures, len(matches), filename)
 
     def test_success_escape_character(self):
         """Test Successful JSON Parsing"""
@@ -81,7 +84,8 @@ class TestCfnJson(BaseTestCase):
 
         matches = []
         matches.extend(self.rules.run(filename, cfn))
-        assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)
+        assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(
+            failures, len(matches), filename)
 
     def test_success_parse_stdin(self):
         """Test Successful JSON Parsing through stdin"""
@@ -97,7 +101,8 @@ class TestCfnJson(BaseTestCase):
 
                 matches = []
                 matches.extend(self.rules.run(filename, cfn))
-                assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), values.get('filename'))
+                assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(
+                    failures, len(matches), values.get('filename'))
 
     def test_fail_run(self):
         """Test failure run"""

--- a/test/module/cfn_yaml/test_yaml.py
+++ b/test/module/cfn_yaml/test_yaml.py
@@ -17,13 +17,16 @@
 import sys
 from mock import patch
 from six import StringIO
-from cfnlint import Template, RulesCollection  # pylint: disable=E0401
+from cfnlint import Template  # pylint: disable=E0401
+from cfnlint.rules import RulesCollection
 from cfnlint.core import DEFAULT_RULESDIR  # pylint: disable=E0401
 import cfnlint.decode.cfn_yaml  # pylint: disable=E0401
 from testlib.testcase import BaseTestCase
 
+
 class TestYamlParse(BaseTestCase):
     """Test YAML Parsing """
+
     def setUp(self):
         """ SetUp template object"""
         self.rules = RulesCollection()
@@ -52,7 +55,8 @@ class TestYamlParse(BaseTestCase):
 
             matches = []
             matches.extend(self.rules.run(filename, cfn))
-            assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), filename)
+            assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(
+                failures, len(matches), filename)
 
     def test_success_parse_stdin(self):
         """Test Successful YAML Parsing through stdin"""
@@ -68,4 +72,5 @@ class TestYamlParse(BaseTestCase):
 
                 matches = []
                 matches.extend(self.rules.run(filename, cfn))
-                assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(failures, len(matches), values.get('filename'))
+                assert len(matches) == failures, 'Expected {} failures, got {} on {}'.format(
+                    failures, len(matches), values.get('filename'))

--- a/test/module/maintenance/test_update_documentation.py
+++ b/test/module/maintenance/test_update_documentation.py
@@ -18,7 +18,7 @@ import sys
 import logging
 from mock import patch, mock_open, call
 import cfnlint.maintenance
-from cfnlint import CloudFormationLintRule, RulesCollection
+from cfnlint.rules import CloudFormationLintRule, RulesCollection
 from testlib.testcase import BaseTestCase
 
 LOGGER = logging.getLogger('cfnlint.maintenance')

--- a/test/module/override/test_complete.py
+++ b/test/module/override/test_complete.py
@@ -14,12 +14,14 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import Runner, RulesCollection
+from cfnlint import Runner
+from cfnlint.rules import RulesCollection
 from cfnlint.rules.resources.Configuration import Configuration  # pylint: disable=E0401
 from cfnlint.rules.resources.properties.Required import Required  # pylint: disable=E0401
 from testlib.testcase import BaseTestCase
 import cfnlint.helpers
 import json
+
 
 class TestComplete(BaseTestCase):
     """Used for Testing Rules"""

--- a/test/module/override/test_exclude.py
+++ b/test/module/override/test_exclude.py
@@ -14,11 +14,13 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import Runner, RulesCollection
+from cfnlint import Runner
+from cfnlint.rules import RulesCollection
 from cfnlint.rules.resources.Configuration import Configuration  # pylint: disable=E0401
 from testlib.testcase import BaseTestCase
 import cfnlint.helpers
 import json
+
 
 class TestExclude(BaseTestCase):
     """Used for Testing Rules"""

--- a/test/module/override/test_include.py
+++ b/test/module/override/test_include.py
@@ -14,11 +14,13 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import Runner, RulesCollection
+from cfnlint import Runner
+from cfnlint.rules import RulesCollection
 from cfnlint.rules.resources.Configuration import Configuration  # pylint: disable=E0401
 from testlib.testcase import BaseTestCase
 import cfnlint.helpers
 import json
+
 
 class TestInclude(BaseTestCase):
     """Used for Testing Rules"""

--- a/test/module/override/test_required.py
+++ b/test/module/override/test_required.py
@@ -14,11 +14,13 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import Runner, RulesCollection
+from cfnlint import Runner
+from cfnlint.rules import RulesCollection
 from cfnlint.rules.resources.properties.Required import Required  # pylint: disable=E0401
 from testlib.testcase import BaseTestCase
 import cfnlint.helpers
 import json
+
 
 class TestOverrideRequired(BaseTestCase):
     """Used for Testing Rules"""

--- a/test/module/rule/test_rule.py
+++ b/test/module/rule/test_rule.py
@@ -14,7 +14,7 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import CloudFormationLintRule  # pylint: disable=E0401
+from cfnlint.rules import CloudFormationLintRule  # pylint: disable=E0401
 from testlib.testcase import BaseTestCase
 
 

--- a/test/module/test_duplicate.py
+++ b/test/module/test_duplicate.py
@@ -15,7 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import json
-from cfnlint import Template, RulesCollection
+from cfnlint import Template
+from cfnlint.rules import RulesCollection
 from cfnlint.core import DEFAULT_RULESDIR  # pylint: disable=E0401
 import cfnlint.decode.cfn_yaml  # pylint: disable=E0401
 import cfnlint.decode.cfn_json  # pylint: disable=E0401
@@ -24,6 +25,7 @@ from testlib.testcase import BaseTestCase
 
 class TestDuplicate(BaseTestCase):
     """Test Duplicates Parsing """
+
     def setUp(self):
         """ SetUp template object"""
         self.rules = RulesCollection()

--- a/test/module/test_null_values.py
+++ b/test/module/test_null_values.py
@@ -15,7 +15,7 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import json
-from cfnlint import RulesCollection  # pylint: disable=E0401
+from cfnlint.rules import RulesCollection  # pylint: disable=E0401
 from cfnlint.core import DEFAULT_RULESDIR
 import cfnlint.decode.cfn_yaml  # pylint: disable=E0401
 import cfnlint.decode.cfn_json  # pylint: disable=E0401
@@ -24,6 +24,7 @@ from testlib.testcase import BaseTestCase
 
 class TestNulls(BaseTestCase):
     """Test Null Value Parsing """
+
     def setUp(self):
         """ SetUp template object"""
         self.rules = RulesCollection()

--- a/test/module/test_rules_collections.py
+++ b/test/module/test_rules_collections.py
@@ -14,7 +14,8 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import RulesCollection, Template, CloudFormationLintRule
+from cfnlint import Template
+from cfnlint.rules import CloudFormationLintRule, RulesCollection
 from cfnlint.core import DEFAULT_RULESDIR  # pylint: disable=E0401
 import cfnlint.decode.cfn_yaml  # pylint: disable=E0401
 from testlib.testcase import BaseTestCase
@@ -22,6 +23,7 @@ from testlib.testcase import BaseTestCase
 
 class TestTemplate(BaseTestCase):
     """Test Template RulesCollection in cfnlint """
+
     def setUp(self):
         """ SetUp template object"""
         self.rules = RulesCollection()
@@ -61,7 +63,8 @@ class TestTemplate(BaseTestCase):
         expected_err_count = 35
         matches = []
         matches.extend(self.rules.run(filename, cfn))
-        assert len(matches) == expected_err_count, 'Expected {} failures, got {}'.format(expected_err_count, len(matches))
+        assert len(matches) == expected_err_count, 'Expected {} failures, got {}'.format(
+            expected_err_count, len(matches))
 
     def test_fail_sub_properties_run(self):
         """Test failure run"""

--- a/test/rules/__init__.py
+++ b/test/rules/__init__.py
@@ -15,7 +15,8 @@
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 import cfnlint.config
-from cfnlint import Runner, RulesCollection
+from cfnlint import Runner
+from cfnlint.rules import RulesCollection
 from testlib.testcase import BaseTestCase
 
 
@@ -44,7 +45,8 @@ class BaseRuleTestCase(BaseTestCase):
         good_runner = Runner(self.collection, filename, template, ['us-east-1'], [])
         good_runner.transform()
         failures = good_runner.run()
-        self.assertEqual(err_count, len(failures), 'Expected {} failures but got {} on {}'.format(err_count, failures, filename))
+        self.assertEqual(err_count, len(failures), 'Expected {} failures but got {} on {}'.format(
+            err_count, failures, filename))
         self.collection.rules[0].configure(config)
 
     def helper_file_positive_template(self, filename):

--- a/test/rules/templates/test_yaml_template.py
+++ b/test/rules/templates/test_yaml_template.py
@@ -14,13 +14,15 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
-from cfnlint import Runner, RulesCollection  # pylint: disable=E0401
+from cfnlint import Runner  # pylint: disable=E0401
+from cfnlint.rules import RulesCollection
 from cfnlint.rules.templates.Base import Base  # pylint: disable=E0401
 from .. import BaseRuleTestCase
 
 
 class TestBaseTemplate(BaseRuleTestCase):
     """Test base template"""
+
     def setUp(self):
         """Setup"""
         self.collection = RulesCollection()


### PR DESCRIPTION
*Issue #, if available:*
#1101 
*Description of changes:*
- Move rule classes to rules __init__ 
- Implement deprecation warnings for old imports and to maintain backwards compatibility

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
