### PR TITLE
Recognize and Check `EnableVersionUpgrade` Update Policy

### DIFF
--- a/src/cfnlint/rules/resources/updatepolicy/Configuration.py
+++ b/src/cfnlint/rules/resources/updatepolicy/Configuration.py
@@ -91,6 +91,12 @@ class Configuration(CloudFormationLintRule):
                     'AWS::Lambda::Alias'
                 ]
             },
+            'EnableVersionUpgrade': {
+                'PrimitiveType': 'Boolean',
+                'ResourceTypes': [
+                    'AWS::Elasticsearch::Domain'
+                ]
+            },
             'UseOnlineResharding': {
                 'PrimitiveType': 'Boolean',
                 'ResourceTypes': [

--- a/test/fixtures/templates/bad/resources/updatepolicy/config.yaml
+++ b/test/fixtures/templates/bad/resources/updatepolicy/config.yaml
@@ -25,7 +25,7 @@ Resources:
       MinSize: '1'
     UpdatePolicy:
       AutoScalingScheduledAction:
-        IgnoreUnmodifiedGroupSizeProperties: 'true' # invalide type
+        IgnoreUnmodifiedGroupSizeProperties: 'true' # invalid type
       AutoScalingRollingUpdate:
         MinInstancesInService: '1' # invalide type
         MaxBatchSize: '2' # invalide type
@@ -130,3 +130,11 @@ Resources:
     Properties:
       MinSize: '1'
       MaxSize: '1'
+  ESD1:
+    Type: AWS::Elasticsearch::Domain
+    UpdatePolicy:
+      AutoScalingReplacingUpdate: true # wrong property name
+  ESD2:
+    Type: AWS::Elasticsearch::Domain
+    UpdatePolicy:
+      EnableVersionUpgrade: 'true' # invalid type

--- a/test/fixtures/templates/good/resources/updatepolicy/config.yaml
+++ b/test/fixtures/templates/good/resources/updatepolicy/config.yaml
@@ -79,3 +79,11 @@ Resources:
     Properties:
       MinSize: '1'
       MaxSize: '1'
+  ESD1:
+    Type: AWS::Elasticsearch::Domain
+    UpdatePolicy:
+      EnableVersionUpgrade: false
+  ESD2:
+    Type: AWS::Elasticsearch::Domain
+    UpdatePolicy:
+      EnableVersionUpgrade: true

--- a/test/unit/rules/resources/updatepolicy/test_configuration.py
+++ b/test/unit/rules/resources/updatepolicy/test_configuration.py
@@ -24,4 +24,4 @@ class TestConfiguration(BaseRuleTestCase):
     def test_file_negative_alias(self):
         """Test failure"""
         self.helper_file_negative(
-            'test/fixtures/templates/bad/resources/updatepolicy/config.yaml', 11)
+            'test/fixtures/templates/bad/resources/updatepolicy/config.yaml', 14)


### PR DESCRIPTION
This is only valid for an `AWS::Elasticsearch::Domain` and it can only
be set to `true` or `false`.

Doc:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-upgradeelasticsearchdomain

*Issue #, if available:* Fixes #1230.

*Description of changes:*

`EnableVersionUpgrade` added to the recognized values for `UpdatePolicy`, accepting a Boolean, and associated with an `AWS::Elasticsearch::Domain`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
