### PR TITLE
Fix superdomain logic for E3041

### DIFF
--- a/src/cfnlint/rules/resources/route53/RecordSetName.py
+++ b/src/cfnlint/rules/resources/route53/RecordSetName.py
@@ -44,7 +44,8 @@ class RecordSetName(CloudFormationLintRule):
                     hz_name = hz_name[:-1]
                 if name[-1] == '.':
                     name = name[:-1]
-                if not name.endswith('.' + hz_name):
+
+                if hz_name not in [name, name[-len(hz_name):]]:
                     message = 'Name must be a superdomain of HostedZoneName at {}'
                     if scenario is None:
                         matches.append(

--- a/test/fixtures/templates/good/resources/route53/recordset_name.yaml
+++ b/test/fixtures/templates/good/resources/route53/recordset_name.yaml
@@ -1,5 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Resources:
+  # Subdomain
+  # Mixed trailing dot notation
   RecordSet1:
     Type: AWS::Route53::RecordSet
     Properties:
@@ -9,11 +11,35 @@ Resources:
         - 192.0.2.99
       TTL: 900
       Type: A
+  # Subdomain
+  # Identical trailing dot notation
   RecordSet2:
     Type: AWS::Route53::RecordSet
     Properties:
       HostedZoneName: example.com.
       Name: rs2.example.com.
+      ResourceRecords:
+        - 192.0.2.99
+      TTL: 900
+      Type: A
+  # "Apex" record for Hosted Zone
+  # Mixed trailing dot notation
+  RecordSet3:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneName: example.com.
+      Name: example.com
+      ResourceRecords:
+        - 192.0.2.99
+      TTL: 900
+      Type: A
+  # "Apex" record for Hosted Zone
+  # Identical trailing dot notation
+  RecordSet4:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneName: example.com.
+      Name: example.com.
       ResourceRecords:
         - 192.0.2.99
       TTL: 900

--- a/test/unit/rules/resources/route53/test_recordset_name.py
+++ b/test/unit/rules/resources/route53/test_recordset_name.py
@@ -24,4 +24,4 @@ class TestRoute53RecordSetName(BaseRuleTestCase):
     def test_file_negative(self):
         """Test failure"""
         self.helper_file_negative(
-            'test/fixtures/templates/bad/resources/route53/recordset_name.yaml', 6)
+            'test/fixtures/templates/bad/resources/route53/recordset_name.yaml', 4)


### PR DESCRIPTION
### Issue #, if available
No issue filed. I identified the problem within a project I was working and decided to fix it myself.

### Description of changes
The current logic works something like this:

1. If the Hosted Zone name (`hz_name`) ends with a `.`, strip it
1. If the Name (`name`) ends with a `.`, strip it
1. `If not name.endswith('.' + hz_name):`, then a match/error is raised

This is incorrect because it prevents the ability for setting the top-level name (possibly an apex). This PR provides more reasonable functionality and most specifically targets the ability to set that top-level domain record for whatever the hosted zone is.

- - -

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.