### PR TITLE
Remove UUOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Lint all `yaml` files in `path` and all subdirectories (recursive):
 
 The template to be linted can also be passed using standard input:
 
-- `cat path/template.yaml | cfn-lint -`
+- `<path/template.yaml cfn-lint -`
 
 ##### Specifying the template with other parameters
 


### PR DESCRIPTION
*Description of changes:*
This commit removes a useless use of cat from the stdin example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
