### PR TITLE
Change type of Role property on AWS::Glue::Job

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -35452,7 +35452,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "Schedule": {
@@ -35672,7 +35672,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "SecurityConfiguration": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -31824,7 +31824,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "Schedule": {
@@ -32044,7 +32044,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "SecurityConfiguration": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -30264,7 +30264,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "Schedule": {
@@ -30484,7 +30484,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "SecurityConfiguration": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -31947,7 +31947,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "Schedule": {
@@ -32167,7 +32167,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "SecurityConfiguration": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -35199,7 +35199,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "Schedule": {
@@ -35419,7 +35419,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "SecurityConfiguration": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -26924,7 +26924,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "Schedule": {
@@ -27127,7 +27127,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "SecurityConfiguration": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -35374,7 +35374,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "Schedule": {
@@ -35594,7 +35594,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "SecurityConfiguration": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -36994,7 +36994,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "Schedule": {
@@ -37214,7 +37214,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "SecurityConfiguration": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -29968,7 +29968,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "Schedule": {
@@ -30171,7 +30171,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "SecurityConfiguration": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -23870,7 +23870,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "Schedule": {
@@ -24073,7 +24073,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "SecurityConfiguration": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -37192,7 +37192,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "Schedule": {
@@ -37412,7 +37412,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "SecurityConfiguration": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -33163,7 +33163,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "Schedule": {
@@ -33383,7 +33383,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "SecurityConfiguration": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -26775,7 +26775,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "Schedule": {
@@ -26978,7 +26978,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "SecurityConfiguration": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -36977,7 +36977,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "Schedule": {
@@ -37197,7 +37197,7 @@
           "Required": true,
           "UpdateType": "Mutable",
           "Value": {
-            "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+            "ValueType": "AWS::IAM::Role.NameOrArn"
           }
         },
         "SecurityConfiguration": {

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_glue.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_glue.json
@@ -3,14 +3,14 @@
     "op": "add",
     "path": "/ResourceTypes/AWS::Glue::Crawler/Properties/Role/Value",
     "value": {
-      "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+      "ValueType": "AWS::IAM::Role.NameOrArn"
     }
   },
   {
     "op": "add",
     "path": "/ResourceTypes/AWS::Glue::Job/Properties/Role/Value",
     "value": {
-      "ValueType": "AWS::IAM::InstanceProfile.NameOrArn"
+      "ValueType": "AWS::IAM::Role.NameOrArn"
     }
   },
   {


### PR DESCRIPTION
Role property on AWS::Glue::Job is currently incorrectly expecting an AWS::IAM::InstanceProfile.NameOrArn but it should have been AWS::IAM::Role.NameOrArn

*No issue logged*

I have changed the type for all regions that were referencing an InstanceProfile - but not made any changes for the regions that just expects a String.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
