### PR TITLE
Add provided.al2 to the list of Lambda runtimes

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -392,6 +392,7 @@
           "nodejs10.x",
           "nodejs12.x",
           "provided",
+          "provided.al2",
           "python2.7",
           "python3.6",
           "python3.7",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This adds the new __provided.al2__ runtime to the list of valid Lambda runtimes. See https://aws.amazon.com/about-aws/whats-new/2020/08/aws-lambda-supports-custom-runtimes-amazon-linux-2/ for the announcement.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
