### PR TITLE
fix missing /Properties/ path segment

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -586,7 +586,7 @@
   },
   {
     "op": "add",
-    "path": "/ResourceTypes/AWS::DMS::ReplicationInstance/AvailabilityZone/Value",
+    "path": "/ResourceTypes/AWS::DMS::ReplicationInstance/Properties/AvailabilityZone/Value",
     "value": {
       "ValueType": "AvailabilityZone"
     }
@@ -796,7 +796,7 @@
   },
   {
     "op": "add",
-    "path": "/ResourceTypes/AWS::EC2::Subnet/AvailabilityZone/Value",
+    "path": "/ResourceTypes/AWS::EC2::Subnet/Properties/AvailabilityZone/Value",
     "value": {
       "ValueType": "AvailabilityZone"
     }


### PR DESCRIPTION
*Description of changes:*

I noticed two patch operations were missing the `/Properties/` segment, which caused them to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
