### PR TITLE
excluding AWS::EC2::FlowLog.LogFormat from Sub required rule (E1029)

### DIFF
--- a/src/cfnlint/rules/functions/SubNeeded.py
+++ b/src/cfnlint/rules/functions/SubNeeded.py
@@ -18,11 +18,9 @@ class SubNeeded(CloudFormationLintRule):
     tags = ['functions', 'sub']
 
     # Free-form text properties to exclude from this rule
-    # content is part of AWS::CloudFormation::Init
-    # RequestMappingTemplate is because of issue #1485
     excludes = ['UserData', 'ZipFile', 'Condition', 'AWS::CloudFormation::Init',
                 'CloudWatchAlarmDefinition', 'TopicRulePayload', 'BuildSpec',
-                'RequestMappingTemplate']
+                'RequestMappingTemplate', 'LogFormat']
     api_excludes = ['Uri', 'Body', 'ConnectionId']
 
 


### PR DESCRIPTION
fixes https://github.com/aws-cloudformation/cfn-python-lint/issues/1644
[`AWS::EC2::FlowLog.LogFormat`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-flowlog.html#cfn-ec2-flowlog-logformat)

Lot of issues/churn for `E1029`, wonder if we need to re-think it at all?
https://github.com/aws-cloudformation/cfn-python-lint/issues?q=E1029
https://github.com/aws-cloudformation/cfn-python-lint/commits/master/src/cfnlint/rules/functions/SubNeeded.py