### PR TITLE
AWS::S3::Bucket.BucketName AllowedPattern

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_s3.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_s3.json
@@ -1,0 +1,11 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::S3::Bucket.BucketName",
+    "value": {
+      "AllowedPatternRegex": "^[a-z0-9][a-z0-9.-]*[a-z0-9]$",
+      "StringMax": 63,
+      "StringMin": 3
+    }
+  }
+] 


### PR DESCRIPTION
https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules

Increasing coverage of allowed BucketName rules:

```
✅ Bucket names must be at least 3 and no more than 63 characters long.

✅ Bucket names must not contain uppercase characters or underscores.

✅ Bucket names must start with a lowercase letter or number.

❌ Bucket names must be a series of one or more labels. Adjacent labels are separated by a single period (.). Bucket names can contain lowercase letters, numbers, and hyphens. Each label must start and end with a lowercase letter or a number.

❌ Bucket names must not be formatted as an IP address (for example, 192.168.5.4).

❌ When you use virtual hosted–style buckets with Secure Sockets Layer (SSL), the SSL wildcard certificate only matches buckets that don't contain periods. To work around this, use HTTP or write your own certificate verification logic. We recommend that you do not use periods (".") in bucket names when using virtual hosted–style buckets.
```

https://regex101.com/r/6N7QXB/3

---

Could use this as a `DisallowedPatternRegex` if that's ever supported:

https://github.com/aws-cloudformation/cfn-python-lint/blob/71b6848fe0137f3492bb615284ac7541bfeb1596/src/cfnlint/helpers.py#L66-L67

Last rule should probably only be a warning anyways