### PR TITLE
removing copyright dates

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 cfn-flip
-Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/docs/getting_started/rules.md
+++ b/docs/getting_started/rules.md
@@ -43,7 +43,7 @@ Use the following skeleton code as a starting point of your new rule:
 
 ```python
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule
@@ -89,7 +89,7 @@ Use the following skeleton code as a starting point of your new rule:
 
 ```python
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules.MyNewRule import MyNewRule  # pylint: disable=E0401

--- a/examples/rules/PropertiesTagsIncluded.py
+++ b/examples/rules/PropertiesTagsIncluded.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/examples/rules/PropertiesTagsRequired.py
+++ b/examples/rules/PropertiesTagsRequired.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/scripts/update_specs_from_pricing.py
+++ b/scripts/update_specs_from_pricing.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 

--- a/scripts/update_specs_services_from_ssm.py
+++ b/scripts/update_specs_services_from_ssm.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import logging

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import codecs

--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import logging

--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import sys

--- a/src/cfnlint/conditions.py
+++ b/src/cfnlint/conditions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import hashlib

--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import sys

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import logging

--- a/src/cfnlint/data/AdditionalSpecs/__init__.py
+++ b/src/cfnlint/data/AdditionalSpecs/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/af-south-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/af-south-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/all/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/all/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/ap-east-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/ap-east-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/ap-northeast-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/ap-northeast-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/ap-northeast-2/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/ap-northeast-2/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/ap-northeast-3/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/ap-northeast-3/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/ap-south-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/ap-south-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/ap-southeast-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/ap-southeast-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/ap-southeast-2/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/ap-southeast-2/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/ca-central-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/ca-central-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/cn-north-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/cn-north-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/cn-northwest-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/cn-northwest-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/eu-central-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/eu-central-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/eu-north-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/eu-north-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/eu-west-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/eu-west-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/eu-west-2/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/eu-west-2/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/eu-west-3/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/eu-west-3/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/me-south-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/me-south-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/sa-east-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/sa-east-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/us-east-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/us-east-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/us-east-2/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/us-east-2/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/us-gov-east-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/us-gov-east-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/us-gov-west-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/us-gov-west-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/us-west-1/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/us-west-1/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/ExtendedSpecs/us-west-2/__init__.py
+++ b/src/cfnlint/data/ExtendedSpecs/us-west-2/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/Serverless/__init__.py
+++ b/src/cfnlint/data/Serverless/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/data/__init__.py
+++ b/src/cfnlint/data/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/decode/__init__.py
+++ b/src/cfnlint/decode/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import sys

--- a/src/cfnlint/decode/cfn_json.py
+++ b/src/cfnlint/decode/cfn_json.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import fileinput

--- a/src/cfnlint/decode/cfn_yaml.py
+++ b/src/cfnlint/decode/cfn_yaml.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import fileinput

--- a/src/cfnlint/decode/node.py
+++ b/src/cfnlint/decode/node.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import sys

--- a/src/cfnlint/formatters/__init__.py
+++ b/src/cfnlint/formatters/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/src/cfnlint/graph.py
+++ b/src/cfnlint/graph.py
@@ -1,7 +1,7 @@
 """
 Helpers for loading resources, managing specs, constants, etc.
 
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import logging

--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -1,7 +1,7 @@
 """
 Helpers for loading resources, managing specs, constants, etc.
 
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import sys

--- a/src/cfnlint/maintenance.py
+++ b/src/cfnlint/maintenance.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import fnmatch

--- a/src/cfnlint/rules/__init__.py
+++ b/src/cfnlint/rules/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import os

--- a/src/cfnlint/rules/conditions/And.py
+++ b/src/cfnlint/rules/conditions/And.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/conditions/Configuration.py
+++ b/src/cfnlint/rules/conditions/Configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/conditions/Equals.py
+++ b/src/cfnlint/rules/conditions/Equals.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/conditions/Exists.py
+++ b/src/cfnlint/rules/conditions/Exists.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/conditions/Not.py
+++ b/src/cfnlint/rules/conditions/Not.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/conditions/Or.py
+++ b/src/cfnlint/rules/conditions/Or.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/conditions/Used.py
+++ b/src/cfnlint/rules/conditions/Used.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/conditions/__init__.py
+++ b/src/cfnlint/rules/conditions/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/functions/Base64.py
+++ b/src/cfnlint/rules/functions/Base64.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/Cidr.py
+++ b/src/cfnlint/rules/functions/Cidr.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/functions/DynamicReferenceSecureString.py
+++ b/src/cfnlint/rules/functions/DynamicReferenceSecureString.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/functions/FindInMap.py
+++ b/src/cfnlint/rules/functions/FindInMap.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/FindInMapKeys.py
+++ b/src/cfnlint/rules/functions/FindInMapKeys.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/GetAtt.py
+++ b/src/cfnlint/rules/functions/GetAtt.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/GetAz.py
+++ b/src/cfnlint/rules/functions/GetAz.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/If.py
+++ b/src/cfnlint/rules/functions/If.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/ImportValue.py
+++ b/src/cfnlint/rules/functions/ImportValue.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/Join.py
+++ b/src/cfnlint/rules/functions/Join.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/Not.py
+++ b/src/cfnlint/rules/functions/Not.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/functions/Ref.py
+++ b/src/cfnlint/rules/functions/Ref.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/RefExist.py
+++ b/src/cfnlint/rules/functions/RefExist.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/functions/RefInCondition.py
+++ b/src/cfnlint/rules/functions/RefInCondition.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/RelationshipConditions.py
+++ b/src/cfnlint/rules/functions/RelationshipConditions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/Select.py
+++ b/src/cfnlint/rules/functions/Select.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/Split.py
+++ b/src/cfnlint/rules/functions/Split.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/Sub.py
+++ b/src/cfnlint/rules/functions/Sub.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/SubNeeded.py
+++ b/src/cfnlint/rules/functions/SubNeeded.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/functions/SubNotJoin.py
+++ b/src/cfnlint/rules/functions/SubNotJoin.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/SubParametersUsed.py
+++ b/src/cfnlint/rules/functions/SubParametersUsed.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/SubUnneeded.py
+++ b/src/cfnlint/rules/functions/SubUnneeded.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/functions/__init__.py
+++ b/src/cfnlint/rules/functions/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/mappings/ApproachingLimitAttributes.py
+++ b/src/cfnlint/rules/mappings/ApproachingLimitAttributes.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/mappings/ApproachingLimitName.py
+++ b/src/cfnlint/rules/mappings/ApproachingLimitName.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/mappings/ApproachingLimitNumber.py
+++ b/src/cfnlint/rules/mappings/ApproachingLimitNumber.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/mappings/Configuration.py
+++ b/src/cfnlint/rules/mappings/Configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/mappings/KeyName.py
+++ b/src/cfnlint/rules/mappings/KeyName.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/mappings/LimitAttributes.py
+++ b/src/cfnlint/rules/mappings/LimitAttributes.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/mappings/LimitName.py
+++ b/src/cfnlint/rules/mappings/LimitName.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/mappings/LimitNumber.py
+++ b/src/cfnlint/rules/mappings/LimitNumber.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/mappings/Name.py
+++ b/src/cfnlint/rules/mappings/Name.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/mappings/Used.py
+++ b/src/cfnlint/rules/mappings/Used.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/mappings/__init__.py
+++ b/src/cfnlint/rules/mappings/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/metadata/InterfaceConfiguration.py
+++ b/src/cfnlint/rules/metadata/InterfaceConfiguration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/metadata/InterfaceParameterExists.py
+++ b/src/cfnlint/rules/metadata/InterfaceParameterExists.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/metadata/__init__.py
+++ b/src/cfnlint/rules/metadata/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/outputs/ApproachingLimitDescription.py
+++ b/src/cfnlint/rules/outputs/ApproachingLimitDescription.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/outputs/ApproachingLimitName.py
+++ b/src/cfnlint/rules/outputs/ApproachingLimitName.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/outputs/ApproachingLimitNumber.py
+++ b/src/cfnlint/rules/outputs/ApproachingLimitNumber.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/outputs/Configuration.py
+++ b/src/cfnlint/rules/outputs/Configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/outputs/Description.py
+++ b/src/cfnlint/rules/outputs/Description.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/outputs/ImportValue.py
+++ b/src/cfnlint/rules/outputs/ImportValue.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/outputs/LimitDescription.py
+++ b/src/cfnlint/rules/outputs/LimitDescription.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/outputs/LimitName.py
+++ b/src/cfnlint/rules/outputs/LimitName.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/outputs/LimitNumber.py
+++ b/src/cfnlint/rules/outputs/LimitNumber.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/outputs/Name.py
+++ b/src/cfnlint/rules/outputs/Name.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/outputs/Required.py
+++ b/src/cfnlint/rules/outputs/Required.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/outputs/Value.py
+++ b/src/cfnlint/rules/outputs/Value.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/outputs/__init__.py
+++ b/src/cfnlint/rules/outputs/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/parameters/AllowedValue.py
+++ b/src/cfnlint/rules/parameters/AllowedValue.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/parameters/ApproachingLimitName.py
+++ b/src/cfnlint/rules/parameters/ApproachingLimitName.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/parameters/ApproachingLimitNumber.py
+++ b/src/cfnlint/rules/parameters/ApproachingLimitNumber.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/parameters/ApproachingLimitValue.py
+++ b/src/cfnlint/rules/parameters/ApproachingLimitValue.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/parameters/Cidr.py
+++ b/src/cfnlint/rules/parameters/Cidr.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/parameters/CidrAllowedValues.py
+++ b/src/cfnlint/rules/parameters/CidrAllowedValues.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/parameters/Configuration.py
+++ b/src/cfnlint/rules/parameters/Configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/parameters/Default.py
+++ b/src/cfnlint/rules/parameters/Default.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/parameters/DefaultRef.py
+++ b/src/cfnlint/rules/parameters/DefaultRef.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/parameters/LambdaMemorySize.py
+++ b/src/cfnlint/rules/parameters/LambdaMemorySize.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/parameters/LimitName.py
+++ b/src/cfnlint/rules/parameters/LimitName.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/parameters/LimitNumber.py
+++ b/src/cfnlint/rules/parameters/LimitNumber.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/parameters/LimitValue.py
+++ b/src/cfnlint/rules/parameters/LimitValue.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/parameters/Name.py
+++ b/src/cfnlint/rules/parameters/Name.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/parameters/Types.py
+++ b/src/cfnlint/rules/parameters/Types.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/parameters/Used.py
+++ b/src/cfnlint/rules/parameters/Used.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from __future__ import unicode_literals

--- a/src/cfnlint/rules/parameters/__init__.py
+++ b/src/cfnlint/rules/parameters/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/ApproachingLimitName.py
+++ b/src/cfnlint/rules/resources/ApproachingLimitName.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/ApproachingLimitNumber.py
+++ b/src/cfnlint/rules/resources/ApproachingLimitNumber.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/BothUpdateReplacePolicyDeletionPolicyNeeded.py
+++ b/src/cfnlint/rules/resources/BothUpdateReplacePolicyDeletionPolicyNeeded.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/CircularDependency.py
+++ b/src/cfnlint/rules/resources/CircularDependency.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/Configuration.py
+++ b/src/cfnlint/rules/resources/Configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/DeletionPolicy.py
+++ b/src/cfnlint/rules/resources/DeletionPolicy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/DependsOn.py
+++ b/src/cfnlint/rules/resources/DependsOn.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/DependsOnObsolete.py
+++ b/src/cfnlint/rules/resources/DependsOnObsolete.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/LimitName.py
+++ b/src/cfnlint/rules/resources/LimitName.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/LimitNumber.py
+++ b/src/cfnlint/rules/resources/LimitNumber.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/Name.py
+++ b/src/cfnlint/rules/resources/Name.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/resources/ServerlessTransform.py
+++ b/src/cfnlint/rules/resources/ServerlessTransform.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/UpdateReplacePolicy.py
+++ b/src/cfnlint/rules/resources/UpdateReplacePolicy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/UpdateReplacePolicyDeletionPolicyOnStatefulResourceTypes.py
+++ b/src/cfnlint/rules/resources/UpdateReplacePolicyDeletionPolicyOnStatefulResourceTypes.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/__init__.py
+++ b/src/cfnlint/rules/resources/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/certificatemanager/DomainValidationOptions.py
+++ b/src/cfnlint/rules/resources/certificatemanager/DomainValidationOptions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/certificatemanager/__init__.py
+++ b/src/cfnlint/rules/resources/certificatemanager/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/cloudfront/Aliases.py
+++ b/src/cfnlint/rules/resources/cloudfront/Aliases.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/resources/cloudfront/__init__.py
+++ b/src/cfnlint/rules/resources/cloudfront/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStageActions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/resources/codepipeline/CodepipelineStages.py
+++ b/src/cfnlint/rules/resources/codepipeline/CodepipelineStages.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/codepipeline/__init__.py
+++ b/src/cfnlint/rules/resources/codepipeline/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/dynamodb/AttributeMismatch.py
+++ b/src/cfnlint/rules/resources/dynamodb/AttributeMismatch.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/dynamodb/BillingMode.py
+++ b/src/cfnlint/rules/resources/dynamodb/BillingMode.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/dynamodb/__init__.py
+++ b/src/cfnlint/rules/resources/dynamodb/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/ectwo/Ebs.py
+++ b/src/cfnlint/rules/resources/ectwo/Ebs.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/resources/ectwo/RouteTableAssociation.py
+++ b/src/cfnlint/rules/resources/ectwo/RouteTableAssociation.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from collections import defaultdict

--- a/src/cfnlint/rules/resources/ectwo/SecurityGroupIngress.py
+++ b/src/cfnlint/rules/resources/ectwo/SecurityGroupIngress.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/ectwo/Subnet.py
+++ b/src/cfnlint/rules/resources/ectwo/Subnet.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/resources/ectwo/Vpc.py
+++ b/src/cfnlint/rules/resources/ectwo/Vpc.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/resources/ectwo/__init__.py
+++ b/src/cfnlint/rules/resources/ectwo/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/elasticache/CacheClusterFailover.py
+++ b/src/cfnlint/rules/resources/elasticache/CacheClusterFailover.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.helpers import bool_compare

--- a/src/cfnlint/rules/resources/elasticache/__init__.py
+++ b/src/cfnlint/rules/resources/elasticache/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/elb/Elb.py
+++ b/src/cfnlint/rules/resources/elb/Elb.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/elb/__init__.py
+++ b/src/cfnlint/rules/resources/elb/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/events/RuleScheduleExpression.py
+++ b/src/cfnlint/rules/resources/events/RuleScheduleExpression.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/events/RuleTargetsLimit.py
+++ b/src/cfnlint/rules/resources/events/RuleTargetsLimit.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/events/__init__.py
+++ b/src/cfnlint/rules/resources/events/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/iam/Permissions.py
+++ b/src/cfnlint/rules/resources/iam/Permissions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/src/cfnlint/rules/resources/iam/Policy.py
+++ b/src/cfnlint/rules/resources/iam/Policy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/src/cfnlint/rules/resources/iam/PolicyVersion.py
+++ b/src/cfnlint/rules/resources/iam/PolicyVersion.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from datetime import date

--- a/src/cfnlint/rules/resources/iam/RefWithPath.py
+++ b/src/cfnlint/rules/resources/iam/RefWithPath.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/iam/__init__.py
+++ b/src/cfnlint/rules/resources/iam/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntime.py
+++ b/src/cfnlint/rules/resources/lmbd/DeprecatedRuntime.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from datetime import datetime

--- a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEnd.py
+++ b/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEnd.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from datetime import datetime

--- a/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEol.py
+++ b/src/cfnlint/rules/resources/lmbd/DeprecatedRuntimeEol.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from datetime import datetime

--- a/src/cfnlint/rules/resources/lmbd/EventsLogGroupName.py
+++ b/src/cfnlint/rules/resources/lmbd/EventsLogGroupName.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/lmbd/FunctionMemorySize.py
+++ b/src/cfnlint/rules/resources/lmbd/FunctionMemorySize.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/lmbd/__init__.py
+++ b/src/cfnlint/rules/resources/lmbd/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/properties/AllowedPattern.py
+++ b/src/cfnlint/rules/resources/properties/AllowedPattern.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/resources/properties/AllowedValue.py
+++ b/src/cfnlint/rules/resources/properties/AllowedValue.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/src/cfnlint/rules/resources/properties/AtLeastOne.py
+++ b/src/cfnlint/rules/resources/properties/AtLeastOne.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/properties/AvailabilityZone.py
+++ b/src/cfnlint/rules/resources/properties/AvailabilityZone.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/properties/Exclusive.py
+++ b/src/cfnlint/rules/resources/properties/Exclusive.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/properties/ImageId.py
+++ b/src/cfnlint/rules/resources/properties/ImageId.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/properties/Inclusive.py
+++ b/src/cfnlint/rules/resources/properties/Inclusive.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/properties/JsonSize.py
+++ b/src/cfnlint/rules/resources/properties/JsonSize.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import datetime

--- a/src/cfnlint/rules/resources/properties/ListDuplicates.py
+++ b/src/cfnlint/rules/resources/properties/ListDuplicates.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import hashlib

--- a/src/cfnlint/rules/resources/properties/ListDuplicatesAllowed.py
+++ b/src/cfnlint/rules/resources/properties/ListDuplicatesAllowed.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import hashlib

--- a/src/cfnlint/rules/resources/properties/ListSize.py
+++ b/src/cfnlint/rules/resources/properties/ListSize.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/properties/NumberSize.py
+++ b/src/cfnlint/rules/resources/properties/NumberSize.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import sys

--- a/src/cfnlint/rules/resources/properties/OnlyOne.py
+++ b/src/cfnlint/rules/resources/properties/OnlyOne.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/properties/Password.py
+++ b/src/cfnlint/rules/resources/properties/Password.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/properties/PropertiesTemplated.py
+++ b/src/cfnlint/rules/resources/properties/PropertiesTemplated.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/properties/Required.py
+++ b/src/cfnlint/rules/resources/properties/Required.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/properties/StringSize.py
+++ b/src/cfnlint/rules/resources/properties/StringSize.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/properties/ValuePrimitiveType.py
+++ b/src/cfnlint/rules/resources/properties/ValuePrimitiveType.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import sys

--- a/src/cfnlint/rules/resources/properties/ValueRefGetAtt.py
+++ b/src/cfnlint/rules/resources/properties/ValueRefGetAtt.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/properties/__init__.py
+++ b/src/cfnlint/rules/resources/properties/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/rds/AuroraDBInstanceProperties.py
+++ b/src/cfnlint/rules/resources/rds/AuroraDBInstanceProperties.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/rds/AuroraScalingConfiguration.py
+++ b/src/cfnlint/rules/resources/rds/AuroraScalingConfiguration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/rds/InstanceEngine.py
+++ b/src/cfnlint/rules/resources/rds/InstanceEngine.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/src/cfnlint/rules/resources/rds/InstanceSize.py
+++ b/src/cfnlint/rules/resources/rds/InstanceSize.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/rds/__init__.py
+++ b/src/cfnlint/rules/resources/rds/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/route53/HealthCheck.py
+++ b/src/cfnlint/rules/resources/route53/HealthCheck.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/resources/route53/RecordSet.py
+++ b/src/cfnlint/rules/resources/route53/RecordSet.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/src/cfnlint/rules/resources/route53/__init__.py
+++ b/src/cfnlint/rules/resources/route53/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
+++ b/src/cfnlint/rules/resources/stepfunctions/StateMachine.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/src/cfnlint/rules/resources/stepfunctions/__init__.py
+++ b/src/cfnlint/rules/resources/stepfunctions/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/resources/updatepolicy/Configuration.py
+++ b/src/cfnlint/rules/resources/updatepolicy/Configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/resources/updatepolicy/__init__.py
+++ b/src/cfnlint/rules/resources/updatepolicy/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/rules/templates/ApproachingLimitDescription.py
+++ b/src/cfnlint/rules/templates/ApproachingLimitDescription.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/templates/ApproachingLimitSize.py
+++ b/src/cfnlint/rules/templates/ApproachingLimitSize.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import os

--- a/src/cfnlint/rules/templates/Base.py
+++ b/src/cfnlint/rules/templates/Base.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/templates/Description.py
+++ b/src/cfnlint/rules/templates/Description.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/src/cfnlint/rules/templates/LimitDescription.py
+++ b/src/cfnlint/rules/templates/LimitDescription.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule

--- a/src/cfnlint/rules/templates/LimitSize.py
+++ b/src/cfnlint/rules/templates/LimitSize.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import os

--- a/src/cfnlint/rules/templates/__init__.py
+++ b/src/cfnlint/rules/templates/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/src/cfnlint/transform.py
+++ b/src/cfnlint/transform.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import os

--- a/src/cfnlint/version.py
+++ b/src/cfnlint/version.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/fixtures/__init__.py
+++ b/test/fixtures/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/fixtures/configs/__init__.py
+++ b/test/fixtures/configs/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/fixtures/results/__init__.py
+++ b/test/fixtures/results/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/fixtures/results/public/__init__.py
+++ b/test/fixtures/results/public/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/fixtures/results/quickstart/__init__.py
+++ b/test/fixtures/results/quickstart/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/fixtures/results/quickstart/non_strict/__init__.py
+++ b/test/fixtures/results/quickstart/non_strict/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/fixtures/rules/__init__.py
+++ b/test/fixtures/rules/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/fixtures/rules/custom1.py
+++ b/test/fixtures/rules/custom1.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule  # pylint: disable=E0401

--- a/test/fixtures/specs/__init__.py
+++ b/test/fixtures/specs/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/fixtures/templates/__init__.py
+++ b/test/fixtures/templates/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/fixtures/templates/quickstart/__init__.py
+++ b/test/fixtures/templates/quickstart/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/integration/__init__.py
+++ b/test/integration/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import sys

--- a/test/integration/test_directives.py
+++ b/test/integration/test_directives.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.integration import BaseCliTestCase

--- a/test/integration/test_good_templates.py
+++ b/test/integration/test_good_templates.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.integration import BaseCliTestCase

--- a/test/integration/test_mandatory_checks.py
+++ b/test/integration/test_mandatory_checks.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.integration import BaseCliTestCase

--- a/test/integration/test_patched_specs.py
+++ b/test/integration/test_patched_specs.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import six

--- a/test/integration/test_quickstart_templates.py
+++ b/test/integration/test_quickstart_templates.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.integration import BaseCliTestCase

--- a/test/integration/test_quickstart_templates_non_strict.py
+++ b/test/integration/test_quickstart_templates_non_strict.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.integration import BaseCliTestCase

--- a/test/testlib/__init__.py
+++ b/test/testlib/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/testlib/testcase.py
+++ b/test/testlib/testcase.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from unittest import TestCase

--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/module/__init__.py
+++ b/test/unit/module/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/module/cfn_json/__init__.py
+++ b/test/unit/module/cfn_json/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/module/cfn_json/test_cfn_json.py
+++ b/test/unit/module/cfn_json/test_cfn_json.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/module/cfn_yaml/__init__.py
+++ b/test/unit/module/cfn_yaml/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/module/cfn_yaml/test_yaml.py
+++ b/test/unit/module/cfn_yaml/test_yaml.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/module/conditions/__init__.py
+++ b/test/unit/module/conditions/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/module/conditions/test_condition.py
+++ b/test/unit/module/conditions/test_condition.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/module/conditions/test_conditions.py
+++ b/test/unit/module/conditions/test_conditions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/module/conditions/test_equal_values.py
+++ b/test/unit/module/conditions/test_equal_values.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/module/conditions/test_equals.py
+++ b/test/unit/module/conditions/test_equals.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/module/conditions/test_get_hash.py
+++ b/test/unit/module/conditions/test_get_hash.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/module/config/__init__.py
+++ b/test/unit/module/config/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/module/config/test_cli_args.py
+++ b/test/unit/module/config/test_cli_args.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import logging

--- a/test/unit/module/config/test_config_file_args.py
+++ b/test/unit/module/config/test_config_file_args.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import logging

--- a/test/unit/module/config/test_config_mixin.py
+++ b/test/unit/module/config/test_config_mixin.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import logging

--- a/test/unit/module/config/test_logging.py
+++ b/test/unit/module/config/test_logging.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import logging

--- a/test/unit/module/config/test_template_args.py
+++ b/test/unit/module/config/test_template_args.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import logging

--- a/test/unit/module/core/__init__.py
+++ b/test/unit/module/core/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/module/core/test_get_rules.py
+++ b/test/unit/module/core/test_get_rules.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import os

--- a/test/unit/module/core/test_run_checks.py
+++ b/test/unit/module/core/test_run_checks.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/module/core/test_run_cli.py
+++ b/test/unit/module/core/test_run_cli.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import logging

--- a/test/unit/module/decode/__init__.py
+++ b/test/unit/module/decode/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/module/decode/test_node.py
+++ b/test/unit/module/decode/test_node.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/module/formatters/__init__.py
+++ b/test/unit/module/formatters/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/module/formatters/test_formatters.py
+++ b/test/unit/module/formatters/test_formatters.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/test/unit/module/helpers/__init__.py
+++ b/test/unit/module/helpers/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/module/helpers/test_convert_dict.py
+++ b/test/unit/module/helpers/test_convert_dict.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/module/helpers/test_create_rules.py
+++ b/test/unit/module/helpers/test_create_rules.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import os

--- a/test/unit/module/helpers/test_downloads_metadata.py
+++ b/test/unit/module/helpers/test_downloads_metadata.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import sys

--- a/test/unit/module/helpers/test_format_json.py
+++ b/test/unit/module/helpers/test_format_json.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import datetime

--- a/test/unit/module/helpers/test_get_url_content.py
+++ b/test/unit/module/helpers/test_get_url_content.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import sys

--- a/test/unit/module/helpers/test_load_plugins.py
+++ b/test/unit/module/helpers/test_load_plugins.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import os

--- a/test/unit/module/maintenance/__init__.py
+++ b/test/unit/module/maintenance/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/module/maintenance/test_patch_spec.py
+++ b/test/unit/module/maintenance/test_patch_spec.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import logging

--- a/test/unit/module/maintenance/test_update_documentation.py
+++ b/test/unit/module/maintenance/test_update_documentation.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import sys

--- a/test/unit/module/maintenance/test_update_iam_policies.py
+++ b/test/unit/module/maintenance/test_update_iam_policies.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import sys

--- a/test/unit/module/maintenance/test_update_resource_specs.py
+++ b/test/unit/module/maintenance/test_update_resource_specs.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import sys

--- a/test/unit/module/override/__init__.py
+++ b/test/unit/module/override/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/module/override/test_complete.py
+++ b/test/unit/module/override/test_complete.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/test/unit/module/override/test_exclude.py
+++ b/test/unit/module/override/test_exclude.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/test/unit/module/override/test_include.py
+++ b/test/unit/module/override/test_include.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/test/unit/module/override/test_required.py
+++ b/test/unit/module/override/test_required.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/test/unit/module/rule/__init__.py
+++ b/test/unit/module/rule/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/module/rule/test_rule.py
+++ b/test/unit/module/rule/test_rule.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/module/test_duplicate.py
+++ b/test/unit/module/test_duplicate.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/test/unit/module/test_null_values.py
+++ b/test/unit/module/test_null_values.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/test/unit/module/test_rules_collections.py
+++ b/test/unit/module/test_rules_collections.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/module/test_string_template.py
+++ b/test/unit/module/test_string_template.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/module/test_template.py
+++ b/test/unit/module/test_template.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/test/unit/module/transform/__init__.py
+++ b/test/unit/module/transform/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/module/transform/test_transform.py
+++ b/test/unit/module/transform/test_transform.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/rules/__init__.py
+++ b/test/unit/rules/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.testlib.testcase import BaseTestCase

--- a/test/unit/rules/conditions/__init__.py
+++ b/test/unit/rules/conditions/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/conditions/test_and.py
+++ b/test/unit/rules/conditions/test_and.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/conditions/test_configuration.py
+++ b/test/unit/rules/conditions/test_configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/conditions/test_equals.py
+++ b/test/unit/rules/conditions/test_equals.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/conditions/test_exists.py
+++ b/test/unit/rules/conditions/test_exists.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/conditions/test_not.py
+++ b/test/unit/rules/conditions/test_not.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/conditions/test_or.py
+++ b/test/unit/rules/conditions/test_or.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/conditions/test_used.py
+++ b/test/unit/rules/conditions/test_used.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/__init__.py
+++ b/test/unit/rules/functions/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/functions/test_base64.py
+++ b/test/unit/rules/functions/test_base64.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_cidr.py
+++ b/test/unit/rules/functions/test_cidr.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_dynamic_reference.py
+++ b/test/unit/rules/functions/test_dynamic_reference.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_find_in_map.py
+++ b/test/unit/rules/functions/test_find_in_map.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_find_in_map_keys.py
+++ b/test/unit/rules/functions/test_find_in_map_keys.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_get_att.py
+++ b/test/unit/rules/functions/test_get_att.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_getazs.py
+++ b/test/unit/rules/functions/test_getazs.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_if.py
+++ b/test/unit/rules/functions/test_if.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_import_value.py
+++ b/test/unit/rules/functions/test_import_value.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_join.py
+++ b/test/unit/rules/functions/test_join.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_not.py
+++ b/test/unit/rules/functions/test_not.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_ref.py
+++ b/test/unit/rules/functions/test_ref.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_ref_exist.py
+++ b/test/unit/rules/functions/test_ref_exist.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_ref_in_condition.py
+++ b/test/unit/rules/functions/test_ref_in_condition.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_relationship_conditions.py
+++ b/test/unit/rules/functions/test_relationship_conditions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_select.py
+++ b/test/unit/rules/functions/test_select.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_split.py
+++ b/test/unit/rules/functions/test_split.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_sub.py
+++ b/test/unit/rules/functions/test_sub.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_sub_needed.py
+++ b/test/unit/rules/functions/test_sub_needed.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_sub_not_join.py
+++ b/test/unit/rules/functions/test_sub_not_join.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_sub_parameters_used.py
+++ b/test/unit/rules/functions/test_sub_parameters_used.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/functions/test_sub_unneeded.py
+++ b/test/unit/rules/functions/test_sub_unneeded.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/mappings/__init__.py
+++ b/test/unit/rules/mappings/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/mappings/test_configuration.py
+++ b/test/unit/rules/mappings/test_configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/mappings/test_key_name.py
+++ b/test/unit/rules/mappings/test_key_name.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/mappings/test_limitattributes.py
+++ b/test/unit/rules/mappings/test_limitattributes.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/mappings/test_limitname.py
+++ b/test/unit/rules/mappings/test_limitname.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/mappings/test_limitnumber.py
+++ b/test/unit/rules/mappings/test_limitnumber.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/mappings/test_name.py
+++ b/test/unit/rules/mappings/test_name.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/mappings/test_used.py
+++ b/test/unit/rules/mappings/test_used.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/metadata/__init__.py
+++ b/test/unit/rules/metadata/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/metadata/test_interface_configuration.py
+++ b/test/unit/rules/metadata/test_interface_configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/metadata/test_interface_parameter_exists.py
+++ b/test/unit/rules/metadata/test_interface_parameter_exists.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/outputs/__init__.py
+++ b/test/unit/rules/outputs/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/outputs/test_configuration.py
+++ b/test/unit/rules/outputs/test_configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/outputs/test_description.py
+++ b/test/unit/rules/outputs/test_description.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/outputs/test_importvalue.py
+++ b/test/unit/rules/outputs/test_importvalue.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/outputs/test_limit_description.py
+++ b/test/unit/rules/outputs/test_limit_description.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/outputs/test_limitname.py
+++ b/test/unit/rules/outputs/test_limitname.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/outputs/test_limitnumber.py
+++ b/test/unit/rules/outputs/test_limitnumber.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/outputs/test_name.py
+++ b/test/unit/rules/outputs/test_name.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/outputs/test_required.py
+++ b/test/unit/rules/outputs/test_required.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/outputs/test_value.py
+++ b/test/unit/rules/outputs/test_value.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/parameters/__init__.py
+++ b/test/unit/rules/parameters/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/parameters/test_allowed_value.py
+++ b/test/unit/rules/parameters/test_allowed_value.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/parameters/test_cidr.py
+++ b/test/unit/rules/parameters/test_cidr.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/parameters/test_cidr_allowed_values.py
+++ b/test/unit/rules/parameters/test_cidr_allowed_values.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/parameters/test_configuration.py
+++ b/test/unit/rules/parameters/test_configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/parameters/test_default.py
+++ b/test/unit/rules/parameters/test_default.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/parameters/test_defaultref.py
+++ b/test/unit/rules/parameters/test_defaultref.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/parameters/test_lambda_memory_size.py
+++ b/test/unit/rules/parameters/test_lambda_memory_size.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/parameters/test_limitname.py
+++ b/test/unit/rules/parameters/test_limitname.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/parameters/test_limitnumber.py
+++ b/test/unit/rules/parameters/test_limitnumber.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/parameters/test_limitvalue.py
+++ b/test/unit/rules/parameters/test_limitvalue.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/parameters/test_name.py
+++ b/test/unit/rules/parameters/test_name.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/parameters/test_types.py
+++ b/test/unit/rules/parameters/test_types.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/parameters/test_used.py
+++ b/test/unit/rules/parameters/test_used.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/__init__.py
+++ b/test/unit/rules/resources/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/certificatemanager/__init__.py
+++ b/test/unit/rules/resources/certificatemanager/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/certificatemanager/test_domainvalidationoptions.py
+++ b/test/unit/rules/resources/certificatemanager/test_domainvalidationoptions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/cloudfront/__init__.py
+++ b/test/unit/rules/resources/cloudfront/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/cloudfront/test_aliases.py
+++ b/test/unit/rules/resources/cloudfront/test_aliases.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/codepipeline/__init__.py
+++ b/test/unit/rules/resources/codepipeline/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/codepipeline/test_stageactions.py
+++ b/test/unit/rules/resources/codepipeline/test_stageactions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/codepipeline/test_stages.py
+++ b/test/unit/rules/resources/codepipeline/test_stages.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/dynamodb/__init__.py
+++ b/test/unit/rules/resources/dynamodb/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/dynamodb/test_attribute_mismatch.py
+++ b/test/unit/rules/resources/dynamodb/test_attribute_mismatch.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/dynamodb/test_billing_mode.py
+++ b/test/unit/rules/resources/dynamodb/test_billing_mode.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/dynamodb/test_delete_policy.py
+++ b/test/unit/rules/resources/dynamodb/test_delete_policy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/ec2/__init__.py
+++ b/test/unit/rules/resources/ec2/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/ec2/test_ec2_ebs.py
+++ b/test/unit/rules/resources/ec2/test_ec2_ebs.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/ec2/test_ec2_subnet.py
+++ b/test/unit/rules/resources/ec2/test_ec2_subnet.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/ec2/test_ec2_vpc.py
+++ b/test/unit/rules/resources/ec2/test_ec2_vpc.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/ec2/test_rt_association.py
+++ b/test/unit/rules/resources/ec2/test_rt_association.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/ec2/test_sg_ingress.py
+++ b/test/unit/rules/resources/ec2/test_sg_ingress.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/elasticache/__init__.py
+++ b/test/unit/rules/resources/elasticache/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/elasticache/test_cache_cluster_failover.py
+++ b/test/unit/rules/resources/elasticache/test_cache_cluster_failover.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/elb/__init__.py
+++ b/test/unit/rules/resources/elb/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/elb/test_elb.py
+++ b/test/unit/rules/resources/elb/test_elb.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/events/__init__.py
+++ b/test/unit/rules/resources/events/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/events/test_rule_schedule_expression.py
+++ b/test/unit/rules/resources/events/test_rule_schedule_expression.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/events/test_rule_targets_limit.py
+++ b/test/unit/rules/resources/events/test_rule_targets_limit.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/iam/__init__.py
+++ b/test/unit/rules/resources/iam/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/iam/test_iam_permissions.py
+++ b/test/unit/rules/resources/iam/test_iam_permissions.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/iam/test_iam_policy.py
+++ b/test/unit/rules/resources/iam/test_iam_policy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/iam/test_iam_policy_version.py
+++ b/test/unit/rules/resources/iam/test_iam_policy_version.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/iam/test_ref_with_path.py
+++ b/test/unit/rules/resources/iam/test_ref_with_path.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/lmbd/__init__.py
+++ b/test/unit/rules/resources/lmbd/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/lmbd/test_deprecated_runtime_end.py
+++ b/test/unit/rules/resources/lmbd/test_deprecated_runtime_end.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/lmbd/test_deprecated_runtime_eol.py
+++ b/test/unit/rules/resources/lmbd/test_deprecated_runtime_eol.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/lmbd/test_events_log_group_name.py
+++ b/test/unit/rules/resources/lmbd/test_events_log_group_name.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/lmbd/test_memory_size.py
+++ b/test/unit/rules/resources/lmbd/test_memory_size.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/__init__.py
+++ b/test/unit/rules/resources/properties/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/properties/test_allowed_pattern.py
+++ b/test/unit/rules/resources/properties/test_allowed_pattern.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import re

--- a/test/unit/rules/resources/properties/test_allowed_value.py
+++ b/test/unit/rules/resources/properties/test_allowed_value.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_atleastone.py
+++ b/test/unit/rules/resources/properties/test_atleastone.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_availability_zone.py
+++ b/test/unit/rules/resources/properties/test_availability_zone.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_exclusive.py
+++ b/test/unit/rules/resources/properties/test_exclusive.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_image_id.py
+++ b/test/unit/rules/resources/properties/test_image_id.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_inclusive.py
+++ b/test/unit/rules/resources/properties/test_inclusive.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_json_size.py
+++ b/test/unit/rules/resources/properties/test_json_size.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_list_duplicates.py
+++ b/test/unit/rules/resources/properties/test_list_duplicates.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_list_duplicates_allowed.py
+++ b/test/unit/rules/resources/properties/test_list_duplicates_allowed.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_list_size.py
+++ b/test/unit/rules/resources/properties/test_list_size.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_number_size.py
+++ b/test/unit/rules/resources/properties/test_number_size.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_onlyone.py
+++ b/test/unit/rules/resources/properties/test_onlyone.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_password.py
+++ b/test/unit/rules/resources/properties/test_password.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_properties.py
+++ b/test/unit/rules/resources/properties/test_properties.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/test/unit/rules/resources/properties/test_properties_templated.py
+++ b/test/unit/rules/resources/properties/test_properties_templated.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_required.py
+++ b/test/unit/rules/resources/properties/test_required.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 import json

--- a/test/unit/rules/resources/properties/test_string_size.py
+++ b/test/unit/rules/resources/properties/test_string_size.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_value_primitive_type.py
+++ b/test/unit/rules/resources/properties/test_value_primitive_type.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/properties/test_value_ref_getatt.py
+++ b/test/unit/rules/resources/properties/test_value_ref_getatt.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/rds/__init__.py
+++ b/test/unit/rules/resources/rds/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/rds/test_auroa_dbinstance_properties.py
+++ b/test/unit/rules/resources/rds/test_auroa_dbinstance_properties.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/rds/test_aurora_scaling_configuration.py
+++ b/test/unit/rules/resources/rds/test_aurora_scaling_configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/rds/test_instance_engine.py
+++ b/test/unit/rules/resources/rds/test_instance_engine.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/rds/test_instance_sizes.py
+++ b/test/unit/rules/resources/rds/test_instance_sizes.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/route53/__init__.py
+++ b/test/unit/rules/resources/route53/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/route53/test_health_check.py
+++ b/test/unit/rules/resources/route53/test_health_check.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/route53/test_recordsets.py
+++ b/test/unit/rules/resources/route53/test_recordsets.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/stepfunctions/__init__.py
+++ b/test/unit/rules/resources/stepfunctions/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/stepfunctions/test_state_machine.py
+++ b/test/unit/rules/resources/stepfunctions/test_state_machine.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/test_circular_dependency.py
+++ b/test/unit/rules/resources/test_circular_dependency.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/test_configurations.py
+++ b/test/unit/rules/resources/test_configurations.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/test_deletionpolicy.py
+++ b/test/unit/rules/resources/test_deletionpolicy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/test_dependson.py
+++ b/test/unit/rules/resources/test_dependson.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/test_limitname.py
+++ b/test/unit/rules/resources/test_limitname.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/test_limitnumber.py
+++ b/test/unit/rules/resources/test_limitnumber.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/test_name.py
+++ b/test/unit/rules/resources/test_name.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/test_serverless_transform.py
+++ b/test/unit/rules/resources/test_serverless_transform.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/test_updatereplacepolicy.py
+++ b/test/unit/rules/resources/test_updatereplacepolicy.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/resources/updatepolicy/__init__.py
+++ b/test/unit/rules/resources/updatepolicy/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/resources/updatepolicy/test_configuration.py
+++ b/test/unit/rules/resources/updatepolicy/test_configuration.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/templates/__init__.py
+++ b/test/unit/rules/templates/__init__.py
@@ -1,4 +1,4 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """

--- a/test/unit/rules/templates/test_base_template.py
+++ b/test/unit/rules/templates/test_base_template.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/templates/test_description.py
+++ b/test/unit/rules/templates/test_description.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/templates/test_limitsize_description.py
+++ b/test/unit/rules/templates/test_limitsize_description.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/templates/test_limitsize_template.py
+++ b/test/unit/rules/templates/test_limitsize_template.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase

--- a/test/unit/rules/templates/test_yaml_template.py
+++ b/test/unit/rules/templates/test_yaml_template.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from test.unit.rules import BaseRuleTestCase


### PR DESCRIPTION
time is a social construct

(more importantly in line with [the legal guidance for 2020 onwards](https://w.amazon.com/bin/view/Open_Source/LicensingForGitHubProjects/#Copyright_Dates_for_Amazon-created_Open_Source))

```shell
cfn-python-lint $ git grep -hiEr 'copyright' * | sort | uniq -c | sort -nr
 440 Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
   1 PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
   1 Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
   1 Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
   1 - Update CopyRight from 2018 to 2019

cfn-python-lint $ git grep -hiErl 'copyright' * | xargs gsed -i 's/Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved/Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved/g'
cfn-python-lint $ git grep -hiErl 'copyright' * | xargs gsed -i 's/Copyright 2017-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved/Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved/g'

cfn-python-lint $ git grep -hiEr 'copyright' * | sort | uniq -c | sort -nr
 441 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
   1 PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
   1 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
   1 - Update CopyRight from 2018 to 2019
```