### PR TITLE
warn on py3.4 and py2.7 eol dates for cfn-lint

### DIFF
--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -2,6 +2,7 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
+import warnings
 import sys
 import logging
 import cfnlint.core
@@ -12,6 +13,13 @@ LOGGER = logging.getLogger('cfnlint')
 
 def main():
     """Main function"""
+    if sys.version_info[:2] == (3, 4):
+        warnings.warn('Python 3.4 has reached end of life. '
+                      'cfn-lint will end support for python 3.4 on July 1st, 2020.', Warning, stacklevel=3)
+    elif sys.version_info[:2] == (2, 7):
+        warnings.warn('Python 2.7 has reached end of life. '
+                      'cfn-lint will end support for python 2.7 on December 31st, 2020.', Warning, stacklevel=3)
+
     try:
         (args, filenames, formatter) = cfnlint.core.get_args_filenames(sys.argv[1:])
         matches = []


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- warn on py3.4 eol date
- warn on py2.7 eol date

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
