### PR TITLE
adding Los Angeles, ElastiCache CacheNodeType, Elasticsearch InstanceType, and fixing Neptune InstanceClass pricing information

### DIFF
--- a/scripts/update_specs_from_pricing.py
+++ b/scripts/update_specs_from_pricing.py
@@ -212,6 +212,10 @@ def get_elasticache_pricing():
     return get_results('AmazonElastiCache', ['Cache Instance'])
 
 
+def get_elasticsearch_pricing():
+    return get_results('AmazonES', ['Elastic Search Instance'])
+
+
 def get_results(service, product_families):
     results = {}
     for page in get_paginator(service):
@@ -244,6 +248,7 @@ def main():
     outputs = update_outputs('DocumentDBInstanceClass', get_documentdb_pricing(), outputs)
     outputs = update_outputs('NeptuneInstanceClass', get_neptune_pricing(), outputs)
     outputs = update_outputs('ElastiCacheInstanceType', get_elasticache_pricing(), outputs)
+    outputs = update_outputs('ElasticsearchInstanceType', get_elasticsearch_pricing(), outputs)
 
     LOGGER.info('Updating spec files')
     for region, patches in outputs.items():

--- a/scripts/update_specs_from_pricing.py
+++ b/scripts/update_specs_from_pricing.py
@@ -246,7 +246,7 @@ def main():
     outputs = update_outputs('DAXInstanceType', get_dax_pricing(), outputs)
     outputs = update_outputs('DocumentDBInstanceClass', get_documentdb_pricing(), outputs)
     outputs = update_outputs('NeptuneInstanceClass', get_neptune_pricing(), outputs)
-
+    get_elasticache_pricing()
     LOGGER.info('Updating spec files')
     for region, patches in outputs.items():
         filename = 'src/cfnlint/data/ExtendedSpecs/%s/05_pricing_property_values.json' % region

--- a/scripts/update_specs_from_pricing.py
+++ b/scripts/update_specs_from_pricing.py
@@ -95,15 +95,13 @@ def get_redshift_pricing():
 
 
 def get_dax_pricing():
-    service = 'AmazonDAX'
-    product_families = 'DAX'
     results = {}
-    for page in get_paginator(service):
+    for page in get_paginator('AmazonDAX'):
         for price_item in page.get('PriceList', []):
             products = json.loads(price_item)
             product = products.get('product', {})
             if product:
-                if product.get('productFamily') in product_families:
+                if product.get('productFamily') in ['DAX']:
                     if not results.get(region_map[product.get('attributes').get('location')]):
                         results[region_map[product.get('attributes').get('location')]] = set()
                     results[region_map[product.get('attributes').get('location')]].add(
@@ -117,14 +115,13 @@ def get_mq_pricing():
         'mq.m5.2xl': 'mq.m5.2xlarge',
         'mq.m5.4xl': 'mq.m5.4xlarge'
     }
-
     results = {}
     for page in get_paginator('AmazonMQ'):
         for price_item in page.get('PriceList', []):
             products = json.loads(price_item)
             product = products.get('product', {})
             if product:
-                if product.get('productFamily') == 'Broker Instances':
+                if product.get('productFamily') in ['Broker Instances']:
                     if not results.get(region_map[product.get('attributes').get('location')]):
                         results[region_map[product.get('attributes').get('location')]] = set()
                     usage_type = product.get('attributes').get('usagetype').split(':')[1]
@@ -169,7 +166,7 @@ def get_rds_pricing():
             products = json.loads(price_item)
             product = products.get('product', {})
             if product:
-                if product.get('productFamily') == 'Database Instance':
+                if product.get('productFamily') in ['Database Instance']:
                     # Get overall instance types
                     if not results.get(region_map[product.get('attributes').get('location')]):
                         results[region_map[product.get('attributes').get('location')]] = set()

--- a/scripts/update_specs_from_pricing.py
+++ b/scripts/update_specs_from_pricing.py
@@ -243,7 +243,8 @@ def main():
     outputs = update_outputs('DAXInstanceType', get_dax_pricing(), outputs)
     outputs = update_outputs('DocumentDBInstanceClass', get_documentdb_pricing(), outputs)
     outputs = update_outputs('NeptuneInstanceClass', get_neptune_pricing(), outputs)
-    get_elasticache_pricing()
+    outputs = update_outputs('ElastiCacheInstanceType', get_elasticache_pricing(), outputs)
+
     LOGGER.info('Updating spec files')
     for region, patches in outputs.items():
         filename = 'src/cfnlint/data/ExtendedSpecs/%s/05_pricing_property_values.json' % region

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_elasticache.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_elasticache.json
@@ -14,5 +14,11 @@
       "NumberMax": 5,
       "NumberMin": 0
     }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/ElastiCacheInstanceType",
+    "value": {
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_elasticsearch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_elasticsearch.json
@@ -1,0 +1,8 @@
+[
+  {
+    "op": "add",
+    "path": "/ValueTypes/ElasticsearchInstanceType",
+    "value": {
+    }
+  }
+]

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_elasticache.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_elasticache.json
@@ -20,5 +20,19 @@
     "value": {
       "ValueType": "AWS::ElastiCache::ReplicationGroup.ReplicasPerNodeGroup"
     }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::ElastiCache::CacheCluster/Properties/CacheNodeType/Value",
+    "value": {
+      "ValueType": "ElastiCacheInstanceType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::ElastiCache::ReplicationGroup/Properties/CacheNodeType/Value",
+    "value": {
+      "ValueType": "ElastiCacheInstanceType"
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_elasticsearch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_elasticsearch.json
@@ -6,5 +6,12 @@
       "ListValueType": "AWS::EC2::SecurityGroup.NamesOrGroupIds",
       "ValueType": "AWS::EC2::SecurityGroup.NameOrGroupId"
     }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::Elasticsearch::Domain.ElasticsearchClusterConfig/Properties/InstanceType/Value",
+    "value": {
+      "ValueType": "ElasticsearchInstanceType"
+    }
   }
 ]


### PR DESCRIPTION
**[Offer files for reference:](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/using-ppslong.html#download-the-offer-index)**
https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/index.json
[AmazonEC2](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/index.json)
[AmazonRedshift](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonRedshift/current/index.json)
[AmazonDAX](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonDAX/current/index.json)
[AmazonMQ](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonMQ/current/index.json)
[AmazonRDS](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonRDS/current/index.json)
[AmazonNeptune](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonNeptune/current/index.json)
[AmazonDocDB](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonDocDB/current/index.json)
[AmazonElastiCache](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonElastiCache/current/index.json)
[AmazonES](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonES/current/index.json)

---

[unrelated to this change, `m6g` instance types launched this week](https://aws.amazon.com/blogs/aws/new-m6g-ec2-instances-powered-by-arm-based-aws-graviton2/)

---

moved [`US West (Los Angeles)` from `region_exceptions` to `region_map` for `us-west-2`](https://aws.amazon.com/blogs/aws/aws-now-available-from-a-local-zone-in-los-angeles/)

which adds `i3en.metal-2tb` EC2 instance type to `src/cfnlint/data/ExtendedSpecs/us-west-2/05_pricing_property_values.json` and 37 lines to `src/cfnlint/data/AdditionalSpecs/RdsProperties.json`

---

switched `AmazonNeptune` from parsing `usagetype` to using `instanceType` which appends `arge` to `db.r5.\d*xl`, which seems correct:

```yaml
Resources:
  DBCluster:
    Type: AWS::Neptune::DBCluster
  DBInstance:
    Type: AWS::Neptune::DBInstance
    Properties:
      DBInstanceClass: db.r5.xl
      DBClusterIdentifier: !Ref DBCluster
```
`Invalid DB Instance class: db.r5.xl (Service: AmazonNeptune; Status Code: 400; Error Code: InvalidParameterValue)`

```yaml
Resources:
  DBCluster:
    Type: AWS::Neptune::DBCluster
  DBInstance:
    Type: AWS::Neptune::DBInstance
    Properties:
      DBInstanceClass: db.r5.xlarge
      DBClusterIdentifier: !Ref DBCluster
```

---

added `AmazonElastiCache` information for:

[`AWS::ElastiCache::CacheCluster.CacheNodeType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticache-cache-cluster.html#cfn-elasticache-cachecluster-cachenodetype)

[`AWS::ElastiCache::ReplicationGroup.CacheNodeType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticache-replicationgroup.html#cfn-elasticache-replicationgroup-cachenodetype)

added `AmazonES` information for:

[`AWS::Elasticsearch::Domain.ElasticsearchClusterConfig.InstanceType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticsearch-domain-elasticsearchclusterconfig.html#cfn-elasticsearch-domain-elasticseachclusterconfig-instnacetype)

---

how to test:
---
```shell
brew install github/gh/gh # https://github.com/cli/cli
gh pr checkout 1535
pip3 install -e .
scripts/update_specs_from_pricing.py # requires Boto3 and Credentials, takes forever
cfn-lint --update-specs
```
```yaml
Resources:
  Domain:
    Type: AWS::Elasticsearch::Domain
    Properties:
      ElasticsearchClusterConfig:
        InstanceType: r3.large.elasticsearch # change this for E3030 errors 🎉
```
---
future work:
---
**more services:**
~~`nodetype`~~

`instanceclass`:

[AWSDatabaseMigrationSvc 'Replication Server'](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AWSDatabaseMigrationSvc/current/index.json) for [`AWS::DMS::ReplicationInstance.ReplicationInstanceClass`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-replicationinstance.html#cfn-dms-replicationinstance-replicationinstanceclass) (`dms.` prefix missing from `instanceType`, could parse `usagetype`)

[`instancetype`](https://www.google.com/search?q=site%3Ahttps%3A%2F%2Fdocs.aws.amazon.com%2FAWSCloudFormation%2Flatest%2FUserGuide+%22instancetype%22):

[ElasticMapReduce 'Elastic Map Reduce Instance'](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/ElasticMapReduce/current/index.json) for [`AWS::EMR::InstanceGroupConfig.InstanceType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-emr-instancegroupconfig.html#cfn-emr-instancegroupconfig-instancetype), [`AWS::EMR::Cluster.`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-cluster-instancegroupconfig.html#cfn-elasticmapreduce-cluster-instancegroupconfig-instancetype), [`AWS::EMR::InstanceFleetConfig.InstanceTypeConfigs.InstanceType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticmapreduce-instancefleetconfig-instancetypeconfig.html#cfn-elasticmapreduce-instancefleetconfig-instancetypeconfig-instancetype)

[AmazonSageMaker](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonSageMaker/current/index.json), etc.

---

[`cn-north-1`](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/src/cfnlint/data/ExtendedSpecs/cn-north-1/05_pricing_property_values.json) and [`cn-northwest-1`](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/src/cfnlint/data/ExtendedSpecs/cn-northwest-1/05_pricing_property_values.json) don't seem to pick up any pricing information 