### PR TITLE
In cases where elasticache had a parameter group defining elasticache…

### DIFF
--- a/src/cfnlint/rules/resources/elasticache/CacheClusterFailover.py
+++ b/src/cfnlint/rules/resources/elasticache/CacheClusterFailover.py
@@ -36,7 +36,7 @@ class CacheClusterFailover(CloudFormationLintRule):
         pg_conditions = cfn.get_conditions_from_path(cfn.template, pg_path)
         # test to make sure that any condition that may apply to the path for the Ref
         # is not applicable
-        if pg_conditions:
+        if pg_conditions and scenario:
             for c_name, c_value in scenario.items():
                 if c_name in pg_conditions:
                     if c_value not in pg_conditions.get(c_name):

--- a/test/fixtures/templates/good/resources/elasticache/cache_cluster_failover.yaml
+++ b/test/fixtures/templates/good/resources/elasticache/cache_cluster_failover.yaml
@@ -4,9 +4,13 @@ Parameters:
   toCluster:
     Type: String
     Default: 'yes'
+  optionalCluster:
+    Type: String
+    Default: 'yes'
 Conditions:
   isCluster: !Equals [!Ref 'toCluster', 'yes']
   IsTesting: !Equals [!Ref 'AWS::Region', 'us-east-1']
+  IsOptionalCluster: !Equals [!Ref 'optionalCluster', 'yes']
 Resources:
   MyParameterGroup:
     Type: AWS::ElastiCache::ParameterGroup
@@ -28,6 +32,15 @@ Resources:
     Type: AWS::ElastiCache::ParameterGroup
     Properties:
       Description: "MyNewParameterGroup"
+      CacheParameterGroupFamily: "memcached1.4"
+      Properties:
+        cas_disabled: "1"
+        cluster-enabled: 'no'
+  MyOptionalClusterParameterGroup:
+    Type: AWS::ElastiCache::ParameterGroup
+    Condition: IsOptionalCluster
+    Properties:
+      Description: "MyOptionalParameterGroup"
       CacheParameterGroupFamily: "memcached1.4"
       Properties:
         cas_disabled: "1"
@@ -101,6 +114,40 @@ Resources:
       Engine: "redis"
       EngineVersion: "4.0.10"
       NumNodeGroups: !If [IsTesting, 1, 3]  # No Error when NumNodeGroups specified
+      ReplicasPerNodeGroup: 1
+      PreferredMaintenanceWindow: "Mon:04:00-Mon:06:00"
+      ReplicationGroupDescription: test
+      SecurityGroupIds:
+      - sg-test
+  FifthReplicationGroup:
+    Type: "AWS::ElastiCache::ReplicationGroup"
+    Condition: IsOptionalCluster
+    Properties:
+      AtRestEncryptionEnabled: true
+      AutomaticFailoverEnabled: true
+      CacheNodeType: cache.r3.large
+      CacheParameterGroupName: !Ref "MyOptionalClusterParameterGroup"
+      CacheSubnetGroupName: subnetGroup
+      Engine: "redis"
+      EngineVersion: "4.0.10"
+      NumNodeGroups: 1
+      ReplicasPerNodeGroup: 1
+      PreferredMaintenanceWindow: "Mon:04:00-Mon:06:00"
+      ReplicationGroupDescription: test
+      SecurityGroupIds:
+      - sg-test
+  SixthReplicationGroup:
+    Type: "AWS::ElastiCache::ReplicationGroup"
+    Condition: IsOptionalCluster
+    Properties:
+      AtRestEncryptionEnabled: true
+      AutomaticFailoverEnabled: true
+      CacheNodeType: cache.r3.large
+      CacheParameterGroupName: !Ref "MyNonClusterParameterGroup"
+      CacheSubnetGroupName: subnetGroup
+      Engine: "redis"
+      EngineVersion: "4.0.10"
+      NumNodeGroups: 1
       ReplicasPerNodeGroup: 1
       PreferredMaintenanceWindow: "Mon:04:00-Mon:06:00"
       ReplicationGroupDescription: test


### PR DESCRIPTION
… properties on a conditional elasticache resource with static pg property values, no scenarios would be generated causing an access violation on a NonType

*Issue #, if available:*

This issue was found when I was optionally generating an ElastiCache cluster in a cloudformation template. There were two resolutions when using the current `cfn-lint` releases:

* Ignore `E3026` check; or
* Add `Fn::If` to ElastiCache ParameterGroup so that a scenario would be generated.
Example of hacking around problem with `Fn::If` solution:
```
  MyCacheParameterGroup:
    Type: AWS::ElastiCache::ParameterGroup
    Condition: HasCacheResources
    Properties:
      CacheParameterGroupFamily: 'redis5.0'
      Description: MyCacheParameterGroup
      Properties:
        "maxmemory-policy":
          Fn::If:
            - HasCacheResources
            - "allkeys-lru"
            - "allkeys-lru"
```

*Description of changes:*

Checking if `scenario` object is not None.

Here is the `cfn-lint` output without the `and scenario` fix but with the updated yaml template that reproduces the error (`test/fixtures/templates/good/resources/elasticache/cache_cluster_failover.yaml`):

```
/cfnlint # cfn-lint test/fixtures/templates/good/resources/elasticache/cache_cluster_failover.yaml
E0002 Unknown exception while processing rule E3026: 'NoneType' object has no attribute 'items'
test/fixtures/templates/good/resources/elasticache/cache_cluster_failover.yaml:1:1
```

With the `and scenario` fix `cfn-lint` passes successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
