### PR TITLE
New rule to check resources if ARNs use correctly placed Pseudo Parameters instead of hardcoded Partition, Region, and Account Number

### DIFF
--- a/src/cfnlint/rules/resources/HardCodedArnProperties.py
+++ b/src/cfnlint/rules/resources/HardCodedArnProperties.py
@@ -1,0 +1,35 @@
+"""
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+import re
+import json
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
+
+
+class HardCodedArnProperties(CloudFormationLintRule):
+    """Checks Resources if ARNs use correctly placed Pseudo Parameters instead of hardcoded Partition, Region, and Account Number"""
+    id = 'W3042'
+    shortdesc = 'ARNs should use correctly placed Pseudo Parameters'
+    description = 'Checks Resources if ARNs use correctly placed Pseudo Parameters instead of hardcoded Partition, Region, and Account Number'
+    source_url = ''
+    tags = ['resources']
+
+    def match(self, cfn):
+        """Check CloudFormation Resources"""
+        matches = []
+        pattern = re.compile("arn:(\$\{[^:]*::[^:]*}|[^:]*):[^:]+:(\$\{[^:]*::[^:]*}|[^:]*):(\$\{[^:]*::[^:]*}|[^:]*)")
+        resources = cfn.template.get('Resources', {})
+        if resources:
+            for resourcename, val  in resources.items():
+                candidates = pattern.findall(str(val))
+                for candidate in candidates:
+                    if candidate[0] != "${AWS::Partition}" or candidate[1] not in ("${AWS::Region}","") or candidate[2] not in ("${AWS::AccountId}",""):
+                        message = 'ARN in Resource {0} contains hardcoded Partition, Region, and/or Account Number in ARN or incorrectly placed Pseudo Parameters'
+                        matches.append(RuleMatch(
+                            ['Resources', resourcename],
+                            message.format(resourcename)
+                        ))
+                        break
+        return matches

--- a/test/fixtures/templates/bad/hard_coded_arn_properties.yaml
+++ b/test/fixtures/templates/bad/hard_coded_arn_properties.yaml
@@ -1,0 +1,105 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  S3BadBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: Private
+      NotificationConfiguration:
+        TopicConfigurations:
+        - Topic: arn:aws:sns:us-east-1:123456789012:TestTopic
+          Event: s3:ReducedRedundancyLostObject
+
+  SampleBadBucketPolicy: 
+    Type: AWS::S3::BucketPolicy
+    Properties: 
+      Bucket: !Ref S3BadBucket
+      PolicyDocument: 
+        Statement: 
+          - Action: 
+              - s3:GetObject
+            Effect: Allow
+            Resource: !Sub arn:aws:s3:::${S3BadBucket}
+            Principal: "*"
+
+  SampleRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+              - ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+
+
+  SampleBadIAMPolicy1:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sns:Publish
+            Resource: !Sub arn:${AWS::Partition}:sns:us-east-1:${AWS::AccountId}:TestTopic
+      Roles:
+        - !Ref SampleRole
+
+  SampleBadIAMPolicy2:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sns:Publish
+            Resource: 
+              - !Sub arn:${AWS::Partition}:sns:us-east-1:${AWS::AccountId}:TestTopic
+              - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:TestTopic
+      Roles:
+        - !Ref SampleRole
+
+  SampleBadIAMPolicy3:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sns:Publish
+            Resource: 
+              - !Sub arn:${AWS::Partition}:sns:${AWS::Partition}:${AWS::AccountId}:TestTopic
+      Roles:
+        - !Ref SampleRole
+
+  SampleGoodIAMPolicy1:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sns:Publish
+            Resource: '*'
+      Roles:
+        - !Ref SampleRole
+
+  SampleGoodIAMPolicy2:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - sns:Publish
+            Resource: !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:TestTopic
+      Roles:
+        - !Ref SampleRole

--- a/test/unit/rules/resources/test_hardcodedarnproperties.py
+++ b/test/unit/rules/resources/test_hardcodedarnproperties.py
@@ -1,0 +1,23 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+from test.unit.rules import BaseRuleTestCase
+from cfnlint.rules.resources.HardCodedArnProperties import HardCodedArnProperties  # pylint: disable=E0401
+
+
+
+class TestHardCodedArnProperties(BaseRuleTestCase):
+    """Test template parameter configurations"""
+    def setUp(self):
+        """Setup"""
+        super(TestHardCodedArnProperties, self).setUp()
+        self.collection.register(HardCodedArnProperties())
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive() # By default, a set of "correct" templates are checked
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('test/fixtures/templates/bad/hard_coded_arn_properties.yaml', 5) # Amount of expected matches


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
Adding Rule W3042 and related testcases.  Checks Resources if ARNs use correctly placed Pseudo Parameters instead of hardcoded Partition, Region, and Account Number

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
