### PR TITLE
AWS::S3::Bucket.TopicConfiguration.Event AllowedValues expansion

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -734,7 +734,11 @@
           "s3:ObjectRemoved:DeleteMarkerCreated",
           "s3:ObjectRestore:Completed",
           "s3:ObjectRestore:Post",
-          "s3:ReducedRedundancyLostObject"
+          "s3:ReducedRedundancyLostObject",
+          "s3:Replication:OperationFailedReplication",
+          "s3:Replication:OperationMissedThreshold",
+          "s3:Replication:OperationReplicatedAfterThreshold",
+          "s3:Replication:OperationNotTracked"
         ]
       },
       "S3BucketVersioningConfigurationStatus": {


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/issues/50

[`AWS::S3::Bucket.TopicConfiguration.Event`](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#notification-how-to-event-types-and-destinations)

reviewing all `AllowedValues` lists with 6 or more values and expanding ones that look like they might be missing values