### PR TITLE
Rule E3042 - Check at least one essential container is specified

### DIFF
--- a/src/cfnlint/rules/resources/ecs/TaskDefinitionEssentialContainer.py
+++ b/src/cfnlint/rules/resources/ecs/TaskDefinitionEssentialContainer.py
@@ -1,0 +1,44 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+from cfnlint.rules import CloudFormationLintRule
+from cfnlint.rules import RuleMatch
+
+
+class TaskDefinitionEssentialContainer(CloudFormationLintRule):
+    """Check if Ec2 Ebs Resource Properties"""
+    id = 'E3042'
+    shortdesc = 'Check at least one essential container is specified'
+    description = 'Check that every TaskDefinition specifies at least one essential container'
+    source_url = 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-essential'
+    tags = ['properties', 'ecs', 'task', 'container', 'fargate']
+
+    def match(self, cfn):
+        """Check at least one essential container is specified"""
+
+        matches = []
+
+        results = cfn.get_resource_properties(['AWS::ECS::TaskDefinition', 'ContainerDefinitions'])
+
+        for result in results:
+            path = result['Path']
+
+            has_essential_container = False
+
+            for container in result['Value']:
+                if 'Essential' in container:
+                    if container['Essential']:
+                        has_essential_container = True
+                    else:
+                        pass
+                else:
+                    # If 'Essential' is not specified, it defaults to an essential container
+                    has_essential_container = True
+
+            if not has_essential_container:
+                message = 'No essential containers defined for {0}'
+                rule_match = RuleMatch(path, message.format('/'.join(map(str, path))))
+                matches.append(rule_match)
+
+        return matches

--- a/src/cfnlint/rules/resources/ecs/TaskDefinitionEssentialContainer.py
+++ b/src/cfnlint/rules/resources/ecs/TaskDefinitionEssentialContainer.py
@@ -7,7 +7,7 @@ from cfnlint.rules import RuleMatch
 
 
 class TaskDefinitionEssentialContainer(CloudFormationLintRule):
-    """Check if Ec2 Ebs Resource Properties"""
+    """Check ECS TaskDefinition ContainerDefinitions Property Species At Least One Essential Container"""
     id = 'E3042'
     shortdesc = 'Check at least one essential container is specified'
     description = 'Check that every TaskDefinition specifies at least one essential container'

--- a/src/cfnlint/rules/resources/ecs/TaskDefinitionEssentialContainer.py
+++ b/src/cfnlint/rules/resources/ecs/TaskDefinitionEssentialContainer.py
@@ -7,7 +7,7 @@ from cfnlint.rules import RuleMatch
 
 
 class TaskDefinitionEssentialContainer(CloudFormationLintRule):
-    """Check ECS TaskDefinition ContainerDefinitions Property Species At Least One Essential Container"""
+    """Check ECS TaskDefinition ContainerDefinitions Property Specifies at least one Essential Container"""
     id = 'E3042'
     shortdesc = 'Check at least one essential container is specified'
     description = 'Check that every TaskDefinition specifies at least one essential container'

--- a/src/cfnlint/rules/resources/ecs/__init__.py
+++ b/src/cfnlint/rules/resources/ecs/__init__.py
@@ -1,0 +1,4 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""

--- a/test/fixtures/templates/bad/resources/ecs/test_ecs_task_definition_essential_container.yml
+++ b/test/fixtures/templates/bad/resources/ecs/test_ecs_task_definition_essential_container.yml
@@ -1,0 +1,53 @@
+---
+Resources:
+
+  BadTaskDefinitionNoEssentialContainersSpecified:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      ContainerDefinitions:
+        - Essential: false
+          Image: amazon/aws-cli
+          Memory: 40
+          Name: amazon-cli
+
+  GoodTaskDefinitionEssentialContainerSpecified:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      ContainerDefinitions:
+        - Essential: true
+          Image: amazon/aws-cli
+          Memory: 40
+          Name: amazon-cli
+
+  GoodTaskDefinitionEssentialContainerDefault:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      ContainerDefinitions:
+        - Image: amazon/aws-cli
+          Memory: 40
+          Name: amazon-cli
+
+  GoodTaskDefinitionEssentialContainerSpecifiedTwo:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      ContainerDefinitions:
+        - Essential: true
+          Image: amazon/aws-cli
+          Memory: 40
+          Name: amazon-cli
+        - Essential: false
+          Image: amazon/aws-cli
+          Memory: 40
+          Name: amazon-cli-two
+
+  GoodTaskDefinitionMultipleEssentialContainersSpecified:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      ContainerDefinitions:
+        - Essential: true
+          Image: amazon/aws-cli
+          Memory: 40
+          Name: amazon-cli
+        - Image: amazon/aws-cli
+          Memory: 40
+          Name: amazon-cli-two

--- a/test/fixtures/templates/good/resources/ecs/test_ecs_task_definition_essential_container.yml
+++ b/test/fixtures/templates/good/resources/ecs/test_ecs_task_definition_essential_container.yml
@@ -1,0 +1,44 @@
+---
+Resources:
+
+  GoodTaskDefinitionEssentialContainerSpecified:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      ContainerDefinitions:
+        - Essential: true
+          Image: amazon/aws-cli
+          Memory: 40
+          Name: amazon-cli
+
+  GoodTaskDefinitionEssentialContainerDefault:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      ContainerDefinitions:
+        - Image: amazon/aws-cli
+          Memory: 40
+          Name: amazon-cli
+
+  GoodTaskDefinitionEssentialContainerSpecifiedTwo:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      ContainerDefinitions:
+        - Essential: true
+          Image: amazon/aws-cli
+          Memory: 40
+          Name: amazon-cli
+        - Essential: false
+          Image: amazon/aws-cli
+          Memory: 40
+          Name: amazon-cli-two
+
+  GoodTaskDefinitionMultipleEssentialContainersSpecified:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      ContainerDefinitions:
+        - Essential: true
+          Image: amazon/aws-cli
+          Memory: 40
+          Name: amazon-cli
+        - Image: amazon/aws-cli
+          Memory: 40
+          Name: amazon-cli-two

--- a/test/unit/rules/resources/ecs/__init__.py
+++ b/test/unit/rules/resources/ecs/__init__.py
@@ -1,0 +1,4 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""

--- a/test/unit/rules/resources/ecs/test_ecs_task_definition_essential_container.py
+++ b/test/unit/rules/resources/ecs/test_ecs_task_definition_essential_container.py
@@ -1,0 +1,26 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+"""
+from test.unit.rules import BaseRuleTestCase
+from cfnlint.rules.resources.ecs.TaskDefinitionEssentialContainer import TaskDefinitionEssentialContainer  # pylint: disable=E0401
+
+
+class TestECSTaskDefinitionEssentialContainer(BaseRuleTestCase):
+    """Test ECS Task Definition has at least one essential container defined"""
+
+    def setUp(self):
+        """Setup"""
+        super(TestECSTaskDefinitionEssentialContainer, self).setUp()
+        self.collection.register(TaskDefinitionEssentialContainer())
+        self.success_templates = [
+            'test/fixtures/templates/good/resources/ecs/test_ecs_task_definition_essential_container.yml',
+        ]
+
+    def test_file_positive(self):
+        """Test Positive"""
+        self.helper_file_positive()
+
+    def test_file_negative(self):
+        """Test failure"""
+        self.helper_file_negative('test/fixtures/templates/bad/resources/ecs/test_ecs_task_definition_essential_container.yml', 1)


### PR DESCRIPTION
*Issue #, if available:* #1547 

*Description of changes:* Adds a new rule, E3042, that checks `AWS::ECS::TaskDefinition.ContainerDefinition` specifies at least one essential container. Not specifying an essential container (or having a container defaulting to essential) will cause a deployment failure. Reference: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-essential.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
