### PR TITLE
Update EFSFileSystemLifecyclePolicy values

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -154,6 +154,7 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
+        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",


### PR DESCRIPTION
*Description of changes:*
Add `AFTER_7_DAYS` to `TransitionToIA` as accepted value.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticfilesystem-filesystem-lifecyclepolicy.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
