### PR TITLE
AWS::ApplicationAutoScaling::ScalingPolicy.PredefinedMetricSpecification.PredefinedMetricType AllowedValues expansion

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_applicationautoscaling.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_applicationautoscaling.json
@@ -15,6 +15,9 @@
     "value": {
       "AllowedValues": [
         "ALBRequestCountPerTarget",
+        "ASGAverageCPUUtilization",
+        "ASGAverageNetworkIn",
+        "ASGAverageNetworkOut",
         "DynamoDBReadCapacityUtilization",
         "DynamoDBWriteCapacityUtilization",
         "EC2SpotFleetRequestAverageCPUUtilization",


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/issues/50

[`AWS::ApplicationAutoScaling::ScalingPolicy.PredefinedMetricSpecification.PredefinedMetricType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-autoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype)

reviewing all `AllowedValues` lists with 6 or more values and expanding ones that look like they might be missing values

---

wasn't sure why there were so many other AllowedValues not in the documentation, so I figured I'd leave them to be safe