### PR TITLE
Resolving Issues with ${} Step Function State Machines and Definition Substitutions E1029

### DIFF
--- a/src/cfnlint/rules/functions/SubNeeded.py
+++ b/src/cfnlint/rules/functions/SubNeeded.py
@@ -2,7 +2,7 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
-from functools import reduce
+from functools import reduce  # pylint: disable=redefined-builtin
 import re
 import six
 from cfnlint.rules import CloudFormationLintRule

--- a/test/fixtures/templates/bad/functions/sub_needed.yaml
+++ b/test/fixtures/templates/bad/functions/sub_needed.yaml
@@ -31,3 +31,43 @@ Resources:
     Type: AWS::SNS::Topic
     Properties:
       TopicName: "${aws:username}-topic"
+
+  TestBadStateMachine1:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      DefinitionString:
+        Fn::Join:
+        - "\n"
+        - - "{"
+          - '    "StartAt": "Test",'
+          - '    "States": {'
+          - '        "Test": {'
+          - '            "End": true,'
+          - '            "Resource": "${definition_substitution_1}",'
+          - '            "ResultPath": "$.result",'
+          - '            "Type": "Task"'
+          - "        }"
+          - "    }"
+          - "}"
+      DefinitionSubstitutions:
+        definition_substitution_2: test
+      RoleArn: arn:aws:iam::123456789012:role/abc
+
+  TestBadStateMachine2:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      DefinitionString:
+        Fn::Join:
+        - "\n"
+        - - "{"
+          - '    "StartAt": "Test",'
+          - '    "States": {'
+          - '        "Test": {'
+          - '            "End": true,'
+          - '            "Resource": "${definition_substitution_1}",'
+          - '            "ResultPath": "$.result",'
+          - '            "Type": "Task"'
+          - "        }"
+          - "    }"
+          - "}"
+      RoleArn: arn:aws:iam::123456789012:role/abc

--- a/test/fixtures/templates/good/functions/sub_needed.yaml
+++ b/test/fixtures/templates/good/functions/sub_needed.yaml
@@ -134,3 +134,23 @@ Resources:
                   - !Ref AWS::Region
                   - !Ref AWS::AccountId
                   - thing/${iot:Connection.Thing.ThingName}*
+  TestGoodStateMachine1:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      DefinitionString:
+        Fn::Join:
+        - "\n"
+        - - "{"
+          - '    "StartAt": "Test",'
+          - '    "States": {'
+          - '        "Test": {'
+          - '            "End": true,'
+          - '            "Resource": "${definition_substitution_1}",'
+          - '            "ResultPath": "$.result",'
+          - '            "Type": "Task"'
+          - "        }"
+          - "    }"
+          - "}"
+      DefinitionSubstitutions:
+        definition_substitution_1: test
+      RoleArn: arn:aws:iam::123456789012:role/abc

--- a/test/unit/rules/functions/test_sub_needed.py
+++ b/test/unit/rules/functions/test_sub_needed.py
@@ -36,4 +36,4 @@ class TestSubNeeded(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/functions/sub_needed.yaml', 6)
+        self.helper_file_negative('test/fixtures/templates/bad/functions/sub_needed.yaml', 8)


### PR DESCRIPTION
Related to Issue
#1602 

State Machines allow for the usage of ${} in the DefinitionString property outside of !Sub due to the DefinitionSubstitutions parameter. The following Pull request  checks whether a potential E1029 inside the DefinitionString is faulty by checking the DefinitionSubsitutions parameter for a matching substitution


The following is an example of good state machine that was previously flagged as an error

```
  TestGoodStateMachine1:
    Type: AWS::StepFunctions::StateMachine
    Properties:
      DefinitionString:
        Fn::Join:
        - "\n"
        - - "{"
          - '    "StartAt": "Test",'
          - '    "States": {'
          - '        "Test": {'
          - '            "End": true,'
          - '            "Resource": "${definition_substitution_1}",'
          - '            "ResultPath": "$.result",'
          - '            "Type": "Task"'
          - "        }"
          - "    }"
          - "}"
      DefinitionSubstitutions:
        definition_substitution_1: test
      RoleArn: arn:aws:iam::123456789012:role/abc
```

These are Bad State Machines that will still be flagged as errors

```
  TestBadStateMachine1:
    Type: AWS::StepFunctions::StateMachine
    Properties:
      DefinitionString:
        Fn::Join:
        - "\n"
        - - "{"
          - '    "StartAt": "Test",'
          - '    "States": {'
          - '        "Test": {'
          - '            "End": true,'
          - '            "Resource": "${definition_substitution_1}",'
          - '            "ResultPath": "$.result",'
          - '            "Type": "Task"'
          - "        }"
          - "    }"
          - "}"
      DefinitionSubstitutions:
        definition_substitution_2: test
      RoleArn: arn:aws:iam::123456789012:role/abc

  TestBadStateMachine2:
    Type: AWS::StepFunctions::StateMachine
    Properties:
      DefinitionString:
        Fn::Join:
        - "\n"
        - - "{"
          - '    "StartAt": "Test",'
          - '    "States": {'
          - '        "Test": {'
          - '            "End": true,'
          - '            "Resource": "${definition_substitution_1}",'
          - '            "ResultPath": "$.result",'
          - '            "Type": "Task"'
          - "        }"
          - "    }"
          - "}"
      RoleArn: arn:aws:iam::123456789012:role/abc
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
