### PR TITLE
Add new scaling policy metric type permitted value

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_applicationautoscaling.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_applicationautoscaling.json
@@ -24,7 +24,8 @@
         "ECSServiceAverageMemoryUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance"
+        "SageMakerVariantInvocationsPerInstance",
+        "LambdaProvisionedConcurrencyUtilization"
       ]
     }
   }


### PR DESCRIPTION
*Description of changes:* Adds `LambdaProvisionedConcurrencyUtilization` as a permitted value for Application Autoscaling Metric Type.

Docs: https://aws.amazon.com/blogs/aws/new-provisioned-concurrency-for-lambda-functions/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
