### PR TITLE
ignoring W3011 if explicit DeletionPolicy/UpdateReplacePolicy value is Delete

### DIFF
--- a/src/cfnlint/rules/resources/BothUpdateReplacePolicyDeletionPolicyNeeded.py
+++ b/src/cfnlint/rules/resources/BothUpdateReplacePolicyDeletionPolicyNeeded.py
@@ -19,6 +19,7 @@ class UpdateReplacePolicyDeletionPolicy(CloudFormationLintRule):
         matches = []
 
         for r_name, r_values in cfn.get_resources().items():
+            # pylint: disable=too-many-boolean-expressions
             if r_values.get('DeletionPolicy') and r_values.get('DeletionPolicy') != 'Delete' and not r_values.get('UpdateReplacePolicy') or not r_values.get('DeletionPolicy') and r_values.get('UpdateReplacePolicy') and r_values.get('UpdateReplacePolicy') != 'Delete':
                 path = ['Resources', r_name]
                 message = 'Both UpdateReplacePolicy and DeletionPolicy are needed to protect resources from deletion'

--- a/src/cfnlint/rules/resources/BothUpdateReplacePolicyDeletionPolicyNeeded.py
+++ b/src/cfnlint/rules/resources/BothUpdateReplacePolicyDeletionPolicyNeeded.py
@@ -19,7 +19,7 @@ class UpdateReplacePolicyDeletionPolicy(CloudFormationLintRule):
         matches = []
 
         for r_name, r_values in cfn.get_resources().items():
-            if r_values.get('DeletionPolicy') and not r_values.get('UpdateReplacePolicy') or not r_values.get('DeletionPolicy') and r_values.get('UpdateReplacePolicy'):
+            if r_values.get('DeletionPolicy') and r_values.get('DeletionPolicy') != 'Delete' and not r_values.get('UpdateReplacePolicy') or not r_values.get('DeletionPolicy') and r_values.get('UpdateReplacePolicy') and r_values.get('UpdateReplacePolicy') != 'Delete':
                 path = ['Resources', r_name]
                 message = 'Both UpdateReplacePolicy and DeletionPolicy are needed to protect resources from deletion'
                 matches.append(RuleMatch(path, message))

--- a/test/fixtures/results/quickstart/nist_application.json
+++ b/test/fixtures/results/quickstart/nist_application.json
@@ -2421,31 +2421,6 @@
     },
     {
         "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
-        "Level": "Warning",
-        "Location": {
-            "End": {
-                "ColumnNumber": 20,
-                "LineNumber": 1176
-            },
-            "Path": [
-                "Resources",
-                "rWebContentBucket"
-            ],
-            "Start": {
-                "ColumnNumber": 3,
-                "LineNumber": 1176
-            }
-        },
-        "Message": "Both UpdateReplacePolicy and DeletionPolicy are needed to protect resources from deletion",
-        "Rule": {
-            "Description": "Both UpdateReplacePolicy and DeletionPolicy are needed to protect resources from deletion",
-            "Id": "W3011",
-            "ShortDescription": "Check resources with UpdateReplacePolicy/DeletionPolicy have both",
-            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html"
-        }
-    },
-    {
-        "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
         "Level": "Error",
         "Location": {
             "End": {

--- a/test/fixtures/results/quickstart/non_strict/nist_application.json
+++ b/test/fixtures/results/quickstart/non_strict/nist_application.json
@@ -991,31 +991,6 @@
         "Level": "Warning",
         "Location": {
             "End": {
-                "ColumnNumber": 20,
-                "LineNumber": 1176
-            },
-            "Path": [
-                "Resources",
-                "rWebContentBucket"
-            ],
-            "Start": {
-                "ColumnNumber": 3,
-                "LineNumber": 1176
-            }
-        },
-        "Message": "Both UpdateReplacePolicy and DeletionPolicy are needed to protect resources from deletion",
-        "Rule": {
-            "Description": "Both UpdateReplacePolicy and DeletionPolicy are needed to protect resources from deletion",
-            "Id": "W3011",
-            "ShortDescription": "Check resources with UpdateReplacePolicy/DeletionPolicy have both",
-            "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html"
-        }
-    },
-    {
-        "Filename": "test/fixtures/templates/quickstart/nist_application.yaml",
-        "Level": "Warning",
-        "Location": {
-            "End": {
                 "ColumnNumber": 14,
                 "LineNumber": 1197
             },


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/pull/1232

https://github.com/aws-cloudformation/cfn-python-lint/issues/1050

[mainly because the default `DeletionPolicy` of `AWS::RDS::DBCluster` and `AWS::RDS::DBInstance` is not `Delete`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html)