### PR TITLE
Fix ${aws:username} fails for a Deny + NotResource

### DIFF
--- a/src/cfnlint/rules/functions/SubNeeded.py
+++ b/src/cfnlint/rules/functions/SubNeeded.py
@@ -103,10 +103,7 @@ class SubNeeded(CloudFormationLintRule):
             # Exxclude the special IAM variables
             variable = parameter_string_path[-1]
 
-            if 'Resource' in parameter_string_path:
-                if variable in self.resource_excludes:
-                    continue
-            if 'NotResource' in parameter_string_path:
+            if 'Resource' or 'NotResource' in parameter_string_path:
                 if variable in self.resource_excludes:
                     continue
             if 'Condition' in parameter_string_path:

--- a/src/cfnlint/rules/functions/SubNeeded.py
+++ b/src/cfnlint/rules/functions/SubNeeded.py
@@ -106,6 +106,9 @@ class SubNeeded(CloudFormationLintRule):
             if 'Resource' in parameter_string_path:
                 if variable in self.resource_excludes:
                     continue
+            if 'NotResource' in parameter_string_path:
+                if variable in self.resource_excludes:
+                    continue
             if 'Condition' in parameter_string_path:
                 if variable in self.condition_excludes:
                     continue

--- a/src/cfnlint/rules/functions/SubNeeded.py
+++ b/src/cfnlint/rules/functions/SubNeeded.py
@@ -103,7 +103,10 @@ class SubNeeded(CloudFormationLintRule):
             # Exxclude the special IAM variables
             variable = parameter_string_path[-1]
 
-            if 'Resource' or 'NotResource' in parameter_string_path:
+            if 'Resource' in parameter_string_path:
+                if variable in self.resource_excludes:
+                    continue
+            if 'NotResource' in parameter_string_path:
                 if variable in self.resource_excludes:
                     continue
             if 'Condition' in parameter_string_path:

--- a/test/fixtures/templates/bad/functions/sub_needed.yaml
+++ b/test/fixtures/templates/bad/functions/sub_needed.yaml
@@ -23,6 +23,10 @@ Resources:
           Action:
             - "iam:UploadSSHPublicKey"
           Resource: "arn:aws:iam::${AWS::AccountId}:user/${aws:username}-${AMIId}"
+        - Effect: "Deny"
+          Action:
+             - "iam:GetLoginProfile"
+          NotResource: "arn:aws:iam::${AWS::AccountId}:user/${aws:username}-${AMIId}"
   mySnsTopic:
     Type: AWS::SNS::Topic
     Properties:

--- a/test/fixtures/templates/good/functions/sub_needed.yaml
+++ b/test/fixtures/templates/good/functions/sub_needed.yaml
@@ -21,6 +21,10 @@ Resources:
           Action:
             - "iam:UploadSSHPublicKey"
           Resource: "arn:aws:iam::*:user/${aws:username}"
+        - Effect: "Deny"
+          Action:
+           - "iam:GetLoginProfile"
+          NotResource: "arn:aws:iam::*:user/${aws:username}"
   myPolicy2:
     Type: AWS::IAM::Policy
     Properties:

--- a/test/unit/rules/functions/test_sub_needed.py
+++ b/test/unit/rules/functions/test_sub_needed.py
@@ -25,4 +25,4 @@ class TestSubNeeded(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/functions/sub_needed.yaml', 3)
+        self.helper_file_negative('test/fixtures/templates/bad/functions/sub_needed.yaml', 4)


### PR DESCRIPTION
Issue # [1314](https://github.com/aws-cloudformation/cfn-python-lint/issues/1314)

Add rule to continue if parameter_string_path is `NotResource` and update Unit Test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
