### PR TITLE
AWS::EC2::CapacityReservation.InstancePlatform AllowedValues expansion

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -123,6 +123,9 @@
       },
       "EC2CapacityReservationInstancePlatform": {
         "AllowedValues": [
+          "Linux with SQL Server Enterprise",
+          "Linux with SQL Server Standard",
+          "Linux with SQL Server Web",
           "Linux/UNIX",
           "Red Hat Enterprise Linux",
           "SUSE Linux",


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/issues/50

[`AWS::EC2::CapacityReservation.InstancePlatform`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-capacityreservation.html#cfn-ec2-capacityreservation-instanceplatform)

reviewing all `AllowedValues` lists with 6 or more values and expanding ones that look like they might be missing values