### PR TITLE
Update rule E1029 to not fail when using redshift:DbUser in IAM Policies

### DIFF
--- a/test/fixtures/templates/good/functions/sub_needed.yaml
+++ b/test/fixtures/templates/good/functions/sub_needed.yaml
@@ -18,6 +18,60 @@ Resources:
           Action:
             - "iam:UploadSSHPublicKey"
           Resource: "arn:aws:iam::*:user/${aws:username}"
+  myPolicy2:
+    Type: AWS::IAM::Policy
+    Properties:
+      Roles:
+      - testRole
+      PolicyName: test2
+      PolicyDocument:
+        {
+          "Version": "2012-10-17",
+            "Statement": [
+              {
+              "Sid": "GetClusterCredsStatement",
+                "Effect": "Allow",
+                "Action": [
+                  "redshift:GetClusterCredentials"
+                ],
+                "Resource": [
+                  "arn:aws:redshift:us-west-2:123456789012:dbuser:examplecluster/${redshift:DbUser}",
+                  "arn:aws:redshift:us-west-2:123456789012:dbname:examplecluster/testdb",
+                  "arn:aws:redshift:us-west-2:123456789012:dbgroup:examplecluster/common_group"
+                ],
+                  "Condition": {
+                      "StringEquals": {
+                    "aws:userid":"AIDIODR4TAW7CSEXAMPLE:${redshift:DbUser}@yourdomain.com"
+                                      }
+                                }
+              },
+              {
+                "Sid": "CreateClusterUserStatement",
+                "Effect": "Allow",
+                "Action": [
+                  "redshift:CreateClusterUser"
+                ],
+                "Resource": [
+                  "arn:aws:redshift:us-west-2:123456789012:dbuser:examplecluster/${redshift:DbUser}"
+                ],
+                "Condition": {
+                  "StringEquals": {
+                    "aws:userid":"AIDIODR4TAW7CSEXAMPLE:${redshift:DbUser}@yourdomain.com"
+                  }
+                }
+              },
+              {
+                "Sid": "RedshiftJoinGroupStatement",
+                "Effect": "Allow",
+                "Action": [
+                  "redshift:JoinGroup"
+                ],
+                "Resource": [
+                  "arn:aws:redshift:us-west-2:123456789012:dbgroup:examplecluster/common_group"
+                ]
+              }
+            ]
+          }
   Key:
     Type: AWS::ApiGateway::ApiKey
     Properties:


### PR DESCRIPTION
*Issue #, if available:*
#Fix 1141
*Description of changes:*
- Add exceptions to rule E1029 so that redshift:DbUser doesn't get flagged in IAM Policies Conditions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
