### PR TITLE
Added DMS EngineName kinesis

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -67,6 +67,7 @@
         "azuredb",
         "db2",
         "dynamodb",
+        "kinesis",
         "mariadb",
         "mongodb",
         "mysql",


### PR DESCRIPTION
Fixes:

```
E3030 You must specify a valid value for EngineName (kinesis).
Valid values are ["aurora-postgresql", "aurora", "azuredb", "db2", "dynamodb", "mariadb", "mongodb", "mysql", "oracle", "postgres", "redshift", "s3", "sqlserver", "sybase"]
```

in

```
  DMSEventStreamEndpoint:
    Type: AWS::DMS::Endpoint
    Properties:
      EndpointIdentifier: !Sub "${AWS::StackName}-dms"
      EndpointType: target
      EngineName: kinesis
      KinesisSettings:
        StreamArn: !StreamArn
        MessageFormat: JSON
        ServiceAccessRoleArn: !RoleArn
```

See also: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-endpoint.html#cfn-dms-endpoint-enginename

