### PR TITLE
Extra exclusive properties for AWS::CloudWatch::Alarm

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/Exclusive.json
+++ b/src/cfnlint/data/AdditionalSpecs/Exclusive.json
@@ -66,10 +66,14 @@
         "Period",
         "Namespace",
         "Statistic",
-        "ExtendedStatistic"
+        "ExtendedStatistic",
+        "Unit"
       ],
       "Statistic": [
         "ExtendedStatistic"
+      ],
+      "Threshold": [
+        "ThresholdMetricId"
       ]
     },
     "AWS::ServiceDiscovery::Service": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_applicationautoscaling.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_applicationautoscaling.json
@@ -24,7 +24,8 @@
         "ECSServiceAverageMemoryUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance"
+        "SageMakerVariantInvocationsPerInstance",
+        "LambdaProvisionedConcurrencyUtilization"
       ]
     }
   }


### PR DESCRIPTION
*Description of changes:*

Some extra exclusive properties for CloudWatch Alarm based on the following errors:

```
Unit should not be set if list of Metrics is set. (Service: AmazonCloudWatch; Status Code: 400; Error Code: ValidationError; Request ID: ...)
```

```
Threshold and ThresholdMetricId cannot both be set (Service: AmazonCloudWatch; Status Code: 400; Error Code: ValidationError; Request ID: ...)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
