### PR TITLE
exempting resource types where the AWS::Serverless transform sets DeletionPolicy but not UpdateReplacePolicy from W3011

### DIFF
--- a/src/cfnlint/rules/resources/BothUpdateReplacePolicyDeletionPolicyNeeded.py
+++ b/src/cfnlint/rules/resources/BothUpdateReplacePolicyDeletionPolicyNeeded.py
@@ -19,10 +19,11 @@ class UpdateReplacePolicyDeletionPolicy(CloudFormationLintRule):
         matches = []
 
         for r_name, r_values in cfn.get_resources().items():
-            # pylint: disable=too-many-boolean-expressions
-            if r_values.get('DeletionPolicy') and r_values.get('DeletionPolicy') != 'Delete' and not r_values.get('UpdateReplacePolicy') or not r_values.get('DeletionPolicy') and r_values.get('UpdateReplacePolicy') and r_values.get('UpdateReplacePolicy') != 'Delete':
-                path = ['Resources', r_name]
-                message = 'Both UpdateReplacePolicy and DeletionPolicy are needed to protect %s from deletion' % '/'.join(path)
-                matches.append(RuleMatch(path, message))
+            if r_values.get('Type') not in ['AWS::Lambda::Version', 'AWS::Lambda::LayerVersion']:
+                # pylint: disable=too-many-boolean-expressions
+                if r_values.get('DeletionPolicy') and r_values.get('DeletionPolicy') != 'Delete' and not r_values.get('UpdateReplacePolicy') or not r_values.get('DeletionPolicy') and r_values.get('UpdateReplacePolicy') and r_values.get('UpdateReplacePolicy') != 'Delete':
+                    path = ['Resources', r_name]
+                    message = 'Both UpdateReplacePolicy and DeletionPolicy are needed to protect %s from deletion' % '/'.join(path)
+                    matches.append(RuleMatch(path, message))
 
         return matches

--- a/test/integration/test_good_templates.py
+++ b/test/integration/test_good_templates.py
@@ -22,34 +22,8 @@ class TestQuickStartTemplates(BaseCliTestCase):
         },
         {
             'filename': 'test/fixtures/templates/good/transform.yaml',
-            'results': [
-                {
-                    "Filename": "test/fixtures/templates/good/transform.yaml",
-                    "Level": "Warning",
-                    "Location": {
-                        "End": {
-                            "ColumnNumber": 10,
-                            "LineNumber": 4
-                        },
-                        "Path": [
-                            "Resources",
-                            "ExampleLayer29b0582575"
-                        ],
-                        "Start": {
-                            "ColumnNumber": 1,
-                            "LineNumber": 4
-                        }
-                    },
-                    "Message": "Both UpdateReplacePolicy and DeletionPolicy are needed to protect Resources/ExampleLayer29b0582575 from deletion",
-                    "Rule": {
-                        "Description": "Both UpdateReplacePolicy and DeletionPolicy are needed to protect resources from deletion",
-                        "Id": "W3011",
-                        "ShortDescription": "Check resources with UpdateReplacePolicy/DeletionPolicy have both",
-                        "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html"
-                    }
-                }
-            ],
-            'exit_code': 4,
+            'results': [],
+            'exit_code': 0,
         },
         {
             'filename': 'test/fixtures/templates/bad/transform_serverless_template.yaml',
@@ -135,94 +109,17 @@ class TestQuickStartTemplates(BaseCliTestCase):
         },
         {
             'filename': 'test/fixtures/templates/good/transform_serverless_api.yaml',
-            'results': [
-                {
-                    "Filename": "test/fixtures/templates/good/transform_serverless_api.yaml",
-                    "Level": "Warning",
-                    "Location": {
-                        "End": {
-                            "ColumnNumber": 10,
-                            "LineNumber": 4
-                        },
-                        "Path": [
-                            "Resources",
-                            "myFunctionVersionee13cf2679"
-                        ],
-                        "Start": {
-                            "ColumnNumber": 1,
-                            "LineNumber": 4
-                        }
-                    },
-                    "Message": "Both UpdateReplacePolicy and DeletionPolicy are needed to protect Resources/myFunctionVersionee13cf2679 from deletion",
-                    "Rule": {
-                        "Description": "Both UpdateReplacePolicy and DeletionPolicy are needed to protect resources from deletion",
-                        "Id": "W3011",
-                        "ShortDescription": "Check resources with UpdateReplacePolicy/DeletionPolicy have both",
-                        "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html"
-                    }
-                }
-            ],
-            'exit_code': 4,
+            'results': [],
+            'exit_code': 0,
         },
         {
             'filename': 'test/fixtures/templates/good/transform_serverless_function.yaml',
-            'results': [
-                {
-                    "Filename": "test/fixtures/templates/good/transform_serverless_function.yaml",
-                    "Level": "Warning",
-                    "Location": {
-                        "End": {
-                            "ColumnNumber": 10,
-                            "LineNumber": 4
-                        },
-                        "Path": [
-                            "Resources",
-                            "myFunctionVersionee13cf2679"
-                        ],
-                        "Start": {
-                            "ColumnNumber": 1,
-                            "LineNumber": 4
-                        }
-                    },
-                    "Message": "Both UpdateReplacePolicy and DeletionPolicy are needed to protect Resources/myFunctionVersionee13cf2679 from deletion",
-                    "Rule": {
-                        "Description": "Both UpdateReplacePolicy and DeletionPolicy are needed to protect resources from deletion",
-                        "Id": "W3011",
-                        "ShortDescription": "Check resources with UpdateReplacePolicy/DeletionPolicy have both",
-                        "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html"
-                    }
-                }
-            ],
-            'exit_code': 4,
+            'results': [],
+            'exit_code': 0,
         },
         {
             'filename': 'test/fixtures/templates/good/transform_serverless_globals.yaml',
             'results': [
-                {
-                    "Filename": "test/fixtures/templates/good/transform_serverless_globals.yaml",
-                    "Level": "Warning",
-                    "Location": {
-                        "End": {
-                            "ColumnNumber": 10,
-                            "LineNumber": 9
-                        },
-                        "Path": [
-                            "Resources",
-                            "myFunctionVersionee13cf2679"
-                        ],
-                        "Start": {
-                            "ColumnNumber": 1,
-                            "LineNumber": 9
-                        }
-                    },
-                    "Message": "Both UpdateReplacePolicy and DeletionPolicy are needed to protect Resources/myFunctionVersionee13cf2679 from deletion",
-                    "Rule": {
-                        "Description": "Both UpdateReplacePolicy and DeletionPolicy are needed to protect resources from deletion",
-                        "Id": "W3011",
-                        "ShortDescription": "Check resources with UpdateReplacePolicy/DeletionPolicy have both",
-                        "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html"
-                    }
-                },
                 {
                     "Filename": "test/fixtures/templates/good/transform_serverless_globals.yaml",
                     "Level": "Error",
@@ -251,38 +148,12 @@ class TestQuickStartTemplates(BaseCliTestCase):
                     }
                 }
             ],
-            'exit_code': 6,
+            'exit_code': 2,
         },
         {
             'filename': 'test/fixtures/templates/good/transform/list_transform.yaml',
-            'results': [
-                {
-                    "Filename": "test/fixtures/templates/good/transform/list_transform.yaml",
-                    "Level": "Warning",
-                    "Location": {
-                        "End": {
-                            "ColumnNumber": 10,
-                            "LineNumber": 14
-                        },
-                        "Path": [
-                            "Resources",
-                            "SkillFunctionVersion55ff35af87"
-                        ],
-                        "Start": {
-                            "ColumnNumber": 1,
-                            "LineNumber": 14
-                        }
-                    },
-                    "Message": "Both UpdateReplacePolicy and DeletionPolicy are needed to protect Resources/SkillFunctionVersion55ff35af87 from deletion",
-                    "Rule": {
-                        "Description": "Both UpdateReplacePolicy and DeletionPolicy are needed to protect resources from deletion",
-                        "Id": "W3011",
-                        "ShortDescription": "Check resources with UpdateReplacePolicy/DeletionPolicy have both",
-                        "Source": "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html"
-                    }
-                }
-            ],
-            'exit_code': 4,
+            'results': [],
+            'exit_code': 0,
         },
         {
             'filename': 'test/fixtures/templates/good/transform/list_transform_many.yaml',


### PR DESCRIPTION
fixes https://github.com/aws-cloudformation/cfn-python-lint/issues/1265 because the [`AWS::Serverless` transform](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-serverless.html) won't support [`UpdateReplacePolicy`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html) soon while it's setting [`DeletionPolicy`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) here:

[`AWS::Lambda::Version`](https://github.com/awslabs/serverless-application-model/blob/a9388b64147e12426ba585482ee96f81db2dd25a/samtranslator/model/sam_resources.py#L415) ([docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-version.html))
[`AWS::Lambda::LayerVersion`](https://github.com/awslabs/serverless-application-model/blob/a9388b64147e12426ba585482ee96f81db2dd25a/samtranslator/model/sam_resources.py#L794) ([docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-layerversion.html))

---

Will investigate resources the [`AWS::Serverless` transform](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-aws-serverless.html) creates that could fail [`I3011`](https://github.com/awslabs/serverless-application-model/pull/1481#issuecomment-596030489) after 