### PR TITLE
Only check rule W2501 when in a resources properties

### DIFF
--- a/src/cfnlint/rules/resources/properties/Password.py
+++ b/src/cfnlint/rules/resources/properties/Password.py
@@ -29,7 +29,11 @@ class Password(CloudFormationLintRule):
         for password_property in password_properties:
             # Build the list of refs
             refs = cfn.search_deep_keys(password_property)
-            trees = [tree for tree in refs if tree[0] == 'Resources']
+            trees = []
+            for tree in refs:
+                if len(tree) > 2:
+                    if tree[0] == 'Resources' and tree[2] == 'Properties':
+                        trees.append(tree)
 
             for tree in trees:
                 obj = tree[-1]


### PR DESCRIPTION
*Issue #, if available:*
Fix #1207 
*Description of changes:*
- Update rule W2501 to only check when inside a resource properties

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
