### PR TITLE
removing explicit AWS::SDB::Domain removals due to automatic 06_ssm_service_removal.json from scripts/update_specs_services_from_ssm.py

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/eu-central-1/01_spec_patch.json
+++ b/src/cfnlint/data/ExtendedSpecs/eu-central-1/01_spec_patch.json
@@ -1,6 +1,1 @@
-[
-  {
-    "op": "remove",
-    "path": "/ResourceTypes/AWS::SDB::Domain"
-  }
-]
+[]

--- a/src/cfnlint/data/ExtendedSpecs/us-east-2/01_spec_patch.json
+++ b/src/cfnlint/data/ExtendedSpecs/us-east-2/01_spec_patch.json
@@ -1,6 +1,1 @@
-[
-  {
-    "op": "remove",
-    "path": "/ResourceTypes/AWS::SDB::Domain"
-  }
-]
+[]


### PR DESCRIPTION

https://github.com/aws-cloudformation/cfn-python-lint/blob/cc6ac28ff7deba86cb82813733cceec4bdff68a2/src/cfnlint/data/ExtendedSpecs/us-east-2/06_ssm_service_removal.json#L6-L9
https://github.com/aws-cloudformation/cfn-python-lint/blob/cc6ac28ff7deba86cb82813733cceec4bdff68a2/src/cfnlint/data/ExtendedSpecs/eu-central-1/06_ssm_service_removal.json#L6-L9
https://github.com/aws-cloudformation/cfn-python-lint/blob/cc6ac28ff7deba86cb82813733cceec4bdff68a2/scripts/update_specs_services_from_ssm.py#L165

only 4 regions left with explicit `01_spec_patch.json` changes after this:

```bash
echo [] > src/cfnlint/data/ExtendedSpecs/us-east-2/01_spec_patch.json
echo [] > src/cfnlint/data/ExtendedSpecs/eu-central-1/01_spec_patch.json
wc -l src/cfnlint/data/ExtendedSpecs/*-*/01* | sort -nr
     359 src/cfnlint/data/ExtendedSpecs/ap-southeast-1/01_spec_patch.json
     359 src/cfnlint/data/ExtendedSpecs/ap-south-1/01_spec_patch.json
     220 src/cfnlint/data/ExtendedSpecs/ap-southeast-2/01_spec_patch.json
      27 src/cfnlint/data/ExtendedSpecs/ap-northeast-3/01_spec_patch.json
```