### PR TITLE
Allowing selective running of tests locally

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py{27,34,35,36,37,38},pylint{27,36,37,38}
 [testenv]
 commands =
   pip install -e .
-  coverage run -m unittest discover -s test
+  coverage run -m unittest discover -s {posargs:test}
 skip_install = True
 deps =
   mock


### PR DESCRIPTION
*Issue #, if available:* No issue

*Description of changes:* Modified the tox config file to allow developers to run a reduced set of tests locally. Now, rather than running `tox` or `tox -e py38` to run the entire test suite, a developer can run `tox -- <path>` (i.e. `tox -e py38 -- test/unit/module/core`) to only run the tests in that directory. This makes it a lot easier to test changes locally.

The path defaults to `test`, so just running `tox` without the additional path argument will still run the full test suite as it does prior to this change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
