### PR TITLE
Removing unused resource specification patches

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
@@ -91,16 +91,6 @@
   },
   {
     "op": "replace",
-    "path": "/PropertyTypes/AWS::Backup::BackupPlan.BackupPlanResourceType/Properties/BackupPlanName/UpdateType",
-    "value": "Immutable"
-  },
-  {
-    "op": "replace",
-    "path": "/PropertyTypes/AWS::Backup::BackupPlan.BackupPlanResourceType/Properties/BackupPlanRule/UpdateType",
-    "value": "Immutable"
-  },
-  {
-    "op": "replace",
     "path": "/PropertyTypes/AWS::Backup::BackupPlan.BackupRuleResourceType/Properties/CompletionWindowMinutes/PrimitiveType",
     "value": "Long"
   },


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/pull/1146

@kddejong the CloudFormation Linter doesn't use `UpdateType` values anywhere, does it? Will close this out if I'm mistaken
