### PR TITLE
Fix Parameter types for AWS::EC2::Subnet.CidrBlock

### DIFF
--- a/src/cfnlint/rules/resources/ectwo/Subnet.py
+++ b/src/cfnlint/rules/resources/ectwo/Subnet.py
@@ -76,7 +76,8 @@ class Subnet(CloudFormationLintRule):
         matches = []
 
         allowed_types = [
-            'String'
+            'String',
+            'AWS::SSM::Parameter::Value<String>'
         ]
 
         if value in resources:
@@ -91,7 +92,7 @@ class Subnet(CloudFormationLintRule):
             parameter_type = parameter.get('Type', None)
             if parameter_type not in allowed_types:
                 param_path = ['Parameters', value]
-                message = 'Security Group Id Parameter should be of type [{0}] for {1}'
+                message = 'CidrBlock Parameter should be of type [{0}] for {1}'
                 matches.append(
                     RuleMatch(
                         param_path,


### PR DESCRIPTION

*Description of changes:*

Ensure that the appropriate types are accepted (both String and the SSM
type) as well as that a correct error message is printed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
