### PR TITLE
Remove support of EOL 3.4 add in 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,46 +2,47 @@ language: python
 sudo: true
 dist: xenial
 services:
-- docker
+  - docker
 stages:
-- Linting
-- Unit Tests
-- Integration
-- Deploy
+  - Linting
+  - Unit Tests
+  - Integration
+  - Deploy
 jobs:
   include:
-  - stage: Linting
-    python: 3.7
-    env: TOXENV=pylint37
-  - python: 2.7
-    env: TOXENV=pylint27
-  - stage: Unit Tests
-    python: 2.7
-    env: TOXENV=py27
-  - python: 3.4
-    env: TOXENV=py34
-  - python: 3.5
-    env: TOXENV=py35
-  - python: 3.6
-    env: TOXENV=py36,codecov
-  - python: 3.7
-    env: TOXENV=py37
-  - stage: Integration
-    python: 3.7
-    script: docker run --rm -it -v ${PWD}:/cfnlint -w /cfnlint python:3.7.1-alpine3.8
-      /bin/sh -c 'pip3 install -e . && cfn-lint test/fixtures/templates/good/generic.yaml && cat test/fixtures/templates/good/generic.yaml | cfn-lint'
-  - stage: Deploy
-    script: skip
-    python: 3.6
-    deploy:
-      provider: pypi
-      user: kddejong
-      password:
-        secure: PRFpbdo0pVE7JvNryNJVsMoIaBERtX9touq4N1YfoLXSp3GFLm7l4iTveJf/XwRMDHlirnt5CNzpEUUD8ra3u6NGhM6ME0G/ti2hy5JI+uANrGlXgwM57y/eQcJRkPbqN71OZ1EFauPm1oXr/YkMkFJ/jSIVvy2Wb0sMuzwgzzdCE79vtA5DCU7vRXE89irNOUzmnqYY+ET3WK9esM2KmkVgvC+eQriakTre0Sp1Q0GrMQxqqHgMpkzt82bxBvd2jCCKTIEYTMXxfWNw5NaUY56nKyFsYyPuiXrau/5ltVNOImITO2eFWeZmPPx4KQdOjyCHg1dYf5urXewXaYz5olg+HJS5pycqUCCkoVGKDqJZZ9nnkabfQ7oYxfDahBl66WMnVwkXQB3CFVV9ztTiHfeW4NlFdn86kDNrEIfFGodIugqhiRiyrOKKlygaqegmJE2ky0ZUoLWqNqCmcYEqMbT36AN4fBRPwqczA5iYcgoR5pOTIP+Mk/HtYDHHecolaGsMxJJiK3Zsk8hL01oVZx0YVyG85XOSLB4z+AVPUFb0SLiJfZSyW8oW7l3UJgC4FQcBpEm7WQ4nMVcaRep/tgwPqeQwl8N6Ks4BNNm7udiGQY06YIy2gANqrse6Yi0RiOK0P5cy/xEPWzc/80LHXxVo9WP8D6rZrl5phIBpMD8=
-      on:
-        tags: true
-      distributions: sdist bdist_wheel
-      skip_existing: true
+    - stage: Linting
+      python: 3.7
+      env: TOXENV=pylint38
+    - python: 2.7
+      env: TOXENV=pylint27
+    - stage: Unit Tests
+      python: 2.7
+      env: TOXENV=py27
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38,codecov
+    - stage: Integration
+      python: 3.7
+      script:
+        docker run --rm -it -v ${PWD}:/cfnlint -w /cfnlint python:3.7.1-alpine3.8
+        /bin/sh -c 'pip3 install -e . && cfn-lint test/fixtures/templates/good/generic.yaml && cat test/fixtures/templates/good/generic.yaml | cfn-lint'
+    - stage: Deploy
+      script: skip
+      python: 3.6
+      deploy:
+        provider: pypi
+        user: kddejong
+        password:
+          secure: PRFpbdo0pVE7JvNryNJVsMoIaBERtX9touq4N1YfoLXSp3GFLm7l4iTveJf/XwRMDHlirnt5CNzpEUUD8ra3u6NGhM6ME0G/ti2hy5JI+uANrGlXgwM57y/eQcJRkPbqN71OZ1EFauPm1oXr/YkMkFJ/jSIVvy2Wb0sMuzwgzzdCE79vtA5DCU7vRXE89irNOUzmnqYY+ET3WK9esM2KmkVgvC+eQriakTre0Sp1Q0GrMQxqqHgMpkzt82bxBvd2jCCKTIEYTMXxfWNw5NaUY56nKyFsYyPuiXrau/5ltVNOImITO2eFWeZmPPx4KQdOjyCHg1dYf5urXewXaYz5olg+HJS5pycqUCCkoVGKDqJZZ9nnkabfQ7oYxfDahBl66WMnVwkXQB3CFVV9ztTiHfeW4NlFdn86kDNrEIfFGodIugqhiRiyrOKKlygaqegmJE2ky0ZUoLWqNqCmcYEqMbT36AN4fBRPwqczA5iYcgoR5pOTIP+Mk/HtYDHHecolaGsMxJJiK3Zsk8hL01oVZx0YVyG85XOSLB4z+AVPUFb0SLiJfZSyW8oW7l3UJgC4FQcBpEm7WQ4nMVcaRep/tgwPqeQwl8N6Ks4BNNm7udiGQY06YIy2gANqrse6Yi0RiOK0P5cy/xEPWzc/80LHXxVo9WP8D6rZrl5phIBpMD8=
+        on:
+          tags: true
+        distributions: sdist bdist_wheel
+        skip_existing: true
 install:
-- pip install tox
+  - pip install tox
 script: tox

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,7 @@ setup(
     packages=find_packages('src'),
     zip_safe=False,
     install_requires=[
-        'pyyaml<=5.2;python_version=="3.4"',
-        'pyyaml;python_version!="3.4"',
+        'pyyaml',
         'six~=1.11',
         'aws-sam-translator>=1.19.1',
         'jsonpatch',
@@ -72,7 +71,7 @@ setup(
         'pathlib2>=2.3.0;python_version<="3.4"',
         'importlib_resources~=1.0.2;python_version<"3.7"',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     entry_points={
         'console_scripts': [
             'cfn-lint = cfnlint.__main__:main'
@@ -89,9 +88,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37},pylint{37,36,27}
+envlist = py{27,35,36,37,38},pylint{38,27}
 
 [testenv]
 commands =


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Remove support for Python 3.4.  
- Add in support for Python 3.8

PyYAML a dependent package has removed support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
