### PR TITLE
Fix unit test failing when executed on Windows due to OS-specific path separator

### DIFF
--- a/test/unit/module/config/test_config_mixin.py
+++ b/test/unit/module/config/test_config_mixin.py
@@ -3,6 +3,7 @@ Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import logging
+import os
 from test.testlib.testcase import BaseTestCase
 from mock import patch
 import cfnlint.config  # pylint: disable=E0401
@@ -96,8 +97,8 @@ class TestConfigMixIn(BaseTestCase):
 
         # test defaults
         self.assertEqual(config.templates, [
-            'test/fixtures/templates/public/lambda-poller.yaml',
-            'test/fixtures/templates/public/rds-cluster.yaml'])
+            'test/fixtures/templates/public' + os.path.sep + 'lambda-poller.yaml',
+            'test/fixtures/templates/public' + os.path.sep + 'rds-cluster.yaml'])
 
     @patch('cfnlint.config.ConfigFileArgs._read_config', create=True)
     def test_config_expand_paths_failure(self, yaml_mock):


### PR DESCRIPTION
*Description of changes:*

Modified a test that was failing on my Windows 10 machine with the following error:

```
FAIL: test_config_expand_paths (test.unit.module.config.test_config_mixin.TestConfigMixIn)
Test precedence in
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Program Files (x86)\Python38-32\lib\site-packages\mock\mock.py", line 1369, in patched
    return func(*newargs, **newkeywargs)
  File "K:\SWS\cfn-python-lint\test\unit\module\config\test_config_mixin.py", line 98, in test_config_expand_paths
    self.assertEqual(config.templates, [
AssertionError: Lists differ: ['tes[22 chars]ublic\\lambda-poller.yaml', 'test/fixtures/tem[28 chars]aml'] != ['tes[22 chars]ublic/lambda-poller.yaml', 'test/fixtures/temp[26 chars]aml']

First differing element 0:
'test/fixtures/templates/public\\lambda-poller.yaml'
'test/fixtures/templates/public/lambda-poller.yaml'

- ['test/fixtures/templates/public\\lambda-poller.yaml',
?                                 ^^

+ ['test/fixtures/templates/public/lambda-poller.yaml',
?                                 ^

-  'test/fixtures/templates/public\\rds-cluster.yaml']
?                                 ^^

+  'test/fixtures/templates/public/rds-cluster.yaml']
?  
```

Looks like the test assumes the path separator is '/', which is not in my case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
