### PR TITLE
AWS::Lambda::Function.Runtime AllowedValues expansion

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -383,6 +383,7 @@
           "dotnetcore3.1",
           "go1.x",
           "java8",
+          "java8.al2",
           "java11",
           "nodejs",
           "nodejs4.3-edge",


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/pull/1649
[`AWS::Lambda::Function.Runtime`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime)
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-to-al2/