### PR TITLE
fixing AWS::ApplicationAutoScaling::ScalingPolicy.PredefinedMetricSpecification.PredefinedMetricType AllowedValues

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_applicationautoscaling.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_applicationautoscaling.json
@@ -15,9 +15,10 @@
     "value": {
       "AllowedValues": [
         "ALBRequestCountPerTarget",
-        "ASGAverageCPUUtilization",
-        "ASGAverageNetworkIn",
-        "ASGAverageNetworkOut",
+        "AppStreamAverageCapacityUtilization",
+        "CassandraReadCapacityUtilization",
+        "CassandraWriteCapacityUtilization",
+        "ComprehendInferenceUtilization",
         "DynamoDBReadCapacityUtilization",
         "DynamoDBWriteCapacityUtilization",
         "EC2SpotFleetRequestAverageCPUUtilization",


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/issues/50
https://github.com/aws-cloudformation/cfn-python-lint/pull/1604#issuecomment-673727491
[`AWS::ApplicationAutoScaling::ScalingPolicy.PredefinedMetricSpecification.PredefinedMetricType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-applicationautoscaling-scalingpolicy-predefinedmetricspecification.html#cfn-applicationautoscaling-scalingpolicy-predefinedmetricspecification-predefinedmetrictype)
https://github.com/boto/botocore/blob/5cc303bf71ea352c71f62254312245f92e82211d/botocore/data/application-autoscaling/2016-02-06/service-2.json#L587