### PR TITLE
Update rule E3503 to not fail if ValidationDomain or DomainName aren't present

### DIFF
--- a/src/cfnlint/rules/resources/certificatemanager/DomainValidationOptions.py
+++ b/src/cfnlint/rules/resources/certificatemanager/DomainValidationOptions.py
@@ -29,8 +29,8 @@ class DomainValidationOptions(CloudFormationLintRule):
             for property_set in property_sets:
                 properties = property_set.get('Object')
                 scenario = property_set.get('Scenario')
-                domain_name = properties.get('DomainName', '')
-                validation_domain = properties.get('ValidationDomain', '')
+                domain_name = properties.get('DomainName', None)
+                validation_domain = properties.get('ValidationDomain', None)
                 if isinstance(domain_name, six.string_types) and isinstance(validation_domain, six.string_types):
                     if domain_name == validation_domain:
                         continue

--- a/test/fixtures/templates/bad/resources/certificatemanager/domain_validation_options.yaml
+++ b/test/fixtures/templates/bad/resources/certificatemanager/domain_validation_options.yaml
@@ -16,12 +16,3 @@ Resources:
       DomainValidationOptions:
         - DomainName: "prefixed-example.com"
           ValidationDomain: "example.com"
-  Certificate3:
-    Type: AWS::CertificateManager::Certificate
-    Properties:
-      DomainName: "*.aws.domain.com"
-      ValidationMethod: DNS
-      DomainValidationOptions:
-        # Don't fail when one of the values don't exist
-        - DomainName: aws.domain.com
-          HostedZoneId: !ImportValue SubdomainHostedZoneId

--- a/test/fixtures/templates/bad/resources/certificatemanager/domain_validation_options.yaml
+++ b/test/fixtures/templates/bad/resources/certificatemanager/domain_validation_options.yaml
@@ -16,3 +16,12 @@ Resources:
       DomainValidationOptions:
         - DomainName: "prefixed-example.com"
           ValidationDomain: "example.com"
+  Certificate3:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: "*.aws.domain.com"
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        # Don't fail when one of the values don't exist
+        - DomainName: aws.domain.com
+          HostedZoneId: !ImportValue SubdomainHostedZoneId

--- a/test/fixtures/templates/good/resources/certificatemanager/domain_validation_options.yaml
+++ b/test/fixtures/templates/good/resources/certificatemanager/domain_validation_options.yaml
@@ -14,3 +14,12 @@ Resources:
       DomainValidationOptions:
         - DomainName: "example.com"
           ValidationDomain: "example.com"
+  Certificate3:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: "*.aws.domain.com"
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        # Don't fail when one of the values don't exist
+        - DomainName: aws.domain.com
+          HostedZoneId: !ImportValue SubdomainHostedZoneId


### PR DESCRIPTION

*Issue #, if available:*
Fix #1619
*Description of changes:*
- Update rule E3503 to use None instead of `''` when getting ValidationDomain and DomainName. There are valid scenarios where ValidationDomain may not be present and comparing to an empty string isn't the correct way to handle it.  We should only be doing this rule when the values are actually present.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
