### PR TITLE
Add CNAME to the list of allowed values for ServiceDiscoveryDnsType

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -28579,7 +28579,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -52832,7 +52832,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -47360,7 +47360,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -26279,7 +26279,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -48719,7 +48719,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -50024,7 +50024,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -52592,7 +52592,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -42194,7 +42194,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/cn-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-north-1.json
@@ -28196,7 +28196,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
@@ -25292,7 +25292,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -53336,7 +53336,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -31752,7 +31752,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -55626,7 +55626,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -47619,7 +47619,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -37389,7 +37389,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/me-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/me-south-1.json
@@ -26539,7 +26539,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -38558,7 +38558,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -55901,7 +55901,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -51310,7 +51310,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -26391,7 +26391,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -30898,7 +30898,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -41560,7 +41560,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -55568,7 +55568,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -726,7 +726,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV"
+        "SRV",
+        "CNAME"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/bad/resources/properties/allowed_values.yaml
@@ -806,7 +806,7 @@ Resources:
         Type: "SSH" # Invalid AllowedValue
       DnsConfig:
         DnsRecords:
-          - Type: "CNAME" # Invalid AllowedValue
+          - Type: "NS" # Invalid AllowedValue
             TTL: 60
   SesReceiptRule:
     Type: "AWS::SES::ReceiptRule"

--- a/test/fixtures/templates/good/resources/properties/allowed_values.yaml
+++ b/test/fixtures/templates/good/resources/properties/allowed_values.yaml
@@ -857,7 +857,7 @@ Resources:
         Type: "HTTP" # Valid AllowedValue
       DnsConfig:
         DnsRecords:
-          - Type: "A" # Valid AllowedValue
+          - Type: "CNAME" # Valid AllowedValue
             TTL: 60
   SesReceiptRule:
     Type: "AWS::SES::ReceiptRule"


### PR DESCRIPTION
*Description of changes:*
The `ServiceDiscovery::Service` resource has a set of allowed values for `ServiceDiscoveryDnsType`. This list seems to be missing `CNAME`

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-servicediscovery-service.html

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-servicediscovery-service-dnsrecord.html#cfn-servicediscovery-service-dnsrecord-type

 I have added `CNAME` to this list because my template fails lint checks even though it can be successfully executed:

    "cloudMapService": {
      "Type": "AWS::ServiceDiscovery::Service",
      "Properties": {
        "Name": "service",
        "Description": "Service",
        "DnsConfig": {
          "DnsRecords": [
            {
              "TTL": 30.0,
              "Type": "CNAME"
            }
          ],
          "RoutingPolicy": "WEIGHTED"
        },
        "NamespaceId": {
          "Fn::ImportValue": {
            "Fn::Sub": "NamespaceId"
          }
        }
      }
    },


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
