### PR TITLE
correctly applying AWS::ElasticLoadBalancingV2::ListenerRule.Priority Maximum and Minimum

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_elasticloadbalancingv2.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_elasticloadbalancingv2.json
@@ -30,7 +30,7 @@
   },
   {
     "op": "add",
-    "path": "/ResourceTypes/AWS::ElasticLoadBalancingV2::ListenerRule.Priority/Properties/Priority/Value",
+    "path": "/ResourceTypes/AWS::ElasticLoadBalancingV2::ListenerRule/Properties/Priority/Value",
     "value": {
       "ValueType": "AWS::ElasticLoadBalancingV2::ListenerRule.Priority"
     }


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/pull/1585#issuecomment-643039030
[`AWS::ElasticLoadBalancingV2::ListenerRule.Priority`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listenerrule.html#cfn-elasticloadbalancingv2-listenerrule-priority)