### PR TITLE
AWS::ElasticLoadBalancingV2::LoadBalancer.LoadBalancerAttribute routing.http.drop_invalid_header_fields.enabled

### DIFF
--- a/src/cfnlint/rules/resources/elb/Elb.py
+++ b/src/cfnlint/rules/resources/elb/Elb.py
@@ -89,6 +89,7 @@ HTTPS has certificate HTTP has no certificate'
             ],
             'application': [
                 'idle_timeout.timeout_seconds',
+                'routing.http.drop_invalid_header_fields.enabled',
                 'routing.http2.enabled'
             ],
             'network': [


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-loadbalancer-loadbalancerattributes.html
