### PR TITLE
Documented Maximums and Minimums of Integer Properties

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_apigateway.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_apigateway.json
@@ -56,5 +56,13 @@
         "API_KEY"
       ]
     }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::ApiGateway::Authorizer.AuthorizerResultTtlInSeconds",
+    "value": {
+      "NumberMax": 3600,
+      "NumberMin": 0
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_appstream.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_appstream.json
@@ -1,0 +1,26 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::AppStream::Fleet.DisconnectTimeoutInSeconds",
+    "value": {
+      "NumberMax": 360000,
+      "NumberMin": 60
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::AppStream::Fleet.IdleDisconnectTimeoutInSeconds",
+    "value": {
+      "NumberMax": 3600,
+      "NumberMin": 0
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::AppStream::Fleet.MaxUserDurationInSeconds",
+    "value": {
+      "NumberMax": 360000,
+      "NumberMin": 600
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloud9.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloud9.json
@@ -1,0 +1,10 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::Cloud9::EnvironmentEC2.AutomaticStopTimeMinutes",
+    "value": {
+      "NumberMax": 20160,
+      "NumberMin": 0
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_codebuild.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_codebuild.json
@@ -76,5 +76,21 @@
         "S3"
       ]
     }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::CodeBuild::Project.TimeoutInMinutes",
+    "value": {
+      "NumberMax": 480,
+      "NumberMin": 5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::CodeBuild::Project.QueuedTimeoutInMinutes",
+    "value": {
+      "NumberMax": 480,
+      "NumberMin": 5
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_docdb.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_docdb.json
@@ -1,0 +1,10 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::DocDB::DBCluster.BackupRetentionPeriod",
+    "value": {
+      "NumberMax": 35,
+      "NumberMin": 1
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_elasticache.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_elasticache.json
@@ -1,0 +1,18 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::ElastiCache::ReplicationGroup.NumCacheClusters",
+    "value": {
+      "NumberMax": 6,
+      "NumberMin": 1
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::ElastiCache::ReplicationGroup.ReplicasPerNodeGroup",
+    "value": {
+      "NumberMax": 5,
+      "NumberMin": 0
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_elb.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_elb.json
@@ -6,5 +6,13 @@
       "NumberMax": 300,
       "NumberMin": 5
     }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::ElasticLoadBalancingV2::TargetGroup.UnhealthyThresholdCount",
+    "value": {
+      "NumberMax": 10,
+      "NumberMin": 2
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_elb.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_elb.json
@@ -14,5 +14,13 @@
       "NumberMax": 10,
       "NumberMin": 2
     }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::ElasticLoadBalancingV2::ListenerRule.Priority",
+    "value": {
+      "NumberMax": 50000,
+      "NumberMin": 1
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_elb.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_elb.json
@@ -1,0 +1,10 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::ElasticLoadBalancingV2::TargetGroup.HealthCheckIntervalSeconds",
+    "value": {
+      "NumberMax": 300,
+      "NumberMin": 5
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_fsx.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_fsx.json
@@ -1,0 +1,10 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::FSx::FileSystem.StorageCapacity",
+    "value": {
+      "NumberMax": 65536,
+      "NumberMin": 300
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
@@ -85,5 +85,13 @@
       "NumberMax": 299,
       "NumberMin": 0
     }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::Glue::MLTransform.MaxCapacity",
+    "value": {
+      "NumberMax": 100,
+      "NumberMin": 1
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
@@ -77,5 +77,13 @@
         "SCHEDULED"
       ]
     }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::Glue::Job.NumberOfWorkers",
+    "value": {
+      "NumberMax": 299,
+      "NumberMin": 0
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_iam.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_iam.json
@@ -230,5 +230,13 @@
         ]
       }
     }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::IAM::Role.MaxSessionDuration",
+    "value": {
+      "NumberMax": 43200,
+      "NumberMin": 3600
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_inspector.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_inspector.json
@@ -1,0 +1,10 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::Inspector::AssessmentTemplate.DurationInSeconds",
+    "value": {
+      "NumberMax": 86400,
+      "NumberMin": 180
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_kinesis.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_kinesis.json
@@ -1,0 +1,18 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::Kinesis::Stream.RetentionPeriodHours",
+    "value": {
+      "NumberMax": 168,
+      "NumberMin": 1
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::Kinesis::Stream.ShardCount",
+    "value": {
+      "NumberMax": 100000,
+      "NumberMin": 1
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_kms.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_kms.json
@@ -1,0 +1,10 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::KMS::Key.PendingWindowInDays",
+    "value": {
+      "NumberMax": 30,
+      "NumberMin": 7
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_lambda.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_lambda.json
@@ -6,5 +6,13 @@
       "NumberMax": 3008,
       "NumberMin": 128
     }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::Lambda::Function.Timeout",
+    "value": {
+      "NumberMax": 900,
+      "NumberMin": 1
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_lambda.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_lambda.json
@@ -14,5 +14,13 @@
       "NumberMax": 900,
       "NumberMin": 1
     }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::Lambda::EventSourceMapping.BatchSize",
+    "value": {
+      "NumberMax": 10000,
+      "NumberMin": 1
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_lambda.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_lambda.json
@@ -1,0 +1,10 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::Lambda::Function.MemorySize",
+    "value": {
+      "NumberMax": 3008,
+      "NumberMin": 128
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_rds.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_rds.json
@@ -1,0 +1,33 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::RDS::DBCluster.BackupRetentionPeriod",
+    "value": {
+      "NumberMax": 35,
+      "NumberMin": 1
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::RDS::DBInstance.BackupRetentionPeriod",
+    "value": {
+      "NumberMax": 35,
+      "NumberMin": 0
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::RDS::DBInstance.PromotionTier",
+    "value": {
+      "NumberMax": 15,
+      "NumberMin": 0
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::RDS::DBInstance.Iops",
+    "value": {
+      "NumberMin": 1000
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_redshift.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_redshift.json
@@ -1,0 +1,10 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::Redshift::Cluster.NumberOfNodes",
+    "value": {
+      "NumberMax": 100,
+      "NumberMin": 1
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_sagemaker.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_sagemaker.json
@@ -1,0 +1,10 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::SageMaker::NotebookInstance.VolumeSizeInGB",
+    "value": {
+      "NumberMax": 16384,
+      "NumberMin": 5
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_sqs.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_sqs.json
@@ -1,0 +1,50 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::SQS::Queue.DelaySeconds",
+    "value": {
+      "NumberMax": 900,
+      "NumberMin": 0
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::SQS::Queue.KmsDataKeyReusePeriodSeconds",
+    "value": {
+      "NumberMax": 86400,
+      "NumberMin": 60
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::SQS::Queue.MaximumMessageSize",
+    "value": {
+      "NumberMax": 262144,
+      "NumberMin": 1024
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::SQS::Queue.MessageRetentionPeriod",
+    "value": {
+      "NumberMax": 1209600,
+      "NumberMin": 60
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::SQS::Queue.ReceiveMessageWaitTimeSeconds",
+    "value": {
+      "NumberMax": 20,
+      "NumberMin": 1
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::SQS::Queue.VisibilityTimeout",
+    "value": {
+      "NumberMax": 43200,
+      "NumberMin": 0
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ssm.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ssm.json
@@ -1,0 +1,18 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::SSM::MaintenanceWindow.Cutoff",
+    "value": {
+      "NumberMax": 23,
+      "NumberMin": 0
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::SSM::MaintenanceWindow.Duration",
+    "value": {
+      "NumberMax": 24,
+      "NumberMin": 1
+    }
+  }
+]


### PR DESCRIPTION
Using this PR as a reference: https://github.com/aws-cloudformation/cfn-python-lint/pull/1109

I'm assuming the regional files are autogenerated and I'm wondering if `04_property_values` is redundant

`"type: integer" "maximum" site:https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource`

`"type: integer" "minimum" site:https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource`

`"type: integer" "less than" site:https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource`

`"type: integer" "more than" site:https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
