### PR TITLE
removing AWS GovCloud (US) from region_map

### DIFF
--- a/scripts/update_specs_from_pricing.py
+++ b/scripts/update_specs_from_pricing.py
@@ -17,7 +17,6 @@ LOGGER = logging.getLogger('cfnlint')
 
 
 region_map = {
-    'AWS GovCloud (US)': 'us-gov-west-1',
     'AWS GovCloud (US-East)': 'us-gov-east-1',
     'AWS GovCloud (US-West)': 'us-gov-west-1',
     'Africa (Cape Town)': 'af-south-1',


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/pull/1380#discussion_r382680756

`location` is just `AWS GovCloud (US-West)` [now](https://github.com/aws-cloudformation/cfn-python-lint/pull/1535) instead of also having the old `AWS GovCloud (US)`