### PR TITLE
WIP: Add PrettyFormatter for colored output in a terminal.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,8 @@ setup(
         'jsonschema~=3.0',
         'pathlib2>=2.3.0;python_version<"3.4"',
         'setuptools',
+        'termcolor',
+        'colorama;platform_system=="Windows"'
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     entry_points={

--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -36,6 +36,11 @@ LOGGER = logging.getLogger(__name__)
 class CloudFormationLintRule(object):
     """CloudFormation linter rules"""
 
+    ERROR = 40
+    INFO = 10
+    NOTSET = 0
+    WARNING = 30
+
     id = ''
     shortdesc = ''
     description = ''
@@ -53,6 +58,16 @@ class CloudFormationLintRule(object):
 
     def __repr__(self):
         return '%s: %s' % (self.id, self.shortdesc)
+
+    @property
+    def severity(self):
+        """Severity level"""
+        levels = {
+            'I': self.INFO,
+            'E': self.ERROR,
+            'W': self.WARNING
+        }
+        return levels.get(self.id[0].upper(), self.NOTSET)
 
     def verbose(self):
         """Verbose output"""

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -82,7 +82,10 @@ def get_formatter(fmt):
         elif fmt == 'json':
             formatter = cfnlint.formatters.JsonFormatter()
     else:
-        formatter = cfnlint.formatters.Formatter()
+        if sys.stdout.isatty():
+            formatter = cfnlint.formatters.PrettyFormatter()
+        else:
+            formatter = cfnlint.formatters.Formatter()
 
     return formatter
 


### PR DESCRIPTION
See #971.
Looking for some feedback before I go further down this rabbit hole.

*Description of changes:*
Added some colors to the output if not connected to a tty.

While grep-like context is not hard to add, all grep variants support a bazillion output options, adding significant complexity. 

I don't have a Windows system to hand to test if adding `colorama` is all that is required.

Also, this may be a breaking change, so perhaps this should just be a `-f pretty` output (but should that be default at some point?).

![image](https://user-images.githubusercontent.com/206176/63322056-d722b500-c365-11e9-81c9-35977626563e.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
