### PR TITLE
AWS::Budgets::Budget.BudgetType AllowedValues expansion

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_budget.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_budget.json
@@ -7,6 +7,8 @@
         "COST",
         "RI_COVERAGE",
         "RI_UTILIZATION",
+        "SAVINGS_PLANS_COVERAGE",
+        "SAVINGS_PLANS_UTILIZATION",
         "USAGE"
       ]
     }


### PR DESCRIPTION
[`AWS::Budgets::Budget.BudgetType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-budgets-budget-budgetdata.html#cfn-budgets-budget-budgetdata-budgettype)

fixes https://github.com/aws-cloudformation/cfn-python-lint/issues/1642