### PR TITLE
update AllowedValues for AWS::SecretsManager::SecretTargetAttachment.TargetType

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -745,8 +745,11 @@
       },
       "SecretsManagerTargetType": {
         "AllowedValues": [
+          "AWS::DocDB::DBCluster",
+          "AWS::DocDB::DBInstance",
           "AWS::RDS::DBCluster",
-          "AWS::RDS::DBInstance"
+          "AWS::RDS::DBInstance",
+          "AWS::Redshift::Cluster"
         ]
       },
       "ServiceDiscoveryDnsType": {


### PR DESCRIPTION
As per latest documentation [1], AWS::SecretsManager::SecretTargetAttachment
TargetType property accepts the following values as well:

* AWS::Redshift::Cluster
* AWS::DocDB::DBInstance
* AWS::DocDB::DBCluster

This commit adds those new values into the list of allowed values for
the TargetType property.

[1] https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-secrettargetattachment.html#cfn-secretsmanager-secrettargetattachment-targettype

--

I wasn't sure if it's been customary to update / re-render generated specs when changing customizations or if that's separately before release. Please let me know if I should update the specs in the same go and I'll try to get that done.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
