### PR TITLE
update Dockerfile to install pydot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.8-alpine
 
 RUN pip install cfn-lint
+RUN pip install pydot
 
 ENTRYPOINT ["cfn-lint"]
 CMD ["--help"]


### PR DESCRIPTION
# Description of changes

**Current behaviour**
Unable to generate the graph `.dot` file that visualizes the dependency graph when using `cfn-lint` in docker.
 
![image](https://user-images.githubusercontent.com/36597466/80209802-02674d80-8633-11ea-9f94-f89ec72d2892.png)


**Future behaviour**
Being able to generate the dependency graph using the docker container of `cfn-lint`.
Now the file can be generated:

![image](https://user-images.githubusercontent.com/36597466/80209934-2cb90b00-8633-11ea-985c-4e084abdfe99.png)

# Updates
* install `pydot` in the docker container.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
