### PR TITLE
add cognito-identity keys to list of excluded resourses for Fn sub needed

### DIFF
--- a/src/cfnlint/rules/functions/SubNeeded.py
+++ b/src/cfnlint/rules/functions/SubNeeded.py
@@ -36,12 +36,14 @@ class SubNeeded(CloudFormationLintRule):
     # https://docs.aws.amazon.com/iot/latest/developerguide/basic-policy-variables.html
     # https://docs.aws.amazon.com/iot/latest/developerguide/thing-policy-variables.html
     # https://docs.aws.amazon.com/transfer/latest/userguide/users.html#users-policies-scope-down
+    # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html
     resource_excludes = ['${aws:CurrentTime}', '${aws:EpochTime}', '${aws:TokenIssueTime}', '${aws:principaltype}',
                          '${aws:SecureTransport}', '${aws:SourceIp}', '${aws:UserAgent}', '${aws:userid}',
                          '${aws:username}', '${ec2:SourceInstanceARN}',
                          '${iot:Connection.Thing.ThingName}', '${iot:Connection.Thing.ThingTypeName}',
                          '${iot:Connection.Thing.IsAttached}', '${iot:ClientId}', '${transfer:HomeBucket}',
-                         '${transfer:HomeDirectory}', '${transfer:HomeFolder}', '${transfer:UserName}']
+                         '${transfer:HomeDirectory}', '${transfer:HomeFolder}', '${transfer:UserName}',
+                         '${cognito-identity.amazonaws.com:aud}', '${cognito-identity.amazonaws.com:sub}', '${cognito-identity.amazonaws.com:amr}']
 
     def _match_values(self, searchRegex, cfnelem, path):
         """Recursively search for values matching the searchRegex"""


### PR DESCRIPTION
*No Issue reported for this*

*Description of changes:*
Add to the list of excluded resources in the `SubNeeded` rule (E1029) to include cognito-identity keys, and a link to their documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
