### PR TITLE
AllowedValues from botocore during --update-specs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ that could potentially be improved'),
         'networkx<=2.2;python_version<"3.5"',
         'junit-xml~=1.9',
         'pyrsistent<=0.16.0;python_version<"3.5"',
+        'requests'
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ that could potentially be improved'),
         'networkx<=2.2;python_version<"3.5"',
         'junit-xml~=1.9',
         'pyrsistent<=0.16.0;python_version<"3.5"',
-        'requests'
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     entry_points={

--- a/src/cfnlint/data/CloudSpecs/af-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/af-south-1.json
@@ -25408,6 +25408,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -25513,6 +25514,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -25529,7 +25531,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -25998,6 +26001,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -26069,7 +26073,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -26380,6 +26387,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -26390,8 +26398,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -26646,6 +26656,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -27006,8 +27017,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -27352,9 +27405,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/af-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/af-south-1.json
@@ -24804,17 +24804,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -24891,10 +24891,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -24925,8 +24925,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -24956,8 +24956,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -24969,12 +24969,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -24982,8 +24982,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -25354,10 +25354,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -25370,9 +25370,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -25443,11 +25443,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -25593,8 +25593,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -25668,13 +25668,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -25738,7 +25738,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -25746,6 +25745,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -25761,13 +25761,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -25796,18 +25796,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -26537,11 +26537,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -26570,10 +26570,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -26967,16 +26967,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -27280,10 +27280,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -27357,8 +27357,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -27380,8 +27380,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -41252,6 +41252,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -41357,6 +41358,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -41373,7 +41375,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -41842,6 +41845,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -41913,7 +41917,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -42224,6 +42231,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -42234,8 +42242,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -42505,6 +42515,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -42888,8 +42899,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -43245,9 +43298,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -40648,17 +40648,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -40735,10 +40735,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -40769,8 +40769,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -40800,8 +40800,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -40813,12 +40813,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -40826,8 +40826,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -41198,10 +41198,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -41214,9 +41214,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -41287,11 +41287,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -41437,8 +41437,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -41512,13 +41512,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -41582,7 +41582,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -41590,6 +41589,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -41605,13 +41605,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -41640,18 +41640,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -42381,11 +42381,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -42414,10 +42414,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -42849,16 +42849,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -43173,10 +43173,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -43250,8 +43250,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -43273,8 +43273,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -65965,17 +65965,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -66052,10 +66052,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -66086,8 +66086,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -66117,8 +66117,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -66130,12 +66130,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -66143,8 +66143,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -66515,10 +66515,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -66531,9 +66531,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -66604,11 +66604,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -66754,8 +66754,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -66829,13 +66829,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -66899,7 +66899,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -66907,6 +66906,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -66922,13 +66922,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -66957,18 +66957,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -67780,11 +67780,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -67813,10 +67813,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -68665,16 +68665,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -69061,10 +69061,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -69138,8 +69138,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -69161,8 +69161,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -66569,6 +66569,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -66674,6 +66675,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -66690,7 +66692,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -67159,6 +67162,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -67230,7 +67234,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -67541,6 +67548,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -67551,8 +67559,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -67992,6 +68002,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -68704,8 +68715,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -69133,9 +69186,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -63628,6 +63628,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -63733,6 +63734,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -63749,7 +63751,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -64218,6 +64221,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -64289,7 +64293,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -64600,6 +64607,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -64610,8 +64618,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -65000,6 +65010,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -65591,8 +65602,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -65992,9 +66045,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -63024,17 +63024,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -63111,10 +63111,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -63145,8 +63145,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -63176,8 +63176,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -63189,12 +63189,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -63202,8 +63202,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -63574,10 +63574,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -63590,9 +63590,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -63663,11 +63663,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -63813,8 +63813,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -63888,13 +63888,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -63958,7 +63958,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -63966,6 +63965,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -63981,13 +63981,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -64016,18 +64016,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -64808,11 +64808,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -64841,10 +64841,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -65552,16 +65552,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -65920,10 +65920,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -65997,8 +65997,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -66020,8 +66020,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -16835,17 +16835,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -16922,10 +16922,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -16956,8 +16956,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -16987,8 +16987,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -17000,12 +17000,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -17013,8 +17013,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -17385,10 +17385,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -17401,9 +17401,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -17474,11 +17474,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -17624,8 +17624,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -17699,13 +17699,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -17769,7 +17769,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -17777,6 +17776,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -17792,13 +17792,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -17827,18 +17827,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -18568,11 +18568,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -18601,10 +18601,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -19016,16 +19016,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -19347,10 +19347,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -19424,8 +19424,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -19447,8 +19447,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -17439,6 +17439,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -17544,6 +17545,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -17560,7 +17562,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -18029,6 +18032,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -18100,7 +18104,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -18411,6 +18418,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -18421,8 +18429,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -18697,6 +18707,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -19055,8 +19066,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -19419,9 +19472,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -63441,6 +63441,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -63546,6 +63547,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -63562,7 +63564,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -64031,6 +64034,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -64102,7 +64106,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -64413,6 +64420,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -64423,8 +64431,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -64810,6 +64820,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -65420,8 +65431,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -65829,9 +65882,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -62837,17 +62837,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -62924,10 +62924,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -62958,8 +62958,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -62989,8 +62989,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -63002,12 +63002,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -63015,8 +63015,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -63387,10 +63387,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -63403,9 +63403,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -63476,11 +63476,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -63626,8 +63626,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -63701,13 +63701,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -63771,7 +63771,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -63779,6 +63778,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -63794,13 +63794,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -63829,18 +63829,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -64630,11 +64630,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -64663,10 +64663,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -65381,16 +65381,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -65757,10 +65757,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -65834,8 +65834,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -65857,8 +65857,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -62696,17 +62696,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -62783,10 +62783,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -62817,8 +62817,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -62848,8 +62848,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -62861,12 +62861,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -62874,8 +62874,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -63246,10 +63246,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -63262,9 +63262,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -63335,11 +63335,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -63485,8 +63485,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -63560,13 +63560,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -63630,7 +63630,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -63638,6 +63637,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -63653,13 +63653,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -63688,18 +63688,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -64510,11 +64510,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -64543,10 +64543,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -65387,16 +65387,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -65783,10 +65783,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -65860,8 +65860,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -65883,8 +65883,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -63300,6 +63300,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -63405,6 +63406,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -63421,7 +63423,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -63890,6 +63893,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -63961,7 +63965,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -64272,6 +64279,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -64282,8 +64290,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -64722,6 +64732,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -65426,8 +65437,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -65855,9 +65908,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -66627,6 +66627,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -66732,6 +66733,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -66748,7 +66750,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -67217,6 +67220,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -67288,7 +67292,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -67599,6 +67606,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -67609,8 +67617,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -68035,6 +68045,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -68712,8 +68723,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -69141,9 +69194,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -66023,17 +66023,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -66110,10 +66110,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -66144,8 +66144,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -66175,8 +66175,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -66188,12 +66188,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -66201,8 +66201,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -66573,10 +66573,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -66589,9 +66589,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -66662,11 +66662,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -66812,8 +66812,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -66887,13 +66887,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -66957,7 +66957,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -66965,6 +66964,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -66980,13 +66980,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -67015,18 +67015,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -67822,11 +67822,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -67855,10 +67855,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -68673,16 +68673,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -69069,10 +69069,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -69146,8 +69146,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -69169,8 +69169,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -55109,6 +55109,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -55214,6 +55215,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -55230,7 +55232,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -55699,6 +55702,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -55770,7 +55774,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -56081,6 +56088,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -56091,8 +56099,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -56411,6 +56421,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -56951,8 +56962,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -57335,9 +57388,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -54505,17 +54505,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -54592,10 +54592,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -54626,8 +54626,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -54657,8 +54657,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -54670,12 +54670,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -54683,8 +54683,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -55055,10 +55055,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -55071,9 +55071,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -55144,11 +55144,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -55294,8 +55294,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -55369,13 +55369,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -55439,7 +55439,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -55447,6 +55446,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -55462,13 +55462,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -55497,18 +55497,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -56247,11 +56247,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -56280,10 +56280,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -56912,16 +56912,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -57263,10 +57263,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -57340,8 +57340,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -57363,8 +57363,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/cn-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-north-1.json
@@ -37982,6 +37982,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -38087,6 +38088,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -38103,7 +38105,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -38572,6 +38575,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -38643,7 +38647,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -38954,6 +38961,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -38964,8 +38972,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -39179,6 +39189,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -39608,8 +39619,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -39979,9 +40032,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/cn-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-north-1.json
@@ -37378,17 +37378,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -37465,10 +37465,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -37499,8 +37499,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -37530,8 +37530,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -37543,12 +37543,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -37556,8 +37556,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -37928,10 +37928,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -37944,9 +37944,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -38017,11 +38017,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -38167,8 +38167,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -38242,13 +38242,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -38312,7 +38312,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -38320,6 +38319,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -38335,13 +38335,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -38370,18 +38370,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -39118,11 +39118,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -39151,10 +39151,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -39569,16 +39569,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -39907,10 +39907,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -39984,8 +39984,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -40007,8 +40007,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
@@ -33029,17 +33029,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -33116,10 +33116,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -33150,8 +33150,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -33181,8 +33181,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -33194,12 +33194,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -33207,8 +33207,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -33579,10 +33579,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -33595,9 +33595,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -33668,11 +33668,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -33818,8 +33818,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -33893,13 +33893,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -33963,7 +33963,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -33971,6 +33970,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -33986,13 +33986,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -34021,18 +34021,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -34780,11 +34780,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -34813,10 +34813,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -35219,16 +35219,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -35552,10 +35552,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -35629,8 +35629,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -35652,8 +35652,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
@@ -33633,6 +33633,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -33738,6 +33739,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -33754,7 +33756,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -34223,6 +34226,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -34294,7 +34298,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -34605,6 +34612,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -34615,8 +34623,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -34841,6 +34851,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -35258,8 +35269,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -35624,9 +35677,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -66665,6 +66665,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -66770,6 +66771,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -66786,7 +66788,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -67255,6 +67258,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -67326,7 +67330,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -67637,6 +67644,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -67647,8 +67655,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -68050,6 +68060,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -68747,8 +68758,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -69168,9 +69221,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -66061,17 +66061,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -66148,10 +66148,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -66182,8 +66182,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -66213,8 +66213,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -66226,12 +66226,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -66239,8 +66239,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -66611,10 +66611,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -66627,9 +66627,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -66700,11 +66700,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -66850,8 +66850,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -66925,13 +66925,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -66995,7 +66995,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -67003,6 +67002,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -67018,13 +67018,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -67053,18 +67053,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -67855,11 +67855,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -67888,10 +67888,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -68708,16 +68708,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -69096,10 +69096,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -69173,8 +69173,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -69196,8 +69196,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -44655,17 +44655,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -44742,10 +44742,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -44776,8 +44776,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -44807,8 +44807,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -44820,12 +44820,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -44833,8 +44833,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -45205,10 +45205,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -45221,9 +45221,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -45294,11 +45294,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -45444,8 +45444,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -45519,13 +45519,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -45589,7 +45589,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -45597,6 +45596,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -45612,13 +45612,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -45647,18 +45647,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -46388,11 +46388,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -46421,10 +46421,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -46855,16 +46855,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -47181,10 +47181,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -47258,8 +47258,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -47281,8 +47281,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -45259,6 +45259,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -45364,6 +45365,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -45380,7 +45382,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -45849,6 +45852,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -45920,7 +45924,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -46231,6 +46238,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -46241,8 +46249,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -46511,6 +46521,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -46894,8 +46905,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -47253,9 +47306,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/eu-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-south-1.json
@@ -30345,6 +30345,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -30450,6 +30451,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -30466,7 +30468,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -30935,6 +30938,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -31006,7 +31010,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -31317,6 +31324,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -31327,8 +31335,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -31587,6 +31597,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -31947,8 +31958,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -32307,9 +32360,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/eu-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-south-1.json
@@ -29741,17 +29741,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -29828,10 +29828,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -29862,8 +29862,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -29893,8 +29893,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -29906,12 +29906,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -29919,8 +29919,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -30291,10 +30291,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -30307,9 +30307,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -30380,11 +30380,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -30530,8 +30530,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -30605,13 +30605,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -30675,7 +30675,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -30683,6 +30682,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -30698,13 +30698,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -30733,18 +30733,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -31474,11 +31474,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -31507,10 +31507,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -31908,16 +31908,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -32235,10 +32235,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -32312,8 +32312,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -32335,8 +32335,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -70184,6 +70184,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -70289,6 +70290,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -70305,7 +70307,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -70774,6 +70777,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -70845,7 +70849,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -71156,6 +71163,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -71166,8 +71174,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -71618,6 +71628,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -72374,8 +72385,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -72803,9 +72856,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/eu-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-1.json
@@ -69580,17 +69580,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -69667,10 +69667,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -69701,8 +69701,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -69732,8 +69732,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -69745,12 +69745,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -69758,8 +69758,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -70130,10 +70130,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -70146,9 +70146,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -70219,11 +70219,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -70369,8 +70369,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -70444,13 +70444,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -70514,7 +70514,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -70522,6 +70521,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -70537,13 +70537,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -70572,18 +70572,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -71401,11 +71401,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -71434,10 +71434,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -72335,16 +72335,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -72731,10 +72731,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -72808,8 +72808,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -72831,8 +72831,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -58383,6 +58383,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -58488,6 +58489,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -58504,7 +58506,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -58973,6 +58976,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -59044,7 +59048,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -59355,6 +59362,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -59365,8 +59373,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -59721,6 +59731,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -60263,8 +60274,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -60658,9 +60711,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -57779,17 +57779,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -57866,10 +57866,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -57900,8 +57900,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -57931,8 +57931,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -57944,12 +57944,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -57957,8 +57957,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -58329,10 +58329,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -58345,9 +58345,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -58418,11 +58418,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -58568,8 +58568,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -58643,13 +58643,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -58713,7 +58713,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -58721,6 +58720,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -58736,13 +58736,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -58771,18 +58771,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -59554,11 +59554,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -59587,10 +59587,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -60224,16 +60224,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -60586,10 +60586,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -60663,8 +60663,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -60686,8 +60686,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -49418,6 +49418,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -49523,6 +49524,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -49539,7 +49541,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -50008,6 +50011,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -50079,7 +50083,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -50390,6 +50397,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -50400,8 +50408,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -50714,6 +50724,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -51161,8 +51172,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -51532,9 +51585,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -48814,17 +48814,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -48901,10 +48901,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -48935,8 +48935,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -48966,8 +48966,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -48979,12 +48979,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -48992,8 +48992,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -49364,10 +49364,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -49380,9 +49380,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -49453,11 +49453,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -49603,8 +49603,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -49678,13 +49678,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -49748,7 +49748,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -49756,6 +49755,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -49771,13 +49771,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -49806,18 +49806,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -50574,11 +50574,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -50607,10 +50607,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -51122,16 +51122,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -51460,10 +51460,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -51537,8 +51537,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -51560,8 +51560,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/me-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/me-south-1.json
@@ -39439,17 +39439,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -39526,10 +39526,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -39560,8 +39560,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -39591,8 +39591,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -39604,12 +39604,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -39617,8 +39617,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -39989,10 +39989,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -40005,9 +40005,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -40078,11 +40078,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -40228,8 +40228,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -40303,13 +40303,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -40373,7 +40373,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -40381,6 +40380,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -40396,13 +40396,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -40431,18 +40431,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -41172,11 +41172,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -41205,10 +41205,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -41616,16 +41616,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -41938,10 +41938,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -42015,8 +42015,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -42038,8 +42038,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/me-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/me-south-1.json
@@ -40043,6 +40043,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -40148,6 +40149,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -40164,7 +40166,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -40633,6 +40636,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -40704,7 +40708,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -41015,6 +41022,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -41025,8 +41033,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -41295,6 +41305,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -41655,8 +41666,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -42010,9 +42063,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -53196,17 +53196,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -53283,10 +53283,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -53317,8 +53317,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -53348,8 +53348,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -53361,12 +53361,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -53374,8 +53374,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -53746,10 +53746,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -53762,9 +53762,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -53835,11 +53835,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -53985,8 +53985,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -54060,13 +54060,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -54130,7 +54130,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -54138,6 +54137,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -54153,13 +54153,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -54188,18 +54188,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -54952,11 +54952,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -54985,10 +54985,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -55670,16 +55670,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -56030,10 +56030,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -56107,8 +56107,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -56130,8 +56130,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -53800,6 +53800,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -53905,6 +53906,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -53921,7 +53923,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -54390,6 +54393,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -54461,7 +54465,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -54772,6 +54779,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -54782,8 +54790,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -55135,6 +55145,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -55709,8 +55720,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -56102,9 +56155,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -70619,6 +70619,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -70724,6 +70725,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -70740,7 +70742,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -71209,6 +71212,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -71280,7 +71284,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -71591,6 +71598,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -71601,8 +71609,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -72058,6 +72068,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -72814,8 +72825,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -73264,9 +73317,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -70015,17 +70015,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -70102,10 +70102,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -70136,8 +70136,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -70167,8 +70167,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -70180,12 +70180,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -70193,8 +70193,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -70565,10 +70565,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -70581,9 +70581,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -70654,11 +70654,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -70804,8 +70804,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -70879,13 +70879,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -70949,7 +70949,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -70957,6 +70956,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -70972,13 +70972,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -71007,18 +71007,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -71836,11 +71836,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -71869,10 +71869,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -72775,16 +72775,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -73192,10 +73192,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -73269,8 +73269,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -73292,8 +73292,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -61906,6 +61906,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -62011,6 +62012,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -62027,7 +62029,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -62496,6 +62499,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -62567,7 +62571,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -62878,6 +62885,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -62888,8 +62896,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -63261,6 +63271,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -63942,8 +63953,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -64357,9 +64410,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -61302,17 +61302,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -61389,10 +61389,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -61423,8 +61423,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -61454,8 +61454,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -61467,12 +61467,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -61480,8 +61480,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -61852,10 +61852,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -61868,9 +61868,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -61941,11 +61941,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -62091,8 +62091,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -62166,13 +62166,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -62236,7 +62236,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -62244,6 +62243,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -62259,13 +62259,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -62294,18 +62294,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -63068,11 +63068,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -63101,10 +63101,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -63903,16 +63903,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -64285,10 +64285,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -64362,8 +64362,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -64385,8 +64385,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -33341,17 +33341,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -33428,10 +33428,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -33462,8 +33462,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -33493,8 +33493,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -33506,12 +33506,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -33519,8 +33519,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -33891,10 +33891,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -33907,9 +33907,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -33980,11 +33980,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -34130,8 +34130,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -34205,13 +34205,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -34275,7 +34275,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -34283,6 +34282,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -34298,13 +34298,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -34333,18 +34333,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -35074,11 +35074,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -35107,10 +35107,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -35580,16 +35580,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -35922,10 +35922,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -35999,8 +35999,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -36022,8 +36022,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -33945,6 +33945,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -34050,6 +34051,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -34066,7 +34068,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -34535,6 +34538,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -34606,7 +34610,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -34917,6 +34924,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -34927,8 +34935,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -35190,6 +35200,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -35619,8 +35630,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -35994,9 +36047,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -41311,17 +41311,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -41398,10 +41398,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -41432,8 +41432,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -41463,8 +41463,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -41476,12 +41476,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -41489,8 +41489,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -41861,10 +41861,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -41877,9 +41877,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -41950,11 +41950,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -42100,8 +42100,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -42175,13 +42175,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -42245,7 +42245,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -42253,6 +42252,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -42268,13 +42268,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -42303,18 +42303,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -43077,11 +43077,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -43110,10 +43110,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -43832,16 +43832,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -44206,10 +44206,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -44283,8 +44283,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -44306,8 +44306,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -41915,6 +41915,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -42020,6 +42021,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -42036,7 +42038,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -42505,6 +42508,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -42576,7 +42580,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -42887,6 +42894,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -42897,8 +42905,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -43293,6 +43303,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -43871,8 +43882,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -44278,9 +44331,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -52030,6 +52030,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -52135,6 +52136,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -52151,7 +52153,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -52620,6 +52623,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -52691,7 +52695,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -53002,6 +53009,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -53012,8 +53020,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -53387,6 +53397,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -54025,8 +54036,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -54427,9 +54480,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -51426,17 +51426,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -51513,10 +51513,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -51547,8 +51547,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -51578,8 +51578,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -51591,12 +51591,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -51604,8 +51604,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -51976,10 +51976,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -51992,9 +51992,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -52065,11 +52065,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -52215,8 +52215,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -52290,13 +52290,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -52360,7 +52360,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -52368,6 +52367,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -52383,13 +52383,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -52418,18 +52418,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -53182,11 +53182,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -53215,10 +53215,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -53986,16 +53986,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -54355,10 +54355,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -54432,8 +54432,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -54455,8 +54455,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -70591,6 +70591,7 @@
     "AWS::CloudFront::Distribution.SslSupportMethod": {
       "AllowedValues": [
         "sni-only",
+        "static-ip",
         "vip"
       ]
     },
@@ -70696,6 +70697,7 @@
     },
     "AWS::CodeBuild::Project.Environment.ComputeType": {
       "AllowedValues": [
+        "BUILD_GENERAL1_2XLARGE",
         "BUILD_GENERAL1_LARGE",
         "BUILD_GENERAL1_MEDIUM",
         "BUILD_GENERAL1_SMALL"
@@ -70712,7 +70714,8 @@
         "ARM_CONTAINER",
         "LINUX_CONTAINER",
         "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
+        "WINDOWS_CONTAINER",
+        "WINDOWS_SERVER_2019_CONTAINER"
       ]
     },
     "AWS::CodeBuild::Project.ProjectCache.Type": {
@@ -71181,6 +71184,7 @@
         "JDBC",
         "KAFKA",
         "MONGODB",
+        "NETWORK",
         "SFTP"
       ]
     },
@@ -71252,7 +71256,10 @@
     },
     "AWS::GuardDuty::IPSet.Format": {
       "AllowedValues": [
+        "ALIEN_VAULT",
+        "FIRE_EYE",
         "OTX_CSV",
+        "PROOF_POINT",
         "STIX",
         "TXT"
       ]
@@ -71563,6 +71570,7 @@
     },
     "AWS::WAFv2::RuleGroup.Rate.AggregateKeyType": {
       "AllowedValues": [
+        "FORWARDED_IP",
         "IP"
       ]
     },
@@ -71573,8 +71581,10 @@
     "AWS::WorkSpaces::Workspace.ComputeTypeName": {
       "AllowedValues": [
         "GRAPHICS",
+        "GRAPHICSPRO",
         "PERFORMANCE",
         "POWER",
+        "POWERPRO",
         "STANDARD",
         "VALUE"
       ]
@@ -72013,6 +72023,7 @@
       "AllowedValues": [
         "gp2",
         "io1",
+        "io2",
         "sc1",
         "st1",
         "standard"
@@ -72768,8 +72779,50 @@
     },
     "LaunchTemplateTagSpecificationResourceType": {
       "AllowedValues": [
+        "client-vpn-endpoint",
+        "customer-gateway",
+        "dedicated-host",
+        "dhcp-options",
+        "egress-only-internet-gateway",
+        "elastic-gpu",
+        "elastic-ip",
+        "export-image-task",
+        "export-instance-task",
+        "fleet",
+        "fpga-image",
+        "host-reservation",
+        "image",
+        "import-image-task",
+        "import-snapshot-task",
         "instance",
-        "volume"
+        "internet-gateway",
+        "key-pair",
+        "launch-template",
+        "local-gateway-route-table-vpc-association",
+        "natgateway",
+        "network-acl",
+        "network-interface",
+        "placement-group",
+        "reserved-instances",
+        "route-table",
+        "security-group",
+        "snapshot",
+        "spot-fleet-request",
+        "spot-instances-request",
+        "subnet",
+        "traffic-mirror-filter",
+        "traffic-mirror-session",
+        "traffic-mirror-target",
+        "transit-gateway",
+        "transit-gateway-attachment",
+        "transit-gateway-multicast-domain",
+        "transit-gateway-route-table",
+        "volume",
+        "vpc",
+        "vpc-flow-log",
+        "vpc-peering-connection",
+        "vpn-connection",
+        "vpn-gateway"
       ]
     },
     "LoadBalancerName": {
@@ -73197,9 +73250,11 @@
         "s3:ObjectRemoved:*",
         "s3:ObjectRemoved:Delete",
         "s3:ObjectRemoved:DeleteMarkerCreated",
+        "s3:ObjectRestore:*",
         "s3:ObjectRestore:Completed",
         "s3:ObjectRestore:Post",
         "s3:ReducedRedundancyLostObject",
+        "s3:Replication:*",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
         "s3:Replication:OperationNotTracked",

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -69987,17 +69987,17 @@
       "AllowedValues": [
         "ACCESS_DENIED",
         "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
         "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
+        "AUTHORIZER_FAILURE",
         "BAD_REQUEST_BODY",
+        "BAD_REQUEST_PARAMETERS",
         "DEFAULT_4XX",
         "DEFAULT_5XX",
         "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
         "INTEGRATION_FAILURE",
         "INTEGRATION_TIMEOUT",
         "INVALID_API_KEY",
+        "INVALID_SIGNATURE",
         "MISSING_AUTHENTICATION_TOKEN",
         "QUOTA_EXCEEDED",
         "REQUEST_TOO_LARGE",
@@ -70074,10 +70074,10 @@
         "EC2SpotFleetRequestAverageNetworkOut",
         "ECSServiceAverageCPUUtilization",
         "ECSServiceAverageMemoryUtilization",
+        "LambdaProvisionedConcurrencyUtilization",
         "RDSReaderAverageCPUUtilization",
         "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
+        "SageMakerVariantInvocationsPerInstance"
       ]
     },
     "AWS::AutoScaling::AutoScalingGroup.HealthCheckType": {
@@ -70108,8 +70108,8 @@
     "AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic": {
       "AllowedValues": [
         "Average",
-        "Minimum",
         "Maximum",
+        "Minimum",
         "SampleCount",
         "Sum"
       ]
@@ -70139,8 +70139,8 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior": {
       "AllowedValues": [
         "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
+        "SetMaxCapacityAboveForecastCapacity",
+        "SetMaxCapacityToForecastCapacity"
       ]
     },
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode": {
@@ -70152,12 +70152,12 @@
     "AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension": {
       "AllowedValues": [
         "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
         "dynamodb:index:ReadCapacityUnits",
         "dynamodb:index:WriteCapacityUnits",
+        "dynamodb:table:ReadCapacityUnits",
+        "dynamodb:table:WriteCapacityUnits",
+        "ec2:spot-fleet-request:TargetCapacity",
+        "ecs:service:DesiredCount",
         "rds:cluster:ReadReplicaCount"
       ]
     },
@@ -70165,8 +70165,8 @@
       "AllowedValues": [
         "autoscaling",
         "dynamodb",
-        "ecs",
         "ec2",
+        "ecs",
         "rds"
       ]
     },
@@ -70537,10 +70537,10 @@
       "AllowedValues": [
         "SSLv3",
         "TLSv1",
-        "TLSv1_2016",
         "TLSv1.1_2016",
         "TLSv1.2_2018",
-        "TLSv1.2_2019"
+        "TLSv1.2_2019",
+        "TLSv1_2016"
       ]
     },
     "AWS::CloudFront::Distribution.OriginProtocolPolicy": {
@@ -70553,9 +70553,9 @@
     "AWS::CloudFront::Distribution.OriginSSLProtocols": {
       "AllowedValues": [
         "SSLv3",
+        "TLSv1",
         "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
+        "TLSv1.2"
       ]
     },
     "AWS::CloudFront::Distribution.PriceClass": {
@@ -70626,11 +70626,11 @@
       "AllowedValues": [
         "GreaterThanOrEqualToThreshold",
         "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
+        "GreaterThanUpperThreshold",
         "LessThanLowerOrGreaterThanUpperThreshold",
         "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
+        "LessThanOrEqualToThreshold",
+        "LessThanThreshold"
       ]
     },
     "AWS::CloudWatch::Alarm.Statistic": {
@@ -70776,8 +70776,8 @@
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption": {
       "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
+        "WITHOUT_TRAFFIC_CONTROL",
+        "WITH_TRAFFIC_CONTROL"
       ]
     },
     "AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType": {
@@ -70851,13 +70851,13 @@
     "AWS::Cognito::UserPoolClient.ExplicitAuthFlows": {
       "AllowedValues": [
         "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
         "ALLOW_ADMIN_USER_PASSWORD_AUTH",
         "ALLOW_CUSTOM_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH",
         "ALLOW_USER_PASSWORD_AUTH",
         "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
+        "CUSTOM_AUTH_FLOW_ONLY",
+        "USER_PASSWORD_AUTH"
       ]
     },
     "AWS::Cognito::UserPoolClient.RefreshTokenValidity": {
@@ -70921,7 +70921,6 @@
         "AWS::AutoScaling::LaunchConfiguration",
         "AWS::AutoScaling::ScalingPolicy",
         "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
         "AWS::CloudFormation::Stack",
         "AWS::CloudFront::Distribution",
         "AWS::CloudFront::StreamingDistribution",
@@ -70929,6 +70928,7 @@
         "AWS::CloudWatch::Alarm",
         "AWS::CodeBuild::Project",
         "AWS::CodePipeline::Pipeline",
+        "AWS::Config::ResourceCompliance",
         "AWS::DynamoDB::Table",
         "AWS::EC2::CustomerGateway",
         "AWS::EC2::EIP",
@@ -70944,13 +70944,13 @@
         "AWS::EC2::RouteTable",
         "AWS::EC2::SecurityGroup",
         "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
         "AWS::EC2::VPC",
         "AWS::EC2::VPCEndpoint",
         "AWS::EC2::VPCEndpointService",
         "AWS::EC2::VPCPeeringConnection",
         "AWS::EC2::VPNConnection",
         "AWS::EC2::VPNGateway",
+        "AWS::EC2::Volume",
         "AWS::ElasticBeanstalk::Application",
         "AWS::ElasticBeanstalk::ApplicationVersion",
         "AWS::ElasticBeanstalk::Environment",
@@ -70979,18 +70979,18 @@
         "AWS::Redshift::EventSubscription",
         "AWS::S3::AccountPublicAccessBlock",
         "AWS::S3::Bucket",
+        "AWS::SNS::Topic",
+        "AWS::SQS::Queue",
+        "AWS::SSM::AssociationCompliance",
+        "AWS::SSM::FileData",
+        "AWS::SSM::ManagedInstanceInventory",
+        "AWS::SSM::PatchCompliance",
         "AWS::SecretsManager::Secret",
         "AWS::ServiceCatalog::CloudFormationProduct",
         "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
         "AWS::ServiceCatalog::Portfolio",
         "AWS::Shield::Protection",
         "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
         "AWS::WAF::RateBasedRule",
         "AWS::WAF::Rule",
         "AWS::WAF::RuleGroup",
@@ -71793,11 +71793,11 @@
         "Linux/UNIX",
         "Red Hat Enterprise Linux",
         "SUSE Linux",
+        "Windows",
+        "Windows with SQL Server",
         "Windows with SQL Server Enterprise",
         "Windows with SQL Server Standard",
-        "Windows with SQL Server Web",
-        "Windows with SQL Server",
-        "Windows"
+        "Windows with SQL Server Web"
       ]
     },
     "EC2InstanceInitiatedShutdownBehavior": {
@@ -71826,10 +71826,10 @@
     },
     "EFSFileSystemLifecyclePolicy": {
       "AllowedValues": [
-        "AFTER_7_DAYS",
         "AFTER_14_DAYS",
         "AFTER_30_DAYS",
         "AFTER_60_DAYS",
+        "AFTER_7_DAYS",
         "AFTER_90_DAYS"
       ]
     },
@@ -72729,16 +72729,16 @@
         "dotnetcore2.1",
         "dotnetcore3.1",
         "go1.x",
+        "java11",
         "java8",
         "java8.al2",
-        "java11",
         "nodejs",
-        "nodejs4.3-edge",
-        "nodejs4.3",
-        "nodejs6.10",
-        "nodejs8.10",
         "nodejs10.x",
         "nodejs12.x",
+        "nodejs4.3",
+        "nodejs4.3-edge",
+        "nodejs6.10",
+        "nodejs8.10",
         "provided",
         "provided.al2",
         "python2.7",
@@ -73125,10 +73125,10 @@
       "AllowedValues": [
         "CALCULATED",
         "CLOUDWATCH_METRIC",
-        "HTTP_STR_MATCH",
         "HTTP",
-        "HTTPS_STR_MATCH",
         "HTTPS",
+        "HTTPS_STR_MATCH",
+        "HTTP_STR_MATCH",
         "TCP"
       ]
     },
@@ -73202,8 +73202,8 @@
         "s3:ReducedRedundancyLostObject",
         "s3:Replication:OperationFailedReplication",
         "s3:Replication:OperationMissedThreshold",
-        "s3:Replication:OperationReplicatedAfterThreshold",
-        "s3:Replication:OperationNotTracked"
+        "s3:Replication:OperationNotTracked",
+        "s3:Replication:OperationReplicatedAfterThreshold"
       ]
     },
     "S3BucketVersioningConfigurationStatus": {
@@ -73225,8 +73225,8 @@
       "AllowedValues": [
         "A",
         "AAAA",
-        "SRV",
-        "CNAME"
+        "CNAME",
+        "SRV"
       ]
     },
     "ServiceDiscoveryHealthCheckConfigType": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -26,19 +26,14 @@
         }
       },
       "CertificateValidationMethod": {
-        "AllowedValues": [
-          "DNS",
-          "EMAIL"
-        ]
+        "botocore": "acm/2015-12-08/ValidationMethod"
       },
       "CidrIp": {
         "AllowedPattern": "x.x.x.x/y",
         "AllowedPatternRegex": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(/([0-9]|[1-2][0-9]|3[0-2]))$"
       },
       "CustomerGatewayType": {
-        "AllowedValues": [
-          "ipsec.1"
-        ]
+        "botocore": "ec2/2016-11-15/GatewayType"
       },
       "DAXInstanceType": {
         "Ref": {
@@ -56,10 +51,7 @@
         ]
       },
       "DLMPolicyResourceType": {
-        "AllowedValues": [
-          "INSTANCE",
-          "VOLUME"
-        ]
+        "botocore": "dlm/2018-01-12/ResourceTypeValues"
       },
       "DmsEndpointEngineName": {
         "AllowedValues": [
@@ -84,18 +76,10 @@
         ]
       },
       "DmsEndpointSslMode": {
-        "AllowedValues": [
-          "none",
-          "require",
-          "verify-ca",
-          "verify-full"
-        ]
+        "botocore": "dms/2016-01-01/DmsSslModeValue"
       },
       "DmsEndpointType": {
-        "AllowedValues": [
-          "source",
-          "target"
-        ]
+        "botocore": "dms/2016-01-01/ReplicationEndpointTypeValue"
       },
       "DocumentDBEngineVersion": {
         "AllowedValues": [
@@ -110,89 +94,41 @@
         }
       },
       "EC2CapacityReservationEndDateType": {
-        "AllowedValues": [
-          "limited",
-          "unlimited"
-        ]
+        "botocore": "ec2/2016-11-15/EndDateType"
       },
       "EC2CapacityReservationInstanceMatchCriteria": {
-        "AllowedValues": [
-          "open",
-          "targeted"
-        ]
+        "botocore": "ec2/2016-11-15/InstanceMatchCriteria"
       },
       "EC2CapacityReservationInstancePlatform": {
-        "AllowedValues": [
-          "Linux with SQL Server Enterprise",
-          "Linux with SQL Server Standard",
-          "Linux with SQL Server Web",
-          "Linux/UNIX",
-          "Red Hat Enterprise Linux",
-          "SUSE Linux",
-          "Windows with SQL Server Enterprise",
-          "Windows with SQL Server Standard",
-          "Windows with SQL Server Web",
-          "Windows with SQL Server",
-          "Windows"
-        ]
+        "botocore": "ec2/2016-11-15/CapacityReservationInstancePlatform"
       },
       "EC2InstanceInitiatedShutdownBehavior": {
-        "AllowedValues": [
-          "stop",
-          "terminate"
-        ]
+        "botocore": "ec2/2016-11-15/ShutdownBehavior"
       },
       "EC2MarketType": {
-        "AllowedValues": [
-          "spot"
-        ]
+        "botocore": "ec2/2016-11-15/MarketType"
       },
       "EC2SpotInstanceInitiatedShutdownBehavior": {
-        "AllowedValues": [
-          "hibernate",
-          "stop",
-          "terminate"
-        ]
+        "botocore": "ec2/2016-11-15/SpotInstanceInterruptionBehavior"
       },
       "EC2SpotInstanceType": {
-        "AllowedValues": [
-          "one-time",
-          "persistent"
-        ]
+        "botocore": "ec2/2016-11-15/SpotInstanceType"
       },
       "EFSFileSystemLifecyclePolicy": {
-        "AllowedValues": [
-          "AFTER_7_DAYS",
-          "AFTER_14_DAYS",
-          "AFTER_30_DAYS",
-          "AFTER_60_DAYS",
-          "AFTER_90_DAYS"
-        ]
+        "botocore": "efs/2015-02-01/TransitionToIARules"
       },
       "EFSFileSystemPerformanceMode": {
-        "AllowedValues": [
-          "generalPurpose",
-          "maxIO"
-        ]
+        "botocore": "efs/2015-02-01/PerformanceMode"
       },
       "EFSFileSystemThroughputMode": {
-        "AllowedValues": [
-          "bursting",
-          "provisioned"
-        ]
+        "botocore": "efs/2015-02-01/ThroughputMode"
       },
       "EbsIops": {
         "NumberMax": 20000,
         "NumberMin": 100
       },
       "EbsVolumeType": {
-        "AllowedValues": [
-          "gp2",
-          "io1",
-          "sc1",
-          "st1",
-          "standard"
-        ]
+        "botocore": "ec2/2016-11-15/VolumeType"
       },
       "Ec2CpuCredits": {
         "AllowedValues": [
@@ -201,10 +137,7 @@
         ]
       },
       "Ec2ElasticIpDomain": {
-        "AllowedValues": [
-          "standard",
-          "vpc"
-        ]
+        "botocore": "ec2/2016-11-15/DomainType"
       },
       "Ec2FleetDefaultTargetCapacityType": {
         "AllowedValues": [
@@ -213,23 +146,13 @@
         ]
       },
       "Ec2FleetExcessCapacityTerminationPolicy": {
-        "AllowedValues": [
-          "no-termination",
-          "termination"
-        ]
+        "botocore": "ec2/2016-11-15/FleetExcessCapacityTerminationPolicy"
       },
       "Ec2FleetOnDemandAllocationStrategy": {
-        "AllowedValues": [
-          "lowest-price",
-          "prioritized"
-        ]
+        "botocore": "ec2/2016-11-15/FleetOnDemandAllocationStrategy"
       },
       "Ec2FleetSpotAllocationStrategy": {
-        "AllowedValues": [
-          "capacityOptimized",
-          "diversified",
-          "lowestPrice"
-        ]
+        "botocore": "ec2/2016-11-15/AllocationStrategy"
       },
       "Ec2FleetSpotInterruptionBehavior": {
         "AllowedValues": [
@@ -239,37 +162,19 @@
         ]
       },
       "Ec2FleetType": {
-        "AllowedValues": [
-          "instant",
-          "maintain",
-          "request"
-        ]
+        "botocore": "ec2/2016-11-15/FleetType"
       },
       "Ec2FlowLogDestinationType": {
-        "AllowedValues": [
-          "cloud-watch-logs",
-          "s3"
-        ]
+        "botocore": "ec2/2016-11-15/LogDestinationType"
       },
       "Ec2FlowLogResourceType": {
-        "AllowedValues": [
-          "NetworkInterface",
-          "Subnet",
-          "VPC"
-        ]
+        "botocore": "ec2/2016-11-15/FlowLogsResourceType"
       },
       "Ec2FlowLogTrafficType": {
-        "AllowedValues": [
-          "ACCEPT",
-          "ALL",
-          "REJECT"
-        ]
+        "botocore": "ec2/2016-11-15/TrafficType"
       },
       "Ec2HostAutoPlacement": {
-        "AllowedValues": [
-          "off",
-          "on"
-        ]
+        "botocore": "ec2/2016-11-15/AutoPlacement"
       },
       "Ec2InstanceType": {
         "Ref": {
@@ -279,36 +184,19 @@
         }
       },
       "Ec2Tenancy": {
-        "AllowedValues": [
-          "dedicated",
-          "default",
-          "host"
-        ]
+        "botocore": "ec2/2016-11-15/Tenancy"
       },
       "EcsLaunchType": {
-        "AllowedValues": [
-          "EC2",
-          "FARGATE"
-        ]
+        "botocore": "ecs/2014-11-13/LaunchType"
       },
       "EcsNetworkMode": {
-        "AllowedValues": [
-          "awsvpc",
-          "bridge",
-          "host",
-          "none"
-        ]
+        "botocore": "ecs/2014-11-13/NetworkMode"
       },
       "EcsSchedulingStrategy": {
-        "AllowedValues": [
-          "DAEMON",
-          "REPLICA"
-        ]
+        "botocore": "ecs/2014-11-13/SchedulingStrategy"
       },
       "EcsTaskDefinitionProxyType": {
-        "AllowedValues": [
-          "APPMESH"
-        ]
+        "botocore": "ecs/2014-11-13/ProxyConfigurationType"
       },
       "ElasticInferenceAccelerator": {
         "AllowedValues": [
@@ -318,10 +206,7 @@
         ]
       },
       "HttpProtocol": {
-        "AllowedValues": [
-          "http",
-          "https"
-        ]
+        "botocore": "s3/2006-03-01/Protocol"
       },
       "ImageId": {
         "GetAtt": {},
@@ -376,31 +261,7 @@
         }
       },
       "LambdaRuntime": {
-        "AllowedValues": [
-          "dotnetcore1.0",
-          "dotnetcore2.0",
-          "dotnetcore2.1",
-          "dotnetcore3.1",
-          "go1.x",
-          "java8",
-          "java8.al2",
-          "java11",
-          "nodejs",
-          "nodejs4.3-edge",
-          "nodejs4.3",
-          "nodejs6.10",
-          "nodejs8.10",
-          "nodejs10.x",
-          "nodejs12.x",
-          "provided",
-          "provided.al2",
-          "python2.7",
-          "python3.6",
-          "python3.7",
-          "python3.8",
-          "ruby2.5",
-          "ruby2.7"
-        ]
+        "botocore": "lambda/2015-03-31/Runtime"
       },
       "LaunchConfigurationName": {
         "GetAtt": {},
@@ -420,10 +281,7 @@
         "StringMin": 3
       },
       "LaunchTemplateTagSpecificationResourceType": {
-        "AllowedValues": [
-          "instance",
-          "volume"
-        ]
+        "botocore": "ec2/2016-11-15/ResourceType"
       },
       "LoadBalancerName": {
         "GetAtt": {},
@@ -466,10 +324,7 @@
         }
       },
       "MicrosoftADEdition": {
-        "AllowedValues": [
-          "Enterprise",
-          "Standard"
-        ]
+        "botocore": "ds/2015-04-16/DirectoryEdition"
       },
       "NeptuneInstanceClass": {
         "Ref": {
@@ -479,20 +334,14 @@
         }
       },
       "NetworkAclRuleAction": {
-        "AllowedValues": [
-          "allow",
-          "deny"
-        ]
+        "botocore": "ec2/2016-11-15/RuleAction"
       },
       "NetworkAclRuleNumber": {
         "NumberMax": 32766,
         "NumberMin": 1
       },
       "NetworkInterfacePermission": {
-        "AllowedValues": [
-          "EIP-ASSOCIATE",
-          "INSTANCE-ATTACH"
-        ]
+        "botocore": "ec2/2016-11-15/InterfacePermissionType"
       },
       "PerformanceInsightsRetentionPeriod": {
         "AllowedValues": [
@@ -512,11 +361,7 @@
         }
       },
       "PlacementGroupStrategy": {
-        "AllowedValues": [
-          "cluster",
-          "partition",
-          "spread"
-        ]
+        "botocore": "ec2/2016-11-15/PlacementGroupStrategy"
       },
       "PlacementTenancy": {
         "AllowedValues": [
@@ -530,15 +375,7 @@
         }
       },
       "PredicateType": {
-        "AllowedValues": [
-          "ByteMatch",
-          "GeoMatch",
-          "IPMatch",
-          "RegexMatch",
-          "SizeConstraint",
-          "SqlInjectionMatch",
-          "XssMatch"
-        ]
+        "botocore": "waf/2015-08-24/PredicateType"
       },
       "PrivateIpAddress": {
         "GetAtt": {
@@ -569,10 +406,7 @@
         }
       },
       "RecordSetFailover": {
-        "AllowedValues": [
-          "PRIMARY",
-          "SECONDARY"
-        ]
+        "botocore": "route53/2013-04-01/ResourceRecordSetFailover"
       },
       "RecordSetGeoContinentCode": {
         "AllowedValues": [
@@ -586,20 +420,7 @@
         ]
       },
       "RecordSetType": {
-        "AllowedValues": [
-          "A",
-          "AAAA",
-          "CAA",
-          "CNAME",
-          "MX",
-          "NAPTR",
-          "NS",
-          "PTR",
-          "SOA",
-          "SPF",
-          "SRV",
-          "TXT"
-        ]
+        "botocore": "route53/2013-04-01/RRType"
       },
       "RedshiftClusterType": {
         "AllowedValues": [
@@ -655,41 +476,19 @@
         }
       },
       "Route53HealthCheckConfigHealthStatus": {
-        "AllowedValues": [
-          "Healthy",
-          "LastKnownStatus",
-          "Unhealthy"
-        ]
+        "botocore": "route53/2013-04-01/InsufficientDataHealthStatus"
       },
       "Route53HealthCheckConfigType": {
-        "AllowedValues": [
-          "CALCULATED",
-          "CLOUDWATCH_METRIC",
-          "HTTP_STR_MATCH",
-          "HTTP",
-          "HTTPS_STR_MATCH",
-          "HTTPS",
-          "TCP"
-        ]
+        "botocore": "route53/2013-04-01/HealthCheckType"
       },
       "Route53ResolverEndpointDirection": {
-        "AllowedValues": [
-          "INBOUND",
-          "OUTBOUND"
-        ]
+        "botocore": "route53resolver/2018-04-01/ResolverEndpointDirection"
       },
       "Route53ResolverRuleType": {
-        "AllowedValues": [
-          "FORWARD",
-          "RECURSIVE",
-          "SYSTEM"
-        ]
+        "botocore": "route53resolver/2018-04-01/RuleTypeOption"
       },
       "S3BucketAccelerationStatus": {
-        "AllowedValues": [
-          "Enabled",
-          "Suspended"
-        ]
+        "botocore": "s3/2006-03-01/BucketAccelerateStatus"
       },
       "S3BucketAccessControl": {
         "AllowedValues": [
@@ -710,47 +509,19 @@
         "StringMin": 1
       },
       "S3BucketInventoryIncludedObjectVersions": {
-        "AllowedValues": [
-          "All",
-          "Current"
-        ]
+        "botocore": "s3/2006-03-01/InventoryIncludedObjectVersions"
       },
       "S3BucketInventoryScheduleFrequency": {
-        "AllowedValues": [
-          "Daily",
-          "Weekly"
-        ]
+        "botocore": "s3/2006-03-01/InventoryFrequency"
       },
       "S3BucketSSEAlgorithm": {
-        "AllowedValues": [
-          "AES256",
-          "aws:kms"
-        ]
+        "botocore": "s3/2006-03-01/ServerSideEncryption"
       },
       "S3BucketTopicConfigurationEvent": {
-        "AllowedValues": [
-          "s3:ObjectCreated:*",
-          "s3:ObjectCreated:CompleteMultipartUpload",
-          "s3:ObjectCreated:Copy",
-          "s3:ObjectCreated:Post",
-          "s3:ObjectCreated:Put",
-          "s3:ObjectRemoved:*",
-          "s3:ObjectRemoved:Delete",
-          "s3:ObjectRemoved:DeleteMarkerCreated",
-          "s3:ObjectRestore:Completed",
-          "s3:ObjectRestore:Post",
-          "s3:ReducedRedundancyLostObject",
-          "s3:Replication:OperationFailedReplication",
-          "s3:Replication:OperationMissedThreshold",
-          "s3:Replication:OperationReplicatedAfterThreshold",
-          "s3:Replication:OperationNotTracked"
-        ]
+        "botocore": "s3/2006-03-01/Event"
       },
       "S3BucketVersioningConfigurationStatus": {
-        "AllowedValues": [
-          "Enabled",
-          "Suspended"
-        ]
+        "botocore": "s3/2006-03-01/BucketVersioningStatus"
       },
       "SecretsManagerTargetType": {
         "AllowedValues": [
@@ -762,31 +533,16 @@
         ]
       },
       "ServiceDiscoveryDnsType": {
-        "AllowedValues": [
-          "A",
-          "AAAA",
-          "SRV",
-          "CNAME"
-        ]
+        "botocore": "servicediscovery/2017-03-14/RecordType"
       },
       "ServiceDiscoveryHealthCheckConfigType": {
-        "AllowedValues": [
-          "HTTP",
-          "HTTPS",
-          "TCP"
-        ]
+        "botocore": "servicediscovery/2017-03-14/HealthCheckType"
       },
       "SesReceiptRuleTlsPolicy": {
-        "AllowedValues": [
-          "Optional",
-          "Require"
-        ]
+        "botocore": "ses/2010-12-01/TlsPolicy"
       },
       "SimpleADSize": {
-        "AllowedValues": [
-          "Large",
-          "Small"
-        ]
+        "botocore": "ds/2015-04-16/DirectorySize"
       },
       "SnsSubscriptionProtocol": {
         "AllowedValues": [
@@ -801,10 +557,7 @@
         ]
       },
       "SpotFleetExcessCapacityTerminationPolicy": {
-        "AllowedValues": [
-          "default",
-          "noTermination"
-        ]
+        "botocore": "ec2/2016-11-15/ExcessCapacityTerminationPolicy"
       },
       "SpotFleetInstanceInterruptionBehavior": {
         "AllowedValues": [
@@ -814,11 +567,7 @@
         ]
       },
       "SpotFleetType": {
-        "AllowedValues": [
-          "instant",
-          "maintain",
-          "request"
-        ]
+        "botocore": "ec2/2016-11-15/FleetType"
       },
       "SsmDocumentName": {
         "GetAtt": {},
@@ -902,10 +651,7 @@
         ]
       },
       "VpcEndpointType": {
-        "AllowedValues": [
-          "Gateway",
-          "Interface"
-        ]
+        "botocore": "ec2/2016-11-15/VpcEndpointType"
       },
       "VpnType": {
         "AllowedValues": [

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_amazonmq.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_amazonmq.json
@@ -3,19 +3,14 @@
     "op": "add",
     "path": "/ValueTypes/AWS::AmazonMQ::Broker.DeploymentMode",
     "value": {
-      "AllowedValues": [
-        "ACTIVE_STANDBY_MULTI_AZ",
-        "SINGLE_INSTANCE"
-      ]
+      "botocore": "mq/2017-11-27/DeploymentMode"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::AmazonMQ::Broker.EngineType",
     "value": {
-      "AllowedValues": [
-        "ACTIVEMQ"
-      ]
+      "botocore": "mq/2017-11-27/EngineType"
     }
   },
   {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_apigateway.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_apigateway.json
@@ -3,49 +3,21 @@
     "op": "add",
     "path": "/ValueTypes/AWS::ApiGateway::RestApi.ApiKeySourceType",
     "value": {
-      "AllowedValues": [
-        "AUTHORIZER",
-        "HEADER"
-      ]
+      "botocore": "apigateway/2015-07-09/ApiKeySourceType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::ApiGateway::Authorizer.Type",
     "value": {
-      "AllowedValues": [
-        "COGNITO_USER_POOLS",
-        "REQUEST",
-        "TOKEN"
-      ]
+      "botocore": "apigateway/2015-07-09/AuthorizerType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::ApiGateway::GatewayResponse.ResponseType",
     "value": {
-      "AllowedValues": [
-        "ACCESS_DENIED",
-        "API_CONFIGURATION_ERROR",
-        "AUTHORIZER_FAILURE",
-        "AUTHORIZER_CONFIGURATION_ERROR",
-        "BAD_REQUEST_PARAMETERS",
-        "BAD_REQUEST_BODY",
-        "DEFAULT_4XX",
-        "DEFAULT_5XX",
-        "EXPIRED_TOKEN",
-        "INVALID_SIGNATURE",
-        "INTEGRATION_FAILURE",
-        "INTEGRATION_TIMEOUT",
-        "INVALID_API_KEY",
-        "MISSING_AUTHENTICATION_TOKEN",
-        "QUOTA_EXCEEDED",
-        "REQUEST_TOO_LARGE",
-        "RESOURCE_NOT_FOUND",
-        "THROTTLED",
-        "UNAUTHORIZED",
-        "UNSUPPORTED_MEDIA_TYPE"
-      ]
+      "botocore": "apigateway/2015-07-09/GatewayResponseType"
     }
   },
   {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_applicationautoscaling.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_applicationautoscaling.json
@@ -3,34 +3,14 @@
     "op": "add",
     "path": "/ValueTypes/AWS::ApplicationAutoScaling::ScalingPolicy.PolicyType",
     "value": {
-      "AllowedValues": [
-        "StepScaling",
-        "TargetTrackingScaling"
-      ]
+      "botocore": "application-autoscaling/2016-02-06/PolicyType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::ApplicationAutoScaling::ScalingPolicy.PredefinedMetricSpecification.PredefinedMetricType",
     "value": {
-      "AllowedValues": [
-        "ALBRequestCountPerTarget",
-        "AppStreamAverageCapacityUtilization",
-        "CassandraReadCapacityUtilization",
-        "CassandraWriteCapacityUtilization",
-        "ComprehendInferenceUtilization",
-        "DynamoDBReadCapacityUtilization",
-        "DynamoDBWriteCapacityUtilization",
-        "EC2SpotFleetRequestAverageCPUUtilization",
-        "EC2SpotFleetRequestAverageNetworkIn",
-        "EC2SpotFleetRequestAverageNetworkOut",
-        "ECSServiceAverageCPUUtilization",
-        "ECSServiceAverageMemoryUtilization",
-        "RDSReaderAverageCPUUtilization",
-        "RDSReaderAverageDatabaseConnections",
-        "SageMakerVariantInvocationsPerInstance",
-        "LambdaProvisionedConcurrencyUtilization"
-      ]
+      "botocore": "application-autoscaling/2016-02-06/MetricType"
     }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_appsync.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_appsync.json
@@ -3,36 +3,21 @@
     "op": "add",
     "path": "/ValueTypes/AWS::AppSync::DataSource.Type",
     "value": {
-      "AllowedValues": [
-        "AMAZON_DYNAMODB",
-        "AMAZON_ELASTICSEARCH",
-        "AWS_LAMBDA",
-        "HTTP",
-        "NONE",
-        "RELATIONAL_DATABASE"
-      ]
+      "botocore": "appsync/2017-07-25/DataSourceType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::AppSync::GraphQLApi.AuthType",
     "value": {
-      "AllowedValues": [
-        "AMAZON_COGNITO_USER_POOLS",
-        "API_KEY",
-        "AWS_IAM",
-        "OPENID_CONNECT"
-      ]
+      "botocore": "appsync/2017-07-25/AuthenticationType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::AppSync::Resolver.Kind",
     "value": {
-      "AllowedValues": [
-        "PIPELINE",
-        "UNIT"
-      ]
+      "botocore": "appsync/2017-07-25/ResolverKind"
     }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_autoscaling.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_autoscaling.json
@@ -66,25 +66,14 @@
     "op": "add",
     "path": "/ValueTypes/AWS::AutoScaling::ScalingPolicy.CustomizedMetricSpecification.Statistic",
     "value": {
-      "AllowedValues": [
-        "Average",
-        "Minimum",
-        "Maximum",
-        "SampleCount",
-        "Sum"
-      ]
+      "botocore": "autoscaling/2011-01-01/MetricStatistic"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::AutoScaling::ScalingPolicy.PredefinedMetricSpecification.PredefinedMetricType",
     "value": {
-      "AllowedValues": [
-        "ALBRequestCountPerTarget",
-        "ASGAverageCPUUtilization",
-        "ASGAverageNetworkIn",
-        "ASGAverageNetworkOut"
-      ]
+      "botocore": "autoscaling/2011-01-01/MetricType"
     }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_autoscalingplans.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_autoscalingplans.json
@@ -3,50 +3,28 @@
     "op": "add",
     "path": "/ValueTypes/AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ScalableDimension",
     "value": {
-      "AllowedValues": [
-        "autoscaling:autoScalingGroup:DesiredCapacity",
-        "ecs:service:DesiredCount",
-        "ec2:spot-fleet-request:TargetCapacity",
-        "dynamodb:table:ReadCapacityUnits",
-        "dynamodb:table:WriteCapacityUnits",
-        "dynamodb:index:ReadCapacityUnits",
-        "dynamodb:index:WriteCapacityUnits",
-        "rds:cluster:ReadReplicaCount"
-      ]
+      "botocore": "autoscaling-plans/2018-01-06/ScalableDimension"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.ServiceNamespace",
     "value": {
-      "AllowedValues": [
-        "autoscaling",
-        "dynamodb",
-        "ecs",
-        "ec2",
-        "rds"
-      ]
+      "botocore": "autoscaling-plans/2018-01-06/ServiceNamespace"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMaxCapacityBehavior",
     "value": {
-      "AllowedValues": [
-        "SetForecastCapacityToMaxCapacity",
-        "SetMaxCapacityToForecastCapacity",
-        "SetMaxCapacityAboveForecastCapacity"
-      ]
+      "botocore": "autoscaling-plans/2018-01-06/PredictiveScalingMaxCapacityBehavior"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::AutoScalingPlans::ScalingPlan.ScalingInstruction.PredictiveScalingMode",
     "value": {
-      "AllowedValues": [
-        "ForecastAndScale",
-        "ForecastOnly"
-      ]
+      "botocore": "autoscaling-plans/2018-01-06/PredictiveScalingMode"
     }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_budget.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_budget.json
@@ -3,47 +3,28 @@
     "op": "add",
     "path": "/ValueTypes/AWS::Budgets::Budget.BudgetType",
     "value": {
-      "AllowedValues": [
-        "COST",
-        "RI_COVERAGE",
-        "RI_UTILIZATION",
-        "SAVINGS_PLANS_COVERAGE",
-        "SAVINGS_PLANS_UTILIZATION",
-        "USAGE"
-      ]
+      "botocore": "budgets/2016-10-20/BudgetType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Budgets::Budget.TimeUnit",
     "value": {
-      "AllowedValues": [
-        "ANNUALLY",
-        "DAILY",
-        "MONTHLY",
-        "QUARTERLY"
-      ]
+      "botocore": "budgets/2016-10-20/TimeUnit"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Budgets::Budget.ComparisonOperator",
     "value": {
-      "AllowedValues": [
-        "EQUAL_TO",
-        "GREATER_THAN",
-        "LESS_THAN"
-      ]
+      "botocore": "budgets/2016-10-20/ComparisonOperator"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Budgets::Budget.NotificationType",
     "value": {
-      "AllowedValues": [
-        "ACTUAL",
-        "FORECASTED"
-      ]
+      "botocore": "budgets/2016-10-20/NotificationType"
     }
   },
   {
@@ -58,20 +39,14 @@
     "op": "add",
     "path": "/ValueTypes/AWS::Budgets::Budget.ThresholdType",
     "value": {
-      "AllowedValues": [
-        "ABSOLUTE_VALUE",
-        "PERCENTAGE"
-      ]
+      "botocore": "budgets/2016-10-20/ThresholdType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Budgets::Budget.SubscriptionType",
     "value": {
-      "AllowedValues": [
-        "EMAIL",
-        "SNS"
-      ]
+      "botocore": "budgets/2016-10-20/SubscriptionType"
     }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloudfront.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloudfront.json
@@ -3,11 +3,7 @@
     "op": "add",
     "path": "/ValueTypes/AWS::CloudFront::Distribution.ViewerProtocolPolicy",
     "value": {
-      "AllowedValues": [
-        "allow-all",
-        "https-only",
-        "redirect-to-https"
-      ]
+      "botocore": "cloudfront/2020-05-31/ViewerProtocolPolicy"
     }
   },
   {
@@ -53,91 +49,56 @@
     "op": "add",
     "path": "/ValueTypes/AWS::CloudFront::Distribution.RestrictionType",
     "value": {
-      "AllowedValues": [
-        "blacklist",
-        "none",
-        "whitelist"
-      ]
+      "botocore": "cloudfront/2020-05-31/GeoRestrictionType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CloudFront::Distribution.HttpVersion",
     "value": {
-      "AllowedValues": [
-        "http1.1",
-        "http2"
-      ]
+      "botocore": "cloudfront/2020-05-31/HttpVersion"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CloudFront::Distribution.EventType",
     "value": {
-      "AllowedValues": [
-        "origin-request",
-        "origin-response",
-        "viewer-request",
-        "viewer-response"
-      ]
+      "botocore": "cloudfront/2020-05-31/EventType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CloudFront::Distribution.OriginProtocolPolicy",
     "value": {
-      "AllowedValues": [
-        "http-only",
-        "https-only",
-        "match-viewer"
-      ]
+      "botocore": "cloudfront/2020-05-31/OriginProtocolPolicy"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CloudFront::Distribution.OriginSSLProtocols",
     "value": {
-      "AllowedValues": [
-        "SSLv3",
-        "TLSv1.1",
-        "TLSv1.2",
-        "TLSv1"
-      ]
+      "botocore": "cloudfront/2020-05-31/SslProtocol"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CloudFront::Distribution.PriceClass",
     "value": {
-      "AllowedValues": [
-        "PriceClass_100",
-        "PriceClass_200",
-        "PriceClass_All"
-      ]
+      "botocore": "cloudfront/2020-05-31/PriceClass"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CloudFront::Distribution.MinimumProtocolVersion",
     "value": {
-      "AllowedValues": [
-        "SSLv3",
-        "TLSv1",
-        "TLSv1_2016",
-        "TLSv1.1_2016",
-        "TLSv1.2_2018",
-        "TLSv1.2_2019"
-      ]
+      "botocore": "cloudfront/2020-05-31/MinimumProtocolVersion"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CloudFront::Distribution.SslSupportMethod",
     "value": {
-      "AllowedValues": [
-        "sni-only",
-        "vip"
-      ]
+      "botocore": "cloudfront/2020-05-31/SSLSupportMethod"
     }
   },
   {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloudtrail.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloudtrail.json
@@ -13,11 +13,7 @@
     "op": "add",
     "path": "/ValueTypes/AWS::CloudTrail::Trail.EventReadWriteType",
     "value": {
-      "AllowedValues": [
-        "All",
-        "ReadOnly",
-        "WriteOnly"
-      ]
+      "botocore": "cloudtrail/2013-11-01/ReadWriteType"
     }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloudwatch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloudwatch.json
@@ -19,28 +19,14 @@
     "op": "add",
     "path": "/ValueTypes/AWS::CloudWatch::Alarm.ComparisonOperator",
     "value": {
-      "AllowedValues": [
-        "GreaterThanOrEqualToThreshold",
-        "GreaterThanThreshold",
-        "LessThanThreshold",
-        "LessThanOrEqualToThreshold",
-        "LessThanLowerOrGreaterThanUpperThreshold",
-        "LessThanLowerThreshold",
-        "GreaterThanUpperThreshold"
-      ]
+      "botocore": "cloudwatch/2010-08-01/ComparisonOperator"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CloudWatch::Alarm.Statistic",
     "value": {
-      "AllowedValues": [
-        "Average",
-        "Maximum",
-        "Minimum",
-        "SampleCount",
-        "Sum"
-      ]
+      "botocore": "cloudwatch/2010-08-01/Statistic"
     }
   },
   {
@@ -59,35 +45,7 @@
     "op": "add",
     "path": "/ValueTypes/AWS::CloudWatch::Alarm.Unit",
     "value": {
-      "AllowedValues": [
-        "Bits",
-        "Bits/Second",
-        "Bytes",
-        "Bytes/Second",
-        "Count",
-        "Count/Second",
-        "Gigabits",
-        "Gigabits/Second",
-        "Gigabytes",
-        "Gigabytes/Second",
-        "Kilobits",
-        "Kilobits/Second",
-        "Kilobytes",
-        "Kilobytes/Second",
-        "Megabits",
-        "Megabits/Second",
-        "Megabytes",
-        "Megabytes/Second",
-        "Microseconds",
-        "Milliseconds",
-        "None",
-        "Percent",
-        "Seconds",
-        "Terabits",
-        "Terabits/Second",
-        "Terabytes",
-        "Terabytes/Second"
-      ]
+      "botocore": "cloudwatch/2010-08-01/StandardUnit"
     }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_codebuild.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_codebuild.json
@@ -3,80 +3,49 @@
     "op": "add",
     "path": "/ValueTypes/AWS::CodeBuild::Project.Artifacts.Packaging",
     "value": {
-      "AllowedValues": [
-        "NONE",
-        "ZIP"
-      ]
+      "botocore": "codebuild/2016-10-06/ArtifactPackaging"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CodeBuild::Project.Artifacts.Type",
     "value": {
-      "AllowedValues": [
-        "CODEPIPELINE",
-        "NO_ARTIFACTS",
-        "S3"
-      ]
+      "botocore": "codebuild/2016-10-06/ArtifactsType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CodeBuild::Project.Environment.ComputeType",
     "value": {
-      "AllowedValues": [
-        "BUILD_GENERAL1_LARGE",
-        "BUILD_GENERAL1_MEDIUM",
-        "BUILD_GENERAL1_SMALL"
-      ]
+      "botocore": "codebuild/2016-10-06/ComputeType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CodeBuild::Project.Environment.ImagePullCredentialsType",
     "value": {
-      "AllowedValues": [
-        "CODEBUILD",
-        "SERVICE_ROLE"
-      ]
+      "botocore": "codebuild/2016-10-06/ImagePullCredentialsType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CodeBuild::Project.Environment.Type",
     "value": {
-      "AllowedValues": [
-        "ARM_CONTAINER",
-        "LINUX_CONTAINER",
-        "LINUX_GPU_CONTAINER",
-        "WINDOWS_CONTAINER"
-      ]
+      "botocore": "codebuild/2016-10-06/EnvironmentType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CodeBuild::Project.ProjectCache.Type",
     "value": {
-      "AllowedValues": [
-        "LOCAL",
-        "NO_CACHE",
-        "S3"
-      ]
+      "botocore": "codebuild/2016-10-06/CacheType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CodeBuild::Project.Source.Type",
     "value": {
-      "AllowedValues": [
-        "BITBUCKET",
-        "CODECOMMIT",
-        "CODEPIPELINE",
-        "GITHUB",
-        "GITHUB_ENTERPRISE",
-        "NO_SOURCE",
-        "S3"
-      ]
+      "botocore": "codebuild/2016-10-06/SourceType"
     }
   },
   {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_codecommit.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_codecommit.json
@@ -3,12 +3,7 @@
     "op": "add",
     "path": "/ValueTypes/AWS::CodeCommit::Repository.RepositoryTrigger.Events",
     "value": {
-      "AllowedValues": [
-        "all",
-        "createReference",
-        "deleteReference",
-        "updateReference"
-      ]
+      "botocore": "codecommit/2015-04-13/RepositoryTriggerEventEnum"
     }
   },
   {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_codedeploy.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_codedeploy.json
@@ -3,70 +3,42 @@
     "op": "add",
     "path": "/ValueTypes/AWS::CodeDeploy::Application.ComputePlatform",
     "value": {
-      "AllowedValues": [
-        "ECS",
-        "Lambda",
-        "Server"
-      ]
+      "botocore": "codedeploy/2014-10-06/ComputePlatform"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CodeDeploy::DeploymentGroup.AutoRollbackConfiguration.Events",
     "value": {
-      "AllowedValues": [
-        "DEPLOYMENT_FAILURE",
-        "DEPLOYMENT_STOP_ON_ALARM",
-        "DEPLOYMENT_STOP_ON_REQUEST"
-      ]
+      "botocore": "codedeploy/2014-10-06/AutoRollbackEvent"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CodeDeploy::DeploymentConfig.MinimumHealthyHosts.Type",
     "value": {
-      "AllowedValues": [
-        "FLEET_PERCENT",
-        "HOST_COUNT"
-      ]
+      "botocore": "codedeploy/2014-10-06/MinimumHealthyHostsType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentOption",
     "value": {
-      "AllowedValues": [
-        "WITH_TRAFFIC_CONTROL",
-        "WITHOUT_TRAFFIC_CONTROL"
-      ]
+      "botocore": "codedeploy/2014-10-06/DeploymentOption"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CodeDeploy::DeploymentGroup.DeploymentStyle.DeploymentType",
     "value": {
-      "AllowedValues": [
-        "BLUE_GREEN",
-        "IN_PLACE"
-      ]
+      "botocore": "codedeploy/2014-10-06/DeploymentType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/WS::CodeDeploy::DeploymentGroup.TriggerConfig.TriggerEvents",
     "value": {
-      "AllowedValues": [
-        "DeploymentFailure",
-        "DeploymentReady",
-        "DeploymentRollback",
-        "DeploymentStart",
-        "DeploymentStop",
-        "DeploymentSuccess",
-        "InstanceFailure",
-        "InstanceReady",
-        "InstanceStart",
-        "InstanceSuccess"
-      ]
+      "botocore": "codedeploy/2014-10-06/TriggerEventType"
     }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_codepipeline.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_codepipeline.json
@@ -3,65 +3,42 @@
     "op": "add",
     "path": "/ValueTypes/AWS::CodePipeline::Pipeline.ActionTypeId.Category",
     "value": {
-      "AllowedValues": [
-        "Approval",
-        "Build",
-        "Deploy",
-        "Invoke",
-        "Source",
-        "Test"
-      ]
+      "botocore": "codepipeline/2015-07-09/ActionCategory"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CodePipeline::Pipeline.ActionTypeId.Owner",
     "value": {
-      "AllowedValues": [
-        "AWS",
-        "Custom",
-        "ThirdParty"
-      ]
+      "botocore": "codepipeline/2015-07-09/ActionOwner"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CodePipeline::Pipeline.ArtifactStore.Type",
     "value": {
-      "AllowedValues": [
-        "S3"
-      ]
+      "botocore": "codepipeline/2015-07-09/ArtifactStoreType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CodePipeline::Pipeline.BlockerDeclaration.Type",
     "value": {
-      "AllowedValues": [
-        "Schedule"
-      ]
+      "botocore": "codepipeline/2015-07-09/BlockerType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::CodePipeline::CustomActionType.ConfigurationProperties.Type",
     "value": {
-      "AllowedValues": [
-        "Boolean",
-        "Number",
-        "String"
-      ]
+      "botocore": "codepipeline/2015-07-09/ActionConfigurationPropertyType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/CodePipelineWehbookAuthentication",
     "value": {
-      "AllowedValues": [
-        "GITHUB_HMAC",
-        "IP",
-        "UNAUTHENTICATED"
-      ]
+      "botocore": "codepipeline/2015-07-09/WebhookAuthenticationType"
     }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cognito.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cognito.json
@@ -3,68 +3,42 @@
     "op": "add",
     "path": "/ValueTypes/AWS::Cognito::UserPool.AliasAttributes",
     "value": {
-      "AllowedValues": [
-        "email",
-        "phone_number",
-        "preferred_username"
-      ]
+      "botocore": "cognito-idp/2016-04-18/AliasAttributeType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Cognito::UserPool.UsernameAttributes",
     "value": {
-      "AllowedValues": [
-        "email",
-        "phone_number"
-      ]
+      "botocore": "cognito-idp/2016-04-18/UsernameAttributeType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Cognito::UserPoolUser.DesiredDeliveryMediums",
     "value": {
-      "AllowedValues": [
-        "EMAIL",
-        "SMS"
-      ]
+      "botocore": "cognito-idp/2016-04-18/DeliveryMediumType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Cognito::UserPoolClient.ExplicitAuthFlows",
     "value": {
-      "AllowedValues": [
-        "ADMIN_NO_SRP_AUTH",
-        "CUSTOM_AUTH_FLOW_ONLY",
-        "USER_PASSWORD_AUTH",
-        "ALLOW_ADMIN_USER_PASSWORD_AUTH",
-        "ALLOW_CUSTOM_AUTH",
-        "ALLOW_USER_PASSWORD_AUTH",
-        "ALLOW_USER_SRP_AUTH",
-        "ALLOW_REFRESH_TOKEN_AUTH"
-      ]
+      "botocore": "cognito-idp/2016-04-18/ExplicitAuthFlowsType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Cognito::UserPoolUser.MessageAction",
     "value": {
-      "AllowedValues": [
-        "RESEND",
-        "SUPPRESS"
-      ]
+      "botocore": "cognito-idp/2016-04-18/MessageActionType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Cognito::UserPool.MfaConfiguration",
     "value": {
-      "AllowedValues": [
-        "OFF",
-        "ON",
-        "OPTIONAL"
-      ]
+      "botocore": "cognito-idp/2016-04-18/UserPoolMfaType"
     }
   },
   {
@@ -85,12 +59,7 @@
     "op": "add",
     "path": "/ValueTypes/AWS::Cognito::UserPool.SchemaAttribute.AttributeDataType",
     "value": {
-      "AllowedValues": [
-        "Boolean",
-        "DateTime",
-        "Number",
-        "String"
-      ]
+      "botocore": "cognito-idp/2016-04-18/AttributeDataType"
     }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_config.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_config.json
@@ -3,145 +3,35 @@
     "op": "add",
     "path": "/ValueTypes/AWS::Config::ConfigurationRecorder.ResourceTypes",
     "value": {
-      "AllowedValues": [
-        "AWS::ACM::Certificate",
-        "AWS::ApiGateway::RestApi",
-        "AWS::ApiGateway::Stage",
-        "AWS::ApiGatewayV2::Api",
-        "AWS::ApiGatewayV2::Stage",
-        "AWS::AutoScaling::AutoScalingGroup",
-        "AWS::AutoScaling::LaunchConfiguration",
-        "AWS::AutoScaling::ScalingPolicy",
-        "AWS::AutoScaling::ScheduledAction",
-        "AWS::Config::ResourceCompliance",
-        "AWS::CloudFormation::Stack",
-        "AWS::CloudFront::Distribution",
-        "AWS::CloudFront::StreamingDistribution",
-        "AWS::CloudTrail::Trail",
-        "AWS::CloudWatch::Alarm",
-        "AWS::CodeBuild::Project",
-        "AWS::CodePipeline::Pipeline",
-        "AWS::DynamoDB::Table",
-        "AWS::EC2::CustomerGateway",
-        "AWS::EC2::EIP",
-        "AWS::EC2::EgressOnlyInternetGateway",
-        "AWS::EC2::FlowLog",
-        "AWS::EC2::Host",
-        "AWS::EC2::Instance",
-        "AWS::EC2::InternetGateway",
-        "AWS::EC2::NatGateway",
-        "AWS::EC2::NetworkAcl",
-        "AWS::EC2::NetworkInterface",
-        "AWS::EC2::RegisteredHAInstance",
-        "AWS::EC2::RouteTable",
-        "AWS::EC2::SecurityGroup",
-        "AWS::EC2::Subnet",
-        "AWS::EC2::Volume",
-        "AWS::EC2::VPC",
-        "AWS::EC2::VPCEndpoint",
-        "AWS::EC2::VPCEndpointService",
-        "AWS::EC2::VPCPeeringConnection",
-        "AWS::EC2::VPNConnection",
-        "AWS::EC2::VPNGateway",
-        "AWS::ElasticBeanstalk::Application",
-        "AWS::ElasticBeanstalk::ApplicationVersion",
-        "AWS::ElasticBeanstalk::Environment",
-        "AWS::ElasticLoadBalancing::LoadBalancer",
-        "AWS::ElasticLoadBalancingV2::LoadBalancer",
-        "AWS::Elasticsearch::Domain",
-        "AWS::IAM::Group",
-        "AWS::IAM::Policy",
-        "AWS::IAM::Role",
-        "AWS::IAM::User",
-        "AWS::KMS::Key",
-        "AWS::Lambda::Function",
-        "AWS::QLDB::Ledger",
-        "AWS::RDS::DBCluster",
-        "AWS::RDS::DBClusterSnapshot",
-        "AWS::RDS::DBInstance",
-        "AWS::RDS::DBSecurityGroup",
-        "AWS::RDS::DBSnapshot",
-        "AWS::RDS::DBSubnetGroup",
-        "AWS::RDS::EventSubscription",
-        "AWS::Redshift::Cluster",
-        "AWS::Redshift::ClusterParameterGroup",
-        "AWS::Redshift::ClusterSecurityGroup",
-        "AWS::Redshift::ClusterSnapshot",
-        "AWS::Redshift::ClusterSubnetGroup",
-        "AWS::Redshift::EventSubscription",
-        "AWS::S3::AccountPublicAccessBlock",
-        "AWS::S3::Bucket",
-        "AWS::SecretsManager::Secret",
-        "AWS::ServiceCatalog::CloudFormationProduct",
-        "AWS::ServiceCatalog::CloudFormationProvisionedProduct",
-        "AWS::ServiceCatalog::Portfolio",
-        "AWS::Shield::Protection",
-        "AWS::ShieldRegional::Protection",
-        "AWS::SNS::Topic",
-        "AWS::SSM::AssociationCompliance",
-        "AWS::SSM::FileData",
-        "AWS::SSM::ManagedInstanceInventory",
-        "AWS::SSM::PatchCompliance",
-        "AWS::SQS::Queue",
-        "AWS::WAF::RateBasedRule",
-        "AWS::WAF::Rule",
-        "AWS::WAF::RuleGroup",
-        "AWS::WAF::WebACL",
-        "AWS::WAFRegional::RateBasedRule",
-        "AWS::WAFRegional::Rule",
-        "AWS::WAFRegional::RuleGroup",
-        "AWS::WAFRegional::WebACL",
-        "AWS::WAFv2::IPSet",
-        "AWS::WAFv2::ManagedRuleSet",
-        "AWS::WAFv2::RegexPatternSet",
-        "AWS::WAFv2::RuleGroup",
-        "AWS::WAFv2::WebACL",
-        "AWS::XRay::EncryptionConfig"
-      ]
+      "botocore": "config/2014-11-12/ResourceType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Config::ConfigRule.Source.Owner",
     "value": {
-      "AllowedValues": [
-        "AWS",
-        "CUSTOM_LAMBDA"
-      ]
+      "botocore": "config/2014-11-12/Owner"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Config::ConfigRule.SourceDetail.EventSource",
     "value": {
-      "AllowedValues": [
-        "aws.config"
-      ]
+      "botocore": "config/2014-11-12/EventSource"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Config::ConfigRule.MaximumExecutionFrequency",
     "value": {
-      "AllowedValues": [
-        "One_Hour",
-        "Six_Hours",
-        "Three_Hours",
-        "Twelve_Hours",
-        "TwentyFour_Hours"
-      ]
+      "botocore": "config/2014-11-12/MaximumExecutionFrequency"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Config::ConfigRule.SourceDetail.MessageType",
     "value": {
-      "AllowedValues": [
-        "ConfigurationItemChangeNotification",
-        "ConfigurationSnapshotDeliveryCompleted",
-        "OversizedConfigurationItemChangeNotification",
-        "ScheduledNotification"
-      ]
+      "botocore": "config/2014-11-12/MessageType"
     }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_dynamodb.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_dynamodb.json
@@ -3,54 +3,35 @@
     "op": "add",
     "path": "/ValueTypes/AWS::DynamoDB::Table.AttributeDefinition.AttributeType",
     "value": {
-      "AllowedValues": [
-        "B",
-        "N",
-        "S"
-      ]
+      "botocore": "dynamodb/2012-08-10/ScalarAttributeType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::DynamoDB::Table.BillingMode",
     "value": {
-      "AllowedValues": [
-        "PAY_PER_REQUEST",
-        "PROVISIONED"
-      ]
+      "botocore": "dynamodb/2012-08-10/BillingMode"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::DynamoDB::Table.KeySchema.KeyType",
     "value": {
-      "AllowedValues": [
-        "HASH",
-        "RANGE"
-      ]
+      "botocore": "dynamodb/2012-08-10/KeyType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::DynamoDB::Table.Projection.ProjectionType",
     "value": {
-      "AllowedValues": [
-        "ALL",
-        "INCLUDE",
-        "KEYS_ONLY"
-      ]
+      "botocore": "dynamodb/2012-08-10/ProjectionType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::DynamoDB::Table.StreamSpecification.StreamViewType",
     "value": {
-      "AllowedValues": [
-        "KEYS_ONLY",
-        "NEW_AND_OLD_IMAGES",
-        "NEW_IMAGE",
-        "OLD_IMAGE"
-      ]
+      "botocore": "dynamodb/2012-08-10/StreamViewType"
     }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ec2.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_ec2.json
@@ -3,10 +3,7 @@
     "op": "add",
     "path": "/ValueTypes/AWS::EC2::Instance.Affinity",
     "value": {
-      "AllowedValues": [
-        "default",
-        "host"
-      ]
+      "botocore": "ec2/2016-11-15/Affinity"
     }
   },
   {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_glue.json
@@ -3,33 +3,21 @@
     "op": "add",
     "path": "/ValueTypes/AWS::Glue::Connection.ConnectionInput.ConnectionType",
     "value": {
-      "AllowedValues": [
-        "JDBC",
-        "KAFKA",
-        "MONGODB",
-        "SFTP"
-      ]
+      "botocore": "glue/2017-03-31/ConnectionType"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Glue::Crawler.SchemaChangePolicy.DeleteBehavior",
     "value": {
-      "AllowedValues": [
-        "DELETE_FROM_DATABASE",
-        "DEPRECATE_IN_DATABASE",
-        "LOG"
-      ]
+      "botocore": "glue/2017-03-31/DeleteBehavior"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Glue::Crawler.SchemaChangePolicy.UpdateBehavior",
     "value": {
-      "AllowedValues": [
-        "LOG",
-        "UPDATE_IN_DATABASE"
-      ]
+      "botocore": "glue/2017-03-31/UpdateBehavior"
     }
   },
   {
@@ -46,19 +34,14 @@
     "op": "add",
     "path": "/ValueTypes/AWS::Glue::Trigger.Predicate.Logical",
     "value": {
-      "AllowedValues": [
-        "AND",
-        "ANY"
-      ]
+      "botocore": "glue/2017-03-31/Logical"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::Glue::Trigger.Condition.LogicalOperator",
     "value": {
-      "AllowedValues": [
-        "EQUALS"
-      ]
+      "botocore": "glue/2017-03-31/LogicalOperator"
     }
   },
   {
@@ -77,11 +60,7 @@
     "op": "add",
     "path": "/ValueTypes/AWS::Glue::Trigger.Type",
     "value": {
-      "AllowedValues": [
-        "CONDITIONAL",
-        "ON_DEMAND",
-        "SCHEDULED"
-      ]
+      "botocore": "glue/2017-03-31/TriggerType"
     }
   },
   {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_guardduty.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_guardduty.json
@@ -3,32 +3,21 @@
     "op": "add",
     "path": "/ValueTypes/AWS::GuardDuty::Detector.FindingPublishingFrequency",
     "value": {
-      "AllowedValues": [
-        "FIFTEEN_MINUTES",
-        "ONE_HOUR",
-        "SIX_HOURS"
-      ]
+      "botocore": "guardduty/2017-11-28/FindingPublishingFrequency"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::GuardDuty::Filter.Action",
     "value": {
-      "AllowedValues": [
-        "ARCHIVE",
-        "NOOP"
-      ]
+      "botocore": "guardduty/2017-11-28/FilterAction"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::GuardDuty::IPSet.Format",
     "value": {
-      "AllowedValues": [
-        "OTX_CSV",
-        "STIX",
-        "TXT"
-      ]
+      "botocore": "guardduty/2017-11-28/IpSetFormat"
     }
   },
   {
@@ -49,14 +38,7 @@
     "op": "add",
     "path": "/ValueTypes/AWS::GuardDuty::ThreatIntelSet.Format",
     "value": {
-      "AllowedValues": [
-        "ALIEN_VAULT",
-        "FIRE_EYE",
-        "OTX_CSV",
-        "PROOF_POINT",
-        "STIX",
-        "TXT"
-      ]
+      "botocore": "guardduty/2017-11-28/ThreatIntelSetFormat"
     }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_iam.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_iam.json
@@ -36,10 +36,7 @@
     "op": "add",
     "path": "/ValueTypes/AWS::IAM::AccessKey.Active",
     "value": {
-      "AllowedValues": [
-        "Active",
-        "Inactive"
-      ]
+      "botocore": "iam/2010-05-08/statusType"
     }
   },
   {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_kinesisanalyticsv2.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_kinesisanalyticsv2.json
@@ -2,12 +2,8 @@
   {
     "op": "add",
     "path": "/ValueTypes/AWS::KinesisAnalyticsV2::Application.RuntimeEnvironment",
-    "value": { 
-      "AllowedValues": [ 
-        "FLINK-1_6", 
-        "FLINK-1_8",
-        "SQL-1_0" 
-      ] 
+    "value": {
+      "botocore": "kinesisanalyticsv2/2018-05-23/RuntimeEnvironment"
     } 
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_wafv2.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_wafv2.json
@@ -11,9 +11,7 @@
         "op": "add",
         "path": "/ValueTypes/AWS::WAFv2::RuleGroup.Rate.AggregateKeyType",
         "value": {
-            "AllowedValues": [
-                "IP"
-            ]
+            "botocore": "wafv2/2019-07-29/RateBasedStatementAggregateKeyType"
         }
     }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_workspace.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_workspace.json
@@ -3,23 +3,14 @@
     "op": "add",
     "path": "/ValueTypes/AWS::WorkSpaces::Workspace.RunningMode",
     "value": {
-      "AllowedValues": [
-        "ALWAYS_ON",
-        "AUTO_STOP"
-      ]
+      "botocore": "workspaces/2015-04-08/RunningMode"
     }
   },
   {
     "op": "add",
     "path": "/ValueTypes/AWS::WorkSpaces::Workspace.ComputeTypeName",
     "value": {
-      "AllowedValues": [
-        "GRAPHICS",
-        "PERFORMANCE",
-        "POWER",
-        "STANDARD",
-        "VALUE"
-      ]
+      "botocore": "workspaces/2015-04-08/Compute"
     }
   }
 ]

--- a/src/cfnlint/maintenance.py
+++ b/src/cfnlint/maintenance.py
@@ -59,15 +59,17 @@ def update_resource_spec(region, url):
         json.dump(spec, f, indent=2, sort_keys=True, separators=(',', ': '))
 
     lines = []
+    botocore_cache = {}
     with open(filename, 'r') as f:
         for line in f:
             if 'botocore' in line:
                 service_and_type = line.split('"')[3]
                 service = '/'.join(service_and_type.split('/')[:-1])
                 botocore_type = service_and_type.split('/')[-1]
-                r = json.loads(get_url_content('https://raw.githubusercontent.com/boto/botocore/master/botocore/data/' + service + '/service-2.json'))
+                if service not in botocore_cache:
+                    botocore_cache[service] = json.loads(get_url_content('https://raw.githubusercontent.com/boto/botocore/master/botocore/data/' + service + '/service-2.json'))
                 lines += '      "AllowedValues": [\n'
-                for value in sorted(r['shapes'][botocore_type]['enum']):
+                for value in sorted(botocore_cache[service]['shapes'][botocore_type]['enum']):
                     lines.append('        "' + value + '",\n')
                 lines[-1] = lines[-1].replace(',', '')
                 lines += '      ]\n'

--- a/src/cfnlint/maintenance.py
+++ b/src/cfnlint/maintenance.py
@@ -8,7 +8,6 @@ import logging
 import multiprocessing
 import os
 import jsonpatch
-import requests
 import cfnlint
 from cfnlint.helpers import get_url_content, url_has_newer_version
 from cfnlint.helpers import SPEC_REGIONS
@@ -66,7 +65,7 @@ def update_resource_spec(region, url):
                 service_and_type = line.split('"')[3]
                 service = '/'.join(service_and_type.split('/')[:-1])
                 botocore_type = service_and_type.split('/')[-1]
-                r = requests.get('https://raw.githubusercontent.com/boto/botocore/master/botocore/data/' + service + '/service-2.json').json()
+                r = json.loads(get_url_content('https://raw.githubusercontent.com/boto/botocore/master/botocore/data/' + service + '/service-2.json'))
                 lines += '      "AllowedValues": [\n'
                 for value in sorted(r['shapes'][botocore_type]['enum']):
                     lines.append('        "' + value + '",\n')


### PR DESCRIPTION
most commonly maintained [concise constraint format](https://github.com/aws-cloudformation/cfn-python-lint/issues/903#issuecomment-595356853) last time I checked:
```
src/cfnlint/data/ExtendedSpecs/all $ git grep 'AllowedValues":' | wc -l
AllowedValues: 187 # only 42 hardcoded AllowedValues remaining after this PR
NumberMin/NumberMax: 46
AllowedPatternRegex: 12
StringMin/StringMax: 8
ListMin/ListMax: 4
JsonMax: 2
```

https://github.com/aws-cloudformation/cfn-python-lint/issues/50#issuecomment-668265454

---

[`CloudSpecs`](https://github.com/aws-cloudformation/cfn-python-lint/tree/master/src/cfnlint/data/CloudSpecs) is autogenerated by [`cfn-lint --update-specs`](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/src/cfnlint/maintenance.py#L21)

---

`AllowedValues` were hardcoded in [`ExtendedSpecs/all`](https://github.com/aws-cloudformation/cfn-python-lint/tree/master/src/cfnlint/data/ExtendedSpecs/all) and patched into all the [Resource Specifications](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) in [`CloudSpecs`](https://github.com/aws-cloudformation/cfn-python-lint/tree/master/src/cfnlint/data/CloudSpecs) when `cfn-lint --update-specs` was run. Now they're references to botocore types in [`ExtendedSpecs/all`](https://github.com/aws-cloudformation/cfn-python-lint/tree/master/src/cfnlint/data/ExtendedSpecs/all) and `cfn-lint --update-specs` pulls from botocore directly to write that part of [`CloudSpecs`](https://github.com/aws-cloudformation/cfn-python-lint/tree/master/src/cfnlint/data/CloudSpecs)

---

[`AWS::WorkSpaces::Workspace.ComputeTypeName`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-workspaces-workspace-workspaceproperties.html#cfn-workspaces-workspace-workspaceproperties-computetypename
) should pick up [`POWERPRO` and `GRAPHICSPRO`](https://github.com/boto/botocore/blob/ae2d0855ac3162520e584a24f5522b633de4e2a9/botocore/data/workspaces/2015-04-08/service-2.json#L822-L823)

[`AWS::CodeBuild::Project.Environment.Type`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-environment.html#cfn-codebuild-project-environment-type) should pick up [`WINDOWS_SERVER_2019_CONTAINER`](https://github.com/boto/botocore/blob/ae2d0855ac3162520e584a24f5522b633de4e2a9/botocore/data/codebuild/2016-10-06/service-2.json#L1873)


[`AWS::S3::Bucket.TopicConfiguration.Event`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-notificationconfig-topicconfig.html#cfn-s3-bucket-notificationconfig-topicconfig-event) should pick up [`s3:ObjectRestore:*` and `s3:Replication:*`](https://github.com/boto/botocore/blob/ae2d0855ac3162520e584a24f5522b633de4e2a9/botocore/data/s3/2006-03-01/service-2.json#L2887-L2890)

[`EbsVolumeType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-ebs-volume.html#cfn-ec2-ebs-volume-volumetype) should pick up [`io2`](https://aws.amazon.com/blogs/aws/new-ebs-volume-type-io2-more-iops-gib-higher-durability/) from [here](https://raw.githubusercontent.com/boto/botocore/master/botocore/data/ec2/2016-11-15/service-2.json)

[`AWS::GuardDuty::IPSet.Format`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-guardduty-ipset.html#cfn-guardduty-ipset-format) should pick up [`ALIEN_VAULT` and `PROOF_POINT` and `FIRE_EYE`](https://github.com/boto/botocore/blob/ae2d0855ac3162520e584a24f5522b633de4e2a9/botocore/data/guardduty/2017-11-28/service-2.json#L3130-L3132)

[`AWS::CodeBuild::Project.Environment.ComputeType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-environment.html#cfn-codebuild-project-environment-computetype) should pick up [`BUILD_GENERAL1_2XLARGE`](https://github.com/boto/botocore/blob/16958153b1e01dcbf5d4334394a14715438b53f1/botocore/data/codebuild/2016-10-06/service-2.json#L1413)

[`AWS::CloudFront::Distribution.SslSupportMethod`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-viewercertificate.html#cfn-cloudfront-distribution-viewercertificate-sslsupportmethod) should pick up [`static-ip`](https://github.com/boto/botocore/blob/ae2d0855ac3162520e584a24f5522b633de4e2a9/botocore/data/cloudfront/2020-05-31/service-2.json#L6101)

[`AWS::WAFv2::RuleGroup.Rate.AggregateKeyType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-rulegroup-ratebasedstatementone.html#cfn-wafv2-rulegroup-ratebasedstatementone-aggregatekeytype) should pick up [`FORWARDED_IP`](https://github.com/boto/botocore/blob/b9b494aac2a0dc03433a8cda711d3dfabb4e5b45/botocore/data/wafv2/2019-07-29/service-2.json#L2715)

[`AWS::Glue::Connection.ConnectionInput.ConnectionType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-connection-connectioninput.html#cfn-glue-connection-connectioninput-connectiontype) picks up [`NETWORK`](https://github.com/boto/botocore/blob/ae2d0855ac3162520e584a24f5522b633de4e2a9/botocore/data/glue/2017-03-31/service-2.json#L3372)

[`AWS::EC2::LaunchTemplate.TagSpecification.ResourceType`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-tagspecification.html#cfn-ec2-launchtemplate-tagspecification-resourcetype) should pick up [42 values](https://raw.githubusercontent.com/boto/botocore/master/botocore/data/ec2/2016-11-15/service-2.json)