### PR TITLE
dotnetcore3.1 AWS::Lambda::Function.Runtime

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -372,6 +372,7 @@
         "dotnetcore1.0",
         "dotnetcore2.0",
         "dotnetcore2.1",
+        "dotnetcore3.1",
         "go1.x",
         "java8",
         "java11",


### PR DESCRIPTION
https://aws.amazon.com/blogs/compute/announcing-aws-lambda-supports-for-net-core-3-1/

fixes https://github.com/aws-cloudformation/cfn-python-lint/issues/1468

[`AWS::Lambda::Function.Runtime`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime)