### PR TITLE
Add new allowed patterns for AWS::S3::Bucket.InventoryConfiguration

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -700,7 +700,7 @@
       },
       "S3BucketInventoryId": {
         "AllowedPattern": "[a-zA-Z0-9.-_]+",
-        "AllowedPatternRegex": "^[a-zA-Z0-9.-_]+$",
+        "AllowedPatternRegex": "^[a-zA-Z0-9.\\-_]+$",
         "StringMax": 64,
         "StringMin": 1
       },

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -700,7 +700,7 @@
       },
       "S3BucketInventoryId": {
         "AllowedPattern": "[a-zA-Z0-9.-_]+",
-        "AllowedPatternRegex": "^[a-zA-Z0-9.\\-_]+$",
+        "AllowedPatternRegex": "^[a-zA-Z0-9-_.]+$",
         "StringMax": 64,
         "StringMin": 1
       },

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -698,6 +698,24 @@
           "PublicReadWrite"
         ]
       },
+      "S3BucketInventoryId": {
+        "AllowedPattern": "[a-zA-Z0-9.-_]+",
+        "AllowedPatternRegex": "^[a-zA-Z0-9.-_]+$",
+        "StringMax": 64,
+        "StringMin": 1
+      },
+      "S3BucketInventoryIncludedObjectVersions": {
+        "AllowedValues": [
+          "All",
+          "Current"
+        ]
+      },
+      "S3BucketInventoryScheduleFrequency": {
+        "AllowedValues": [
+          "Daily",
+          "Weekly"
+        ]
+      },
       "S3BucketSSEAlgorithm": {
         "AllowedValues": [
           "AES256",

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -267,6 +267,27 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::S3::Bucket.InventoryConfiguration/Properties/Id/Value",
+    "value": {
+      "ValueType": "S3BucketInventoryId"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::S3::Bucket.InventoryConfiguration/Properties/IncludedObjectVersions/Value",
+    "value": {
+      "ValueType": "S3BucketInventoryIncludedObjectVersions"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/PropertyTypes/AWS::S3::Bucket.InventoryConfiguration/Properties/ScheduleFrequency/Value",
+    "value": {
+      "ValueType": "S3BucketInventoryScheduleFrequency"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::S3::Bucket.RedirectAllRequestsTo/Properties/Protocol/Value",
     "value": {
       "ValueType": "HttpProtocol"


### PR DESCRIPTION
Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>

*Issue #1550*

*Description of changes:*

Add allowed patterns for [InventoryConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-inventoryconfiguration.html#cfn-s3-bucket-inventoryconfiguration-destination), some of it from experience with the AWS console.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
