### PR TITLE
Don't alert on E1029 when in parameters since Sub can't be used there

### DIFF
--- a/src/cfnlint/rules/functions/SubNeeded.py
+++ b/src/cfnlint/rules/functions/SubNeeded.py
@@ -98,6 +98,8 @@ class SubNeeded(CloudFormationLintRule):
 
         # We want to search all of the paths to check if each one contains an 'Fn::Sub'
         for parameter_string_path in parameter_string_paths:
+            if parameter_string_path[0] in ['Parameters']:
+                continue
             # Exxclude the special IAM variables
             variable = parameter_string_path[-1]
 

--- a/test/fixtures/templates/good/functions/sub_needed.yaml
+++ b/test/fixtures/templates/good/functions/sub_needed.yaml
@@ -1,6 +1,9 @@
 ---
 AWSTemplateFormatVersion: "2010-09-09"
 Parameters:
+  MyContentBucket:
+    Description: "Bucket name for content (usually ${VPCName}-my-content), use 'none' to disable creation"
+    Type: String
   AMIId:
     Type: 'String'
     Description: 'The AMI ID for the image to use.'


### PR DESCRIPTION
*Issue #, if available:*
Fix #1252
*Description of changes:*
- Don't alert on E1029 when looking at Parameters

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
