### PR TITLE
E6001: Fn::Transform can be used in output values

### DIFF
--- a/src/cfnlint/rules/outputs/Configuration.py
+++ b/src/cfnlint/rules/outputs/Configuration.py
@@ -23,7 +23,7 @@ class Configuration(CloudFormationLintRule):
     ]
 
     # Map can be singular or multiple for this case we are going to skip
-    valid_funcs = FUNCTIONS_SINGLE + ['Fn::FindInMap']
+    valid_funcs = FUNCTIONS_SINGLE + ['Fn::FindInMap', 'Fn::Transform']
 
     def check_func(self, value, path):
         """ Check that a value is using the correct functions """


### PR DESCRIPTION
*Description of changes:*

cfn-lint v0.27.0 threw an error on a working template of ours, stating that `Fn::Transform` is not an allowed function for an `Output` `Value`. Transforms are actually working just fine in outputs, hence my addition of the function to the `valid_funcs` list.

Please let me know if anything is missing!

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
