### PR TITLE
refactoring limit rules

### DIFF
--- a/src/cfnlint/rules/common.py
+++ b/src/cfnlint/rules/common.py
@@ -19,7 +19,7 @@ def approaching_name_limit(cfn, section):
 
 def approaching_number_limit(cfn, section):
     matches = []
-    number = cfn.template.get(section, {})
+    number = cfn.get_resources() if section == 'Resources' else cfn.template.get(section, {})
     if LIMITS['threshold'] * LIMITS[section]['number'] < len(number) <= LIMITS[section]['number']:
         message = 'The number of ' + section + ' ({0}) is approaching the limit ({1})'
         matches.append(RuleMatch([section], message.format(len(number), LIMITS[section]['number'])))
@@ -37,7 +37,7 @@ def name_limit(cfn, section):
 
 def number_limit(cfn, section):
     matches = []
-    number = cfn.template.get(section, {})
+    number = cfn.get_resources() if section == 'Resources' else cfn.template.get(section, {})
     if len(number) > LIMITS[section]['number']:
         message = 'The number of ' + section + ' ({0}) exceeds the limit ({1})'
         matches.append(RuleMatch([section], message.format(len(number), LIMITS[section]['number'])))

--- a/src/cfnlint/rules/resources/ApproachingLimitNumber.py
+++ b/src/cfnlint/rules/resources/ApproachingLimitNumber.py
@@ -3,8 +3,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule
-from cfnlint.rules import RuleMatch
-from cfnlint.helpers import LIMITS
+from cfnlint.rules.common import approaching_number_limit
 
 
 class LimitNumber(CloudFormationLintRule):
@@ -16,9 +15,4 @@ class LimitNumber(CloudFormationLintRule):
     tags = ['resources', 'limits']
 
     def match(self, cfn):
-        matches = []
-        resources = cfn.get_resources()
-        if LIMITS['threshold'] * LIMITS['Resources']['number'] < len(resources) <= LIMITS['Resources']['number']:
-            message = 'The number of resources ({0}) is approaching the limit ({1})'
-            matches.append(RuleMatch(['Resources'], message.format(len(resources), LIMITS['Resources']['number'])))
-        return matches
+        return approaching_number_limit(cfn, 'Resources')

--- a/src/cfnlint/rules/resources/LimitNumber.py
+++ b/src/cfnlint/rules/resources/LimitNumber.py
@@ -3,8 +3,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
 from cfnlint.rules import CloudFormationLintRule
-from cfnlint.rules import RuleMatch
-from cfnlint.helpers import LIMITS
+from cfnlint.rules.common import number_limit
 
 
 class LimitNumber(CloudFormationLintRule):
@@ -16,9 +15,4 @@ class LimitNumber(CloudFormationLintRule):
     tags = ['resources', 'limits']
 
     def match(self, cfn):
-        matches = []
-        resources = cfn.get_resources()
-        if len(resources) > LIMITS['Resources']['number']:
-            message = 'The number of resources ({0}) exceeds the limit ({1})'
-            matches.append(RuleMatch(['Resources'], message.format(len(resources), LIMITS['Resources']['number'])))
-        return matches
+        return number_limit(cfn, 'Resources')


### PR DESCRIPTION
last couple rules left from https://github.com/aws-cloudformation/cfn-python-lint/pull/1558


```bash
# limit test templates
find test -name "*limit*" | grep -v '.py' | grep -v 'events'
test/fixtures/templates/bad/limit_name.yaml
test/fixtures/templates/bad/limit_parameter_value.yaml
test/fixtures/templates/bad/limit_numbers.yaml
test/fixtures/templates/bad/approaching_limit_numbers.yaml
test/fixtures/templates/bad/approaching_limit_size.yaml
test/fixtures/templates/bad/limit_size.yaml

# ignoring all their unrelated W1011, W1020, W2001 violations
find test -name "*limit*" | grep -v '.py' | grep -v 'events' | xargs cfn-lint -c I -t | grep -Eo '^\w\d+' | sort | uniq -c | sort -nr
1426 W1011
 936 W1020
   3 W2001
   3 E2012
   2 I7010
   2 I6010
   2 I2010
   2 E7010
   2 E6010
   2 E3010
   2 E2010
   1 I7012
   1 I6012
   1 I3010
   1 I1003
   1 I1002
   1 E7012
   1 E7011
   1 E6011
   1 E3011
   1 E2011
   1 E1003
   1 E1002

# same output when run with previous version and this version before the last casing commit
find test -name "*limit*" | grep -v '.py' | grep -v 'events' | xargs cfn-lint -i W1011 W1020 W2001 -c I -t

# testing informational level rules
gsed -i 's/AndNowItIs//' test/fixtures/templates/bad/limit_name.yaml
gsed -i 's/ Sed rhoncus eros eget purus accumsan cras amet.//' test/fixtures/templates/bad/limit_parameter_value.yaml
gsed -i 's/4097/4095/' test/fixtures/templates/bad/limit_parameter_value.yaml

# same output when run with previous version and this version before the last casing commit
find test -name "*limit*" | grep -v '.py' | grep -v 'events' | xargs cfn-lint -i W1011 W1020 W2001 -c I -t
```
