### PR TITLE
AWS::ElasticLoadBalancingV2::LoadBalancer.LoadBalancerAttribute routing.http.desync_mitigation_mode

### DIFF
--- a/src/cfnlint/rules/resources/elb/Elb.py
+++ b/src/cfnlint/rules/resources/elb/Elb.py
@@ -89,6 +89,7 @@ HTTPS has certificate HTTP has no certificate'
             ],
             'application': [
                 'idle_timeout.timeout_seconds',
+                'routing.http.desync_mitigation_mode',
                 'routing.http.drop_invalid_header_fields.enabled',
                 'routing.http2.enabled'
             ],


### PR DESCRIPTION
similar to https://github.com/aws-cloudformation/cfn-python-lint/pull/1220

[`AWS::ElasticLoadBalancingV2::LoadBalancer.LoadBalancerAttribute`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-loadbalancer-loadbalancerattributes.html#cfn-elasticloadbalancingv2-loadbalancer-loadbalancerattributes-key)