### PR TITLE
AWS::EC2::SecurityGroup.Description 

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -23879,8 +23879,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -45077,8 +45077,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -40577,8 +40577,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -23898,8 +23898,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -39642,8 +39642,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -40718,8 +40718,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -44773,8 +44773,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -34296,8 +34296,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/cn-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-north-1.json
@@ -24174,8 +24174,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
@@ -22678,8 +22678,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -45414,8 +45414,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -27283,8 +27283,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -47498,8 +47498,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -38524,8 +38524,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -31212,8 +31212,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/me-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/me-south-1.json
@@ -20604,8 +20604,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -31913,8 +31913,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -47764,8 +47764,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -42532,8 +42532,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -22695,8 +22695,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -25129,8 +25129,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -34222,8 +34222,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -47457,8 +47457,8 @@
     },
     "AWS::EC2::SecurityGroup.Description": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     },
     "AWS::EC2::SecurityGroup.GroupId": {
       "GetAtt": {},

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ec2.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ec2.json
@@ -110,8 +110,8 @@
     "path": "/ValueTypes/AWS::EC2::SecurityGroup.Description",
     "value": {
       "AllowedPatternRegex": "^([a-z,A-Z,0-9,. _\\-:/()#,@[\\]+=&;\\{\\}!$*])*$",
-      "StringMax": "255",
-      "StringMin": ""
+      "StringMax": 255,
+      "StringMin": 0
     }
   }
 ]


### PR DESCRIPTION
*Description of changes:*

Change the types of `AWS::EC2::SecurityGroup.Description` `StringMax` and `StringMin` to integers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
