### PR TITLE
Update excludes for E1029

### DIFF
--- a/src/cfnlint/rules/functions/SubNeeded.py
+++ b/src/cfnlint/rules/functions/SubNeeded.py
@@ -20,7 +20,7 @@ class SubNeeded(CloudFormationLintRule):
     # Free-form text properties to exclude from this rule
     excludes = ['UserData', 'ZipFile', 'Condition', 'AWS::CloudFormation::Init',
                 'CloudWatchAlarmDefinition', 'TopicRulePayload', 'BuildSpec',
-                'RequestMappingTemplate', 'LogFormat', 'TemplateBody']
+                'RequestMappingTemplate', 'LogFormat', 'TemplateBody', 'ResponseMappingTemplate']
     api_excludes = ['Uri', 'Body', 'ConnectionId']
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

AppSync supports using variables in `RequestMappingTemplate` and `ResponseMappingTemplate`. These variables trigger a cfn-lint warning

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
