### PR TITLE
Fix an issue with get_safe when default isn't specified but type_t is

### DIFF
--- a/src/cfnlint/decode/node.py
+++ b/src/cfnlint/decode/node.py
@@ -117,14 +117,23 @@ def create_dict_node_class(cls):
             """
             path = path or []
             value = self.get(key, default)
+            if value is None and default is None:
+                # if default is None and value is None return empty list
+                return []
+
+            # if the value is the default make sure that the default value is of type_t when specified
+            if bool(type_t) and value == default and not isinstance(default, type_t):
+                raise ValueError('"default" type should be of "type_t"')
+
+            # when not a dict see if if the value is of the right type
+            results = []
             if not isinstance(value, (dict)):
                 if isinstance(value, type_t) or not type_t:
                     return [(value, (path[:] + [key]))]
-
-            results = []
-            for sub_v, sub_path in value.items_safe(path + [key]):
-                if isinstance(sub_v, type_t) or not type_t:
-                    results.append((sub_v, sub_path))
+            else:
+                for sub_v, sub_path in value.items_safe(path + [key]):
+                    if isinstance(sub_v, type_t) or not type_t:
+                        results.append((sub_v, sub_path))
 
             return results
 


### PR DESCRIPTION
*Issue #, if available:*
Fix #1363 
*Description of changes:*
- Fix an issue with decode when default is None and type_t is specified

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
