### PR TITLE
Don't check SSM parameter values for CIDR Regex

### DIFF
--- a/src/cfnlint/rules/parameters/CidrAllowedValues.py
+++ b/src/cfnlint/rules/parameters/CidrAllowedValues.py
@@ -60,7 +60,7 @@ class CidrAllowedValues(CloudFormationLintRule):
             parameter = parameters.get(value, {})
             parameter_type = parameters.get(value, {}).get('Type', '')
             if parameter_type == 'AWS::SSM::Parameter::Value<String>':
-                # If we are reading from the Parameter store we can longer
+                # If we are reading from the Parameter store we can no longer
                 # check the value of the allowed values
                 return matches
             allowed_values = parameter.get('AllowedValues', None)

--- a/src/cfnlint/rules/parameters/CidrAllowedValues.py
+++ b/src/cfnlint/rules/parameters/CidrAllowedValues.py
@@ -58,6 +58,11 @@ class CidrAllowedValues(CloudFormationLintRule):
 
         if value in parameters:
             parameter = parameters.get(value, {})
+            parameter_type = parameters.get(value, {}).get('Type', '')
+            if parameter_type == 'AWS::SSM::Parameter::Value<String>':
+                # If we are reading from the Parameter store we can longer
+                # check the value of the allowed values
+                return matches
             allowed_values = parameter.get('AllowedValues', None)
             if allowed_values:
                 for cidr in allowed_values:


### PR DESCRIPTION
*Issue #, if available:*
fix #1570
*Description of changes:*
- Update rule E2004 to not check `AllowedValues` when the `Type` is `AWS::SSM::Parameter::Value<String>`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
