### PR TITLE
AWS::Config::ConfigurationRecorder.ResourceTypes AllowedValues expansion

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_config.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_config.json
@@ -79,6 +79,7 @@
         "AWS::ShieldRegional::Protection",
         "AWS::SNS::Topic",
         "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
         "AWS::SSM::ManagedInstanceInventory",
         "AWS::SSM::PatchCompliance",
         "AWS::SQS::Queue",


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/issues/50
[added to `botocore` on July 23](https://github.com/boto/botocore/blame/master/botocore/data/config/2014-11-12/service-2.json#L6077)
[Config Resource Types](https://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html#supported-resources)
[`AWS::Config::ConfigurationRecorder.ResourceTypes`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-config-configurationrecorder-recordinggroup.html#cfn-config-configurationrecorder-recordinggroup-resourcetypes)