### PR TITLE
Add option to disable E1029 using a regex pattern on the variable name (#1278)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,15 +185,21 @@ cfn-lint applies configurations from several sources. The rules at lower levels 
 
 ### Configure Rules
 
-Certain rules will support configuration properties. You can configure these rules by using `configure_rules` parameter.
+Certain rules support configuration properties. You can configure these rules by using `configure_rules` parameter.
 
-From the command line the format is `E3012:strict=false`
+From the command line the format is `RuleId:key=value`, for example: `E3012:strict=false`.
 From the cfnlintrc or Metadata section the format is
+
+```yaml
+Metadata:
+  cfn-lint:
+    config:
+      configure_rules:
+        RuleId:
+          key: value
 ```
-configure_rules:
-  E3012:
-    strict: False  
-```
+
+The configurable rules have a non-empty Config entry in the table [here](docs/rules.md#rules-1).
 
 ### Getting Started Guides
 

--- a/test/fixtures/templates/good/functions/sub_needed_custom_excludes.yaml
+++ b/test/fixtures/templates/good/functions/sub_needed_custom_excludes.yaml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Template containing third-party preprocessor-like variables to test custom ignore filters
+Resources:
+  TestRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: TestRole-${self:provider.stage}
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - arn:aws:iam::${self:custom.config.masterAccount}:user/${self:custom.config.deploymentUser}
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: TestBucket
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - arn:aws:s3:::${self:custom.config.deploymentBucket}/*

--- a/test/unit/rules/functions/test_sub_needed.py
+++ b/test/unit/rules/functions/test_sub_needed.py
@@ -23,6 +23,17 @@ class TestSubNeeded(BaseRuleTestCase):
         """Test Positive"""
         self.helper_file_positive()
 
+    def test_template_config(self):
+        """Test custom excludes configuration"""
+        self.helper_file_rule_config(
+            'test/fixtures/templates/good/functions/sub_needed_custom_excludes.yaml',
+            {'custom_excludes': '^\${self.+}$'}, 0
+        )
+        self.helper_file_rule_config(
+            'test/fixtures/templates/good/functions/sub_needed_custom_excludes.yaml',
+            {}, 3
+        )        
+
     def test_file_negative(self):
         """Test failure"""
         self.helper_file_negative('test/fixtures/templates/bad/functions/sub_needed.yaml', 4)


### PR DESCRIPTION
*Issue #, if available:*
#1278 

*Description of changes:*
Added a config option that lets cfn-lint ignore certain "variables" in a CloudFormation template, that are not a truly valid CloudFormation syntax. As described in #1278, this is useful when using cfn-lint in combination with 3rd party tools such as Serverless Framework that do preprocessing of the template before uploading it to AWS.

Config example:
```yaml
# .cfnlintrc
configure_rules:
  E1029:
    custom_excludes: ^\${self.+}$
```

The above configuration will make cfn-lint treat any variable that starts with "self" as a literal, as far as rule E1029 is concerned.

-----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
