### PR TITLE
AWS::Glue::Trigger.Condition.State AllowedValues expansion

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
@@ -66,7 +66,10 @@
     "path": "/ValueTypes/AWS::Glue::Trigger.Condition.State",
     "value": {
       "AllowedValues": [
-        "SUCCEEDED"
+        "SUCCEEDED",
+        "STOPPED",
+        "TIMEOUT",
+        "FAILED"
       ]
     }
   },


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/issues/50

[`AWS::Glue::Trigger.Condition.State`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-trigger-condition.html#cfn-glue-trigger-condition-state)