### PR TITLE
Adding extra attributes to specific rules

### DIFF
--- a/src/cfnlint/rules/functions/Cidr.py
+++ b/src/cfnlint/rules/functions/Cidr.py
@@ -129,8 +129,9 @@ class Cidr(CloudFormationLintRule):
                                     count_parameters.append(index_value)
                     elif not isinstance(count_obj, six.integer_types):
                         message = 'Cidr count should be a int for {0}'
+                        extra_args = {'actual_type': type(count_obj).__name__, 'expected_type': six.integer_types[0].__name__}
                         matches.append(RuleMatch(
-                            tree[:] + [1], message.format('/'.join(map(str, tree[:] + [1])))))
+                            tree[:] + [1], message.format('/'.join(map(str, tree[:] + [1]))), **extra_args))
 
                     if isinstance(size_mask_obj, dict):
                         if len(size_mask_obj) == 1:
@@ -143,8 +144,9 @@ class Cidr(CloudFormationLintRule):
                                     size_mask_parameters.append(index_value)
                     elif not isinstance(size_mask_obj, six.integer_types):
                         message = 'Cidr sizeMask should be a int for {0}'
+                        extra_args = {'actual_type': type(count_obj).__name__, 'expected_type': six.integer_types[0].__name__}
                         matches.append(RuleMatch(
-                            tree[:] + [2], message.format('/'.join(map(str, tree[:] + [2])))))
+                            tree[:] + [2], message.format('/'.join(map(str, tree[:] + [2]))), **extra_args))
 
                 else:
                     message = 'Cidr should be a list of 2 or 3 elements for {0}'

--- a/src/cfnlint/rules/resources/events/RuleScheduleExpression.py
+++ b/src/cfnlint/rules/resources/events/RuleScheduleExpression.py
@@ -37,7 +37,8 @@ class RuleScheduleExpression(CloudFormationLintRule):
                 # Check the Value
                 if not items[0].isdigit():
                     message = 'Rate Value ({}) should be of type Integer.'
-                    matches.append(RuleMatch(path, message.format(items[0])))
+                    extra_args = {'actual_type': type(items[0]).__name__, 'expected_type': int.__name__}
+                    matches.append(RuleMatch(path, message.format(items[0]), **extra_args))
 
         return matches
 

--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -82,7 +82,8 @@ class RecordSet(CloudFormationLintRule):
                 # Check the flag value
                 if not items[0].isdigit():
                     message = 'CAA record flag setting ({}) should be of type Integer.'
-                    matches.append(RuleMatch(path, message.format(items[0])))
+                    extra_args = {'actual_type': type(items[0]).__name__, 'expected_type': int.__name__}
+                    matches.append(RuleMatch(path, message.format(items[0]), **extra_args))
                 else:
                     if int(items[0]) not in [0, 128]:
                         message = 'Invalid CAA record flag setting ({}) given, must be 0 or 128.'
@@ -130,7 +131,8 @@ class RecordSet(CloudFormationLintRule):
                 # Check the priority value
                 if not items[0].isdigit():
                     message = 'MX record priority setting ({}) should be of type Integer.'
-                    matches.append(RuleMatch(path, message.format(items[0], value)))
+                    extra_args = {'actual_type': type(items[0]).__name__, 'expected_type': int.__name__}
+                    matches.append(RuleMatch(path, message.format(items[0], value), **extra_args))
                 else:
                     if not 0 <= int(items[0]) <= 65535:
                         message = 'Invalid MX record priority setting ({}) given, must be between 0 and 65535.'


### PR DESCRIPTION

*Description of changes:*

This PR adds `actual_type` and `expected_type` attributes to specific rules/conditions/test-cases. This is an extension of #570, where support for these attributes was added. 

The intent here is to expose certain metadata that will be useful for auto-remediation. I have a basic auto-remediation script in place locally for type-checks (expected int, found string, so forth).  Currently, it's function over form, but this PR will help refine a few less-common use cases. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
