### PR TITLE
Allow for ephemeral 0-23 in E2504

### DIFF
--- a/src/cfnlint/rules/resources/ectwo/Ebs.py
+++ b/src/cfnlint/rules/resources/ectwo/Ebs.py
@@ -59,7 +59,7 @@ class Ebs(CloudFormationLintRule):
                     ebs = properties.get('Ebs')
                     if virtual_name:
                         # switch to regex
-                        if not re.match(r'^ephemeral[0-9]$', virtual_name):
+                        if not re.match(r'^ephemeral([0-9]|[1][0-9]|[2][0-3])$', virtual_name):
                             pathmessage = path[:] + [index, 'VirtualName']
                             message = 'Property VirtualName should be of type ephemeral(n) for {0}'
                             matches.append(

--- a/test/fixtures/templates/bad/resources/ec2/ebs.yaml
+++ b/test/fixtures/templates/bad/resources/ec2/ebs.yaml
@@ -1,10 +1,6 @@
 ---
 AWSTemplateFormatVersion: "2010-09-09"
 Description: A sample template
-Parameters:
-  myIops:
-    Type: Number
-    Default: 1000
 Resources:
   ## Missing Properties
   MyEC2Instance:
@@ -14,11 +10,16 @@ Resources:
       InstanceType: t1.micro
       KeyName: 1
       BlockDeviceMappings:
-        -
-          DeviceName: /dev/sdm
+        - DeviceName: /dev/sdm
           Ebs:
             VolumeType: io1
-            Iops: 1000
+            Iops: 0
+            DeleteOnTermination: false
+            VolumeSize: 20
+        - DeviceName: /dev/sdn
+          Ebs:
+            VolumeType: magnetic
+            Iops: 100
             DeleteOnTermination: false
             VolumeSize: 20
       NetworkInterfaces:
@@ -28,25 +29,29 @@ Resources:
     Properties:
       ImageId: "ami-2f726546"
       BlockDeviceMappings:
-      -
-        DeviceName: /dev/sdm
-        VirtualName: ephemeral0
+        - DeviceName: /dev/sdm
+          VirtualName: ephemeralA
+        - DeviceName: /dev/sdn
+          VirtualName: ephemeral0
+        - DeviceName: /dev/sdo
+          VirtualName: ephemeral24
+        - DeviceName: /dev/sdo
+          VirtualName: ephemeral100
   MyLaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
       ImageId: "ami-2f726546"
       InstanceType: t2.micro
       BlockDeviceMappings:
-        -
-          DeviceName: /dev/sdm
+        - DeviceName: /dev/sdm
           Ebs:
             VolumeType: io1
-            Iops: !Ref myIops
+            Iops: 10
             DeleteOnTermination: false
             VolumeSize: 20
-        -
-          DeviceName: /dev/sdn
+        - DeviceName: /dev/sdn
           Ebs:
             VolumeType: standard
+            Iops: 100
             DeleteOnTermination: false
             VolumeSize: 20

--- a/test/fixtures/templates/good/resources/ec2/ebs.yaml
+++ b/test/fixtures/templates/good/resources/ec2/ebs.yaml
@@ -1,0 +1,52 @@
+---
+AWSTemplateFormatVersion: "2010-09-09"
+Description: A sample template
+Parameters:
+  myIops:
+    Type: Number
+    Default: 1000
+Resources:
+  ## Missing Properties
+  MyEC2Instance:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      ImageId: "ami-2f726546"
+      InstanceType: t1.micro
+      KeyName: 1
+      BlockDeviceMappings:
+        - DeviceName: /dev/sdm
+          Ebs:
+            VolumeType: io1
+            Iops: 1000
+            DeleteOnTermination: false
+            VolumeSize: 20
+      NetworkInterfaces:
+        - DeviceIndex: "1"
+  MyEC2Instance3:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      ImageId: "ami-2f726546"
+      BlockDeviceMappings:
+        - DeviceName: /dev/sdm
+          VirtualName: ephemeral0
+        - DeviceName: /dev/sdn
+          VirtualName: ephemeral23
+        - DeviceName: /dev/sdo
+          VirtualName: ephemeral19
+  MyLaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      ImageId: "ami-2f726546"
+      InstanceType: t2.micro
+      BlockDeviceMappings:
+        - DeviceName: /dev/sdm
+          Ebs:
+            VolumeType: io1
+            Iops: !Ref myIops
+            DeleteOnTermination: false
+            VolumeSize: 20
+        - DeviceName: /dev/sdn
+          Ebs:
+            VolumeType: standard
+            DeleteOnTermination: false
+            VolumeSize: 20

--- a/test/unit/rules/resources/ec2/test_ec2_ebs.py
+++ b/test/unit/rules/resources/ec2/test_ec2_ebs.py
@@ -13,6 +13,9 @@ class TestPropertyEc2Ebs(BaseRuleTestCase):
         """Setup"""
         super(TestPropertyEc2Ebs, self).setUp()
         self.collection.register(Ebs())
+        self.success_templates = [
+            'test/fixtures/templates/good/resources/ec2/ebs.yaml',
+        ]
 
     def test_file_positive(self):
         """Test Positive"""
@@ -20,4 +23,4 @@ class TestPropertyEc2Ebs(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/properties_ebs.yaml', 3)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/ec2/ebs.yaml', 5)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update rule E2504 to support ephemeral[0-23] as stated in https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
