### PR TITLE
expanding templated_exceptions property types that require package command (E3002/W3002)

### DIFF
--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -177,11 +177,11 @@ class Properties(CloudFormationLintRule):
             - Start with handling exceptions for templated code.
         """
         templated_exceptions = {
-            'AWS::ApiGateway::RestApi': ['BodyS3Location'],
+            'AWS::ApiGateway::RestApi': ['S3Location'],
             'AWS::Lambda::Function': ['Code'],
             'AWS::Lambda::LayerVersion': ['Content'],
             'AWS::ElasticBeanstalk::ApplicationVersion': ['SourceBundle'],
-            'AWS::StepFunctions::StateMachine': ['DefinitionS3Location'],
+            'AWS::StepFunctions::StateMachine': ['S3Location'],
         }
 
         exceptions = templated_exceptions.get(parenttype, [])

--- a/src/cfnlint/rules/resources/properties/Properties.py
+++ b/src/cfnlint/rules/resources/properties/Properties.py
@@ -181,6 +181,7 @@ class Properties(CloudFormationLintRule):
             'AWS::Lambda::Function': ['Code'],
             'AWS::Lambda::LayerVersion': ['Content'],
             'AWS::ElasticBeanstalk::ApplicationVersion': ['SourceBundle'],
+            'AWS::StepFunctions::StateMachine': ['DefinitionS3Location'],
         }
 
         exceptions = templated_exceptions.get(parenttype, [])

--- a/src/cfnlint/rules/resources/properties/PropertiesTemplated.py
+++ b/src/cfnlint/rules/resources/properties/PropertiesTemplated.py
@@ -22,7 +22,9 @@ class PropertiesTemplated(CloudFormationLintRule):
         self.resource_property_types.extend([
             'AWS::ApiGateway::RestApi',
             'AWS::Lambda::Function',
+            'AWS::Lambda::LayerVersion',
             'AWS::ElasticBeanstalk::ApplicationVersion',
+            'AWS::StepFunctions::StateMachine',
         ])
 
     def check_value(self, value, path):
@@ -44,6 +46,7 @@ class PropertiesTemplated(CloudFormationLintRule):
             'AWS::Lambda::Function': ['Code'],
             'AWS::Lambda::LayerVersion': ['Content'],
             'AWS::ElasticBeanstalk::ApplicationVersion': ['SourceBundle'],
+            'AWS::StepFunctions::StateMachine': ['DefinitionS3Location'],
         }
 
         for key in templated_exceptions.get(resourcetype, []):


### PR DESCRIPTION
fixes https://github.com/aws-cloudformation/cfn-python-lint/issues/1683

According to https://github.com/aws-cloudformation/cfn-python-lint/issues/608, this [documentation seems incomplete](https://docs.aws.amazon.com/cli/latest/reference/cloudformation/package.html), so I used [this as the source instead](https://github.com/aws/aws-cli/blob/master/awscli/customizations/cloudformation/artifact_exporter.py)

---

these other property types were already `String`:

```python
            'AWS::AppSync::FunctionConfiguration': ['RequestMappingTemplateS3Location', 'ResponseMappingTemplateS3Location'],
            'AWS::AppSync::GraphQLSchema': ['DefinitionS3Location'],
            'AWS::AppSync::Resolver': ['RequestMappingTemplateS3Location', 'ResponseMappingTemplateS3Location'],
            'AWS::CloudFormation::Stack': ['TemplateURL'],
            'AWS::Glue::Job': ['Command.ScriptLocation'],  # not sure about this syntax
```

---

Test template:

```yaml
Resources:
  StateMachine:
    Type: AWS::StepFunctions::StateMachine
    Properties:
      RoleArn: RoleArn
      DefinitionS3Location: file
  LayerVersion:
    Type: AWS::Lambda::LayerVersion
    Properties:
      Content: file
  RestApi:
    Type: AWS::ApiGateway::RestApi
    Properties:
      BodyS3Location: file
```

---

@kddejong any way this section can use `templated_exceptions` keys as well?

https://github.com/aws-cloudformation/cfn-python-lint/blob/df4b7bc463d301b638f0e0274ed0e41d37239092/src/cfnlint/rules/resources/properties/PropertiesTemplated.py#L34-L38