### PR TITLE
AWS::Glue::Connection.ConnectionInput.ConnectionType AllowedValues expansion

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
@@ -5,6 +5,8 @@
     "value": {
       "AllowedValues": [
         "JDBC",
+        "KAFKA",
+        "MONGODB",
         "SFTP"
       ]
     }


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/issues/50

https://github.com/cloudtools/troposphere/issues/1776

[`AWS::Glue::Connection.ConnectionInput.ConnectionType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype)