### PR TITLE
Don't fail on AWS::CloudFormation::Stack not being a string

### DIFF
--- a/src/cfnlint/rules/resources/properties/ValuePrimitiveType.py
+++ b/src/cfnlint/rules/resources/properties/ValuePrimitiveType.py
@@ -84,7 +84,6 @@ class ValuePrimitiveType(CloudFormationLintRule):
     def check_primitive_type(self, value, item_type, path):
         """Chec item type"""
         matches = []
-
         if isinstance(value, dict) and item_type == 'Json':
             return matches
         if item_type in ['String']:
@@ -140,7 +139,7 @@ class ValuePrimitiveType(CloudFormationLintRule):
 
         return matches
 
-    def check(self, cfn, properties, specs, path):
+    def check(self, cfn, properties, specs, spec_type, path):
         """Check itself"""
         matches = []
 
@@ -154,14 +153,15 @@ class ValuePrimitiveType(CloudFormationLintRule):
                 else:
                     item_type = None
                 if primitive_type:
-                    matches.extend(
-                        cfn.check_value(
-                            properties, prop, path,
-                            check_value=self.check_value,
-                            primitive_type=primitive_type,
-                            item_type=item_type
+                    if not(spec_type == 'AWS::CloudFormation::Stack' and prop == 'Parameters'):
+                        matches.extend(
+                            cfn.check_value(
+                                properties, prop, path,
+                                check_value=self.check_value,
+                                primitive_type=primitive_type,
+                                item_type=item_type
+                            )
                         )
-                    )
 
         return matches
 
@@ -171,7 +171,7 @@ class ValuePrimitiveType(CloudFormationLintRule):
 
         if self.property_specs.get(property_type, {}).get('Properties'):
             property_specs = self.property_specs.get(property_type, {}).get('Properties', {})
-            matches.extend(self.check(cfn, properties, property_specs, path))
+            matches.extend(self.check(cfn, properties, property_specs, property_type, path))
 
         return matches
 
@@ -179,6 +179,6 @@ class ValuePrimitiveType(CloudFormationLintRule):
         """Check CloudFormation Properties"""
         matches = []
         resource_specs = self.resource_specs.get(resource_type, {}).get('Properties', {})
-        matches.extend(self.check(cfn, properties, resource_specs, path))
+        matches.extend(self.check(cfn, properties, resource_specs, resource_type, path))
 
         return matches

--- a/test/fixtures/templates/good/resources/properties/primitive_types.yaml
+++ b/test/fixtures/templates/good/resources/properties/primitive_types.yaml
@@ -6,7 +6,7 @@ Resources:
     Properties:
       Name: Test
       Cutoff: 0
-      Schedule: 'rate(1 days)'
+      Schedule: "rate(1 days)"
       AllowUnassociatedTargets: false
       Duration: 1
   BaselinePatchDailySSMMaintenanceWindowTarget:
@@ -17,7 +17,13 @@ Resources:
       WindowId: !Ref BaselinePatchDailySSMMaintenanceWindow
       ResourceType: INSTANCE
       Targets:
-      - Key: tag:Patch
-        Values:
-        - Daily
-        - daily
+        - Key: tag:Patch
+          Values:
+            - Daily
+            - daily
+  ManagerService:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: ../../../common/service.yaml
+      Parameters:
+        DesiredCount: 1


### PR DESCRIPTION
*Issue #, if available:*
Fix #800 
*Description of changes:*
- Do not fail E3012 on `AWS::CloudFormation::Stack` `Parameters` when they aren't a string

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
