### PR TITLE
Fix link for Intellij integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ There are IDE plugins available to get direct linter feedback from you favorite 
   * [Syntastic](https://github.com/speshak/vim-cfn)
 * [Sublime](https://packagecontrol.io/packages/SublimeLinter-contrib-cloudformation)
 * [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=kddejong.vscode-cfn-lint)
-* [IntelliJ IDEA](https://plugins.jetbrains.com/plugin/10973-cfn-lint/update/48247)
+* [IntelliJ IDEA](https://plugins.jetbrains.com/plugin/10973-cfn-lint)
 
 ### GitHub Actions
 


### PR DESCRIPTION
Previously the link to the Intellij plugin linked to a page of an outdated version of the plugin. This changes the link to the plugin overview page in the JetBrains plugin repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
