### PR TITLE
AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment AllowedValues

### DIFF
--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -30046,6 +30046,13 @@
       "NumberMax": 100000,
       "NumberMin": 1
     },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
+    },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,
       "NumberMin": 1

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -45175,7 +45175,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-runtimeenvironment",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment"
+          }
         },
         "ServiceExecutionRole": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-serviceexecutionrole",
@@ -53602,6 +53605,13 @@
     "AWS::Kinesis::Stream.ShardCount": {
       "NumberMax": 100000,
       "NumberMin": 1
+    },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
     },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -42486,7 +42486,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-runtimeenvironment",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment"
+          }
         },
         "ServiceExecutionRole": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-serviceexecutionrole",
@@ -50389,6 +50392,13 @@
     "AWS::Kinesis::Stream.ShardCount": {
       "NumberMax": 100000,
       "NumberMin": 1
+    },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
     },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -25575,6 +25575,13 @@
       "NumberMax": 100000,
       "NumberMin": 1
     },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
+    },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,
       "NumberMin": 1

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -49338,6 +49338,13 @@
       "NumberMax": 100000,
       "NumberMin": 1
     },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
+    },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,
       "NumberMin": 1

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -42814,7 +42814,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-runtimeenvironment",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment"
+          }
         },
         "ServiceExecutionRole": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-serviceexecutionrole",
@@ -50850,6 +50853,13 @@
     "AWS::Kinesis::Stream.ShardCount": {
       "NumberMax": 100000,
       "NumberMin": 1
+    },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
     },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -44628,7 +44628,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-runtimeenvironment",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment"
+          }
         },
         "ServiceExecutionRole": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-serviceexecutionrole",
@@ -53337,6 +53340,13 @@
     "AWS::Kinesis::Stream.ShardCount": {
       "NumberMax": 100000,
       "NumberMin": 1
+    },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
     },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -43376,6 +43376,13 @@
       "NumberMax": 100000,
       "NumberMin": 1
     },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
+    },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,
       "NumberMin": 1

--- a/src/cfnlint/data/CloudSpecs/cn-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-north-1.json
@@ -29656,6 +29656,13 @@
       "NumberMax": 100000,
       "NumberMin": 1
     },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
+    },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,
       "NumberMin": 1

--- a/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
@@ -27028,6 +27028,13 @@
       "NumberMax": 100000,
       "NumberMin": 1
     },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
+    },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,
       "NumberMin": 1

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -44833,7 +44833,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-runtimeenvironment",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment"
+          }
         },
         "ServiceExecutionRole": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-serviceexecutionrole",
@@ -53866,6 +53869,13 @@
     "AWS::Kinesis::Stream.ShardCount": {
       "NumberMax": 100000,
       "NumberMin": 1
+    },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
     },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -35378,6 +35378,13 @@
       "NumberMax": 100000,
       "NumberMin": 1
     },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
+    },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,
       "NumberMin": 1

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -46876,7 +46876,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-runtimeenvironment",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment"
+          }
         },
         "ServiceExecutionRole": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-serviceexecutionrole",
@@ -56364,6 +56367,13 @@
     "AWS::Kinesis::Stream.ShardCount": {
       "NumberMax": 100000,
       "NumberMin": 1
+    },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
     },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -40613,7 +40613,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-runtimeenvironment",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment"
+          }
         },
         "ServiceExecutionRole": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-serviceexecutionrole",
@@ -48285,6 +48288,13 @@
     "AWS::Kinesis::Stream.ShardCount": {
       "NumberMax": 100000,
       "NumberMin": 1
+    },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
     },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -38288,6 +38288,13 @@
       "NumberMax": 100000,
       "NumberMin": 1
     },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
+    },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,
       "NumberMin": 1

--- a/src/cfnlint/data/CloudSpecs/me-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/me-south-1.json
@@ -29082,6 +29082,13 @@
       "NumberMax": 100000,
       "NumberMin": 1
     },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
+    },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,
       "NumberMin": 1

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -39269,6 +39269,13 @@
       "NumberMax": 100000,
       "NumberMin": 1
     },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
+    },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,
       "NumberMin": 1

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -47313,7 +47313,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-runtimeenvironment",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment"
+          }
         },
         "ServiceExecutionRole": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-serviceexecutionrole",
@@ -56875,6 +56878,13 @@
     "AWS::Kinesis::Stream.ShardCount": {
       "NumberMax": 100000,
       "NumberMin": 1
+    },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
     },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -44310,7 +44310,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-runtimeenvironment",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment"
+          }
         },
         "ServiceExecutionRole": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-serviceexecutionrole",
@@ -52512,6 +52515,13 @@
     "AWS::Kinesis::Stream.ShardCount": {
       "NumberMax": 100000,
       "NumberMin": 1
+    },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
     },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -26654,6 +26654,13 @@
       "NumberMax": 100000,
       "NumberMin": 1
     },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
+    },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,
       "NumberMin": 1

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -32628,6 +32628,13 @@
       "NumberMax": 100000,
       "NumberMin": 1
     },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
+    },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,
       "NumberMin": 1

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -41939,6 +41939,13 @@
       "NumberMax": 100000,
       "NumberMin": 1
     },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
+    },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,
       "NumberMin": 1

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -47272,7 +47272,10 @@
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-runtimeenvironment",
           "PrimitiveType": "String",
           "Required": true,
-          "UpdateType": "Immutable"
+          "UpdateType": "Immutable",
+          "Value": {
+            "ValueType": "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment"
+          }
         },
         "ServiceExecutionRole": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-serviceexecutionrole",
@@ -56760,6 +56763,13 @@
     "AWS::Kinesis::Stream.ShardCount": {
       "NumberMax": 100000,
       "NumberMin": 1
+    },
+    "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment": {
+      "AllowedValues": [
+        "FLINK-1_6",
+        "FLINK-1_8",
+        "SQL-1_0"
+      ]
     },
     "AWS::Lambda::EventSourceMapping.BatchSize": {
       "NumberMax": 10000,

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_kinesisanalyticsv2.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_kinesisanalyticsv2.json
@@ -1,0 +1,13 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment",
+    "value": { 
+      "AllowedValues": [ 
+        "FLINK-1_6", 
+        "FLINK-1_8",
+        "SQL-1_0" 
+      ] 
+    } 
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_kinesisanalyticsv2.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_kinesisanalyticsv2.json
@@ -1,0 +1,9 @@
+[
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::KinesisAnalyticsV2::Application/Properties/RuntimeEnvironment/Value",
+    "value": {
+      "ValueType": "AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment"
+    }
+  }
+]


### PR DESCRIPTION
[inconsistent `AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment` documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesisanalyticsv2-application.html#cfn-kinesisanalyticsv2-application-runtimeenvironment)

https://github.com/cloudtools/troposphere/issues/1583#issuecomment-586741771

```
1 validation error detected: Value 'SQL-1.0' at 'runtimeEnvironment' failed to satisfy constraint: Member must satisfy enum value set: [SQL-1_0, FLINK-1_6, FLINK-1_8] (Service: AmazonKinesisAnalyticsV2; Status Code: 400; Error Code: ValidationException; Request ID: REDACTED)
```

---

[`src/cfnlint/data/ExtendedSpecs/all/`](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/src/cfnlint/data/ExtendedSpecs/all) artisanally hand-crafted 
[`src/cfnlint/data/CloudSpecs/`](https://github.com/aws-cloudformation/cfn-python-lint/tree/master/src/cfnlint/data/CloudSpecs) changes generated from:
```shell
cfn-python-lint $ pip3 install -e . --user
cfn-python-lint $ cfn-lint --update-specs
```