### PR TITLE
disable codecov comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+comment: false
 coverage:
   status:
     project:


### PR DESCRIPTION
https://docs.codecov.io/docs/pull-request-comments#disable-comment

just gets rid of the massive comment and still leaves the check itself along with the link to more information