### PR TITLE
Update docdb to have allowed versions of 3.6.0

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -26722,7 +26722,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -47963,7 +47963,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -45117,7 +45117,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -25140,7 +25140,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -44182,7 +44182,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -45373,7 +45373,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -47594,7 +47594,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -37824,7 +37824,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/cn-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-north-1.json
@@ -26856,7 +26856,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
@@ -24625,7 +24625,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -48457,7 +48457,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -30061,7 +30061,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -50662,7 +50662,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -42909,7 +42909,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -33569,7 +33569,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/me-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/me-south-1.json
@@ -24225,7 +24225,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -34211,7 +34211,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -50941,7 +50941,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -46526,7 +46526,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -25278,7 +25278,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -29506,7 +29506,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -37329,7 +37329,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -50702,7 +50702,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -94,7 +94,7 @@
     },
     "DocumentDBEngineVersion": {
       "AllowedValues": [
-        "docdb"
+        "3.6.0"
       ]
     },
     "DocumentDBInstanceClass": {

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -552,7 +552,7 @@ Resources:
     Properties:
       AvailabilityZones:
         - String
-      EngineVersion: "docdb" # Valid AllowedValue
+      EngineVersion: "3.6.0" # Valid AllowedValue
   DocumentDBInstance:
     Type: "AWS::DocDB::DBInstance"
     Properties:


### PR DESCRIPTION
*Issue #, if available:*
Fix #1202
*Description of changes:*
- Update docdb allowed values to only be 3.6.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
