### PR TITLE
Hooks template section

### DIFF
--- a/src/cfnlint/rules/templates/Base.py
+++ b/src/cfnlint/rules/templates/Base.py
@@ -26,12 +26,12 @@ class Base(CloudFormationLintRule):
         for x in cfn.template:
             top_level.append(x)
             if x not in cfn.sections:
-                message = 'Top level item {0} isn\'t valid'
+                message = 'Top level template section {0} is not valid'
                 matches.append(RuleMatch([x], message.format(x)))
 
         for y in self.required_keys:
             if y not in top_level:
-                message = 'Missing top level item {0} to file module'
+                message = 'Missing top level template section {0}'
                 matches.append(RuleMatch([y], message.format(y)))
 
         return matches

--- a/src/cfnlint/template.py
+++ b/src/cfnlint/template.py
@@ -29,6 +29,7 @@ class Template(object):  # pylint: disable=R0904
             'Mappings',
             'Conditions',
             'Transform',
+            'Hooks',
             'Resources',
             'Outputs',
             'Rules'


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/blue-green.html

still missing from [template anatomy documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-anatomy.html)

getting rid of [`E1001 Top level item Hooks isn't valid`](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/docs/rules.md#E1001)

wasn't able to get a `HOOK` `Schema` from the [CloudFormation registry](https://aws.amazon.com/blogs/aws/cloudformation-update-cli-third-party-resource-support-registry/) yet:
```shell
$ aws cloudformation describe-type --type HOOK --type-name AWS::CodeDeploy::BlueGreen
An error occurred (ValidationError) when calling the DescribeType operation: 1 validation error detected: Value 'HOOK' at 'type' failed to satisfy constraint: Member must satisfy enum value set: [RESOURCE]
```