### PR TITLE
Move RoutingRule conditions from onlyone to at least one

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/AtLeastOne.json
+++ b/src/cfnlint/data/AdditionalSpecs/AtLeastOne.json
@@ -1,5 +1,11 @@
 {
   "PropertyTypes": {
+    "AWS::S3::Bucket.RoutingRuleCondition": [
+      [
+        "HttpErrorCodeReturnedEquals",
+        "KeyPrefixEquals"
+      ]
+    ]
   },
   "ResourceTypes": {
     "AWS::ApplicationAutoScaling::ScalingPolicy": [

--- a/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
+++ b/src/cfnlint/data/AdditionalSpecs/OnlyOne.json
@@ -59,12 +59,6 @@
         "Ebs",
         "NoDevice"
       ]
-    ],
-    "AWS::S3::Bucket.RoutingRuleCondition": [
-      [
-        "HttpErrorCodeReturnedEquals",
-        "KeyPrefixEquals"
-      ]
     ]
   },
   "ResourceTypes": {

--- a/test/unit/module/test_rules_collections.py
+++ b/test/unit/module/test_rules_collections.py
@@ -62,7 +62,7 @@ class TestTemplate(BaseTestCase):
 
         matches = []
         matches.extend(self.rules.run(filename, cfn))
-        assert len(matches) == 6, 'Expected {} failures, got {}'.format(5, len(matches))
+        self.assertEqual(5, len(matches), 'Expected {} failures, got {}'.format(5, len(matches)))
 
     def test_success_filtering_of_rules_default(self):
         """Test extend function"""

--- a/test/unit/rules/resources/properties/test_onlyone.py
+++ b/test/unit/rules/resources/properties/test_onlyone.py
@@ -21,4 +21,4 @@ class TestPropertyOnlyOne(BaseRuleTestCase):
     def test_file_negative(self):
         """Test failure"""
         self.helper_file_negative(
-            'test/fixtures/templates/bad/resources/properties/onlyone.yaml', 5)
+            'test/fixtures/templates/bad/resources/properties/onlyone.yaml', 4)


### PR DESCRIPTION
*Issue #, if available:*
Fix #1282
*Description of changes:*
- Move routing rule conditions from only one to at least one per documentation

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-websiteconfiguration-routingrules-routingrulecondition.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
