### PR TITLE
correctly applying AWS::RDS::DBInstance MonitoringInterval and PerformanceInsightsRetentionPeriod AllowedValues

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -946,14 +946,14 @@
   },
   {
     "op": "add",
-    "path": "/ResourceTypes/AWS::RDS::Instance/Properties/MonitoringInterval/Value",
+    "path": "/ResourceTypes/AWS::RDS::DBInstance/Properties/MonitoringInterval/Value",
     "value": {
       "ValueType": "RdsInstanceMonitoringInterval"
     }
   },
   {
     "op": "add",
-    "path": "/ResourceTypes/AWS::RDS::Instance/Properties/PerformanceInsightsRetentionPeriod/Value",
+    "path": "/ResourceTypes/AWS::RDS::DBInstance/Properties/PerformanceInsightsRetentionPeriod/Value",
     "value": {
       "ValueType": "PerformanceInsightsRetentionPeriod"
     }


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/issues/50
https://github.com/aws-cloudformation/cfn-python-lint/pull/1585#issuecomment-643039030
[`AWS::RDS::DBInstance.MonitoringInterval`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-monitoringinterval)
[`AWS::RDS::DBInstance.PerformanceInsightsRetentionPeriod`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-performanceinsightsretentionperiod)