### PR TITLE
Don't do definitionUri when using CORS

### DIFF
--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -92,7 +92,7 @@ class Transform(object):
                     Transform._update_to_s3_uri('Location', resource_dict)
             if resource_type == 'AWS::Serverless::Api':
                 if ('DefinitionBody' not in resource_dict and
-                        'Auth' not in resource_dict):
+                        'Auth' not in resource_dict and 'Cors' not in resource_dict):
                     Transform._update_to_s3_uri('DefinitionUri', resource_dict)
                 else:
                     resource_dict['DefinitionBody'] = ''


### PR DESCRIPTION
*Issue #, if available:*
Fix #1183
*Description of changes:*
- Don't use DefinitionUri when using CORS in a SAM template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
