### PR TITLE
Fix noisy tests

### DIFF
--- a/test/unit/module/core/test_run_cli.py
+++ b/test/unit/module/core/test_run_cli.py
@@ -24,6 +24,7 @@ class TestCli(BaseTestCase):
 
     def tearDown(self):
         """Tear Down"""
+        logging.disable(logging.NOTSET)
         for handler in LOGGER.handlers:
             LOGGER.removeHandler(handler)
 

--- a/test/unit/module/core/test_run_cli.py
+++ b/test/unit/module/core/test_run_cli.py
@@ -16,8 +16,14 @@ LOGGER = logging.getLogger('cfnlint')
 class TestCli(BaseTestCase):
     """Test CLI processing """
 
-    def tearDown(self):
+    def setUp(self):
         """Setup"""
+        # Disable all but critical logger output, as both 'test_template_not_found' and
+        # 'test_template_not_found_directory' like to print out errors to the console.
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        """Tear Down"""
         for handler in LOGGER.handlers:
             LOGGER.removeHandler(handler)
 
@@ -27,7 +33,7 @@ class TestCli(BaseTestCase):
         filename = 'test/fixtures/templates/good/core/not_found.yaml'
 
         (args, filenames, _) = cfnlint.core.get_args_filenames(
-            ['--template', filename, '--ignore_bad_template'])
+            ['--template', filename, '--ignore-bad-template'])
         (_, _, matches) = cfnlint.core.get_template_rules(filenames[0], args)
 
         self.assertEqual(len(matches), 1)
@@ -38,7 +44,7 @@ class TestCli(BaseTestCase):
         filename = 'test/fixtures/templates/good/core'
 
         (args, filenames, _) = cfnlint.core.get_args_filenames(
-            ['--template', filename, '--ignore_bad_template'])
+            ['--template', filename, '--ignore-bad-template'])
         (_, _, matches) = cfnlint.core.get_template_rules(filenames[0], args)
 
         self.assertEqual(len(matches), 1)


### PR DESCRIPTION
*Description of changes:* I was fed up of seeing the template not found and directory not found tests appearing in the console when running tests, so I decided to fix it. I have tested that failing tests still show up as normal after the test runner has concluded.

The current situation:
```
py27 run-test: commands[1] | coverage run -m unittest discover -s test
.............2020-03-19 12:32:55,859 - cfnlint.decode - ERROR - Template file not found: test/fixtures/templates/good/core/not_found.yaml
.2020-03-19 12:32:55,866 - cfnlint.decode - ERROR - Template references a directory, not a file: test/fixtures/templates/good/core
...........
```

With this PR:
```
py27 run-test: commands[1] | coverage run -m unittest discover -s test
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 473 tests in 106.894s

OK
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
