### PR TITLE
adding me-south-1 to REGIONS

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -55,6 +55,7 @@ REGIONS = [
     'eu-west-1',
     'eu-west-2',
     'eu-west-3',
+    'me-south-1',
     'sa-east-1',
     'us-east-1',
     'us-east-2',


### PR DESCRIPTION
Could also use the keys here to maintain one less list:
https://github.com/aws-cloudformation/cfn-python-lint/blob/7e0332274e544c8b63dcef81684bf413486c2267/src/cfnlint/maintenance.py#L31-L55

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
