### PR TITLE
removing invalid duplicate AWS::EC2::LaunchTemplate.BlockDeviceMapping.Ebs.VolumeType patch

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json
@@ -64,13 +64,6 @@
   },
   {
     "op": "add",
-    "path": "/PropertyTypes/AWS::EC2::LaunchTemplate.BlockDeviceMapping/Properties/VolumeType/Value",
-    "value": {
-      "ValueType": "EbsVolumeType"
-    }
-  },
-  {
-    "op": "add",
     "path": "/PropertyTypes/AWS::EC2::LaunchTemplate.CreditSpecification/Properties/CpuCredits/Value",
     "value": {
       "ValueType": "Ec2CpuCredits"


### PR DESCRIPTION
[`AWS::EC2::LaunchTemplate BlockDeviceMapping`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-blockdevicemapping.html)
[`AWS::EC2::LaunchTemplate Ebs`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-blockdevicemapping-ebs.html)
https://github.com/aws-cloudformation/cfn-python-lint/pull/1585#issuecomment-643039030

should be properly covered here:

https://github.com/aws-cloudformation/cfn-python-lint/blob/399731d830f1e0370ab8abd6612bf62e4de8a2b5/src/cfnlint/data/ExtendedSpecs/all/04_property_values.json#L79-L85