### PR TITLE
AWS::Config::ConfigRule.Description length

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_config.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_config.json
@@ -143,5 +143,13 @@
         "ScheduledNotification"
       ]
     }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::Config::ConfigRule.Description",
+    "value": {
+      "StringMax": 256,
+      "StringMin": 1
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_config.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_config.json
@@ -43,7 +43,7 @@
   },
   {
     "op": "add",
-    "path": "/PropertyTypes/AWS::Config::ConfigRule/Properties/Description/Value",
+    "path": "/ResourceTypes/AWS::Config::ConfigRule/Properties/Description/Value",
     "value": {
       "ValueType": "AWS::Config::ConfigRule.Description"
     }

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_config.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_config.json
@@ -43,6 +43,13 @@
   },
   {
     "op": "add",
+    "path": "/PropertyTypes/AWS::Config::ConfigRule/Properties/Description/Value",
+    "value": {
+      "ValueType": "AWS::Config::ConfigRule.Description"
+    }
+  },
+  {
+    "op": "add",
     "path": "/PropertyTypes/AWS::Config::ConfigurationRecorder.RecordingGroup/Properties/ResourceTypes/Value",
     "value": {
       "ValueType": "AWS::Config::ConfigurationRecorder.ResourceTypes"


### PR DESCRIPTION
fixes #1710

*Description of changes:*
Adding validation to ConfigRule.Description length
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-config-configrule.html#cfn-config-configrule-description

```
Minimum: 0
Maximum: 256
```

Maybe this should be set to 0, but I saw `StringMin: 1` and assumed this
was fine.

example template:
```yaml
AWSTemplateFormatVersion: "2010-09-09"

Resources:
  AccessKeysRotatedConfigRule:
    Type: "AWS::Config::ConfigRule"
    Properties:
      ConfigRuleName: InfoSecAccessKeysRotated
      Description: |
        This is a test on longer description This is a test on longer description This is a test on longer description This is a test on longer description This is a test on longer description This is a test on longer description This is a test on longer description This is a test on longer description This is a test on longer description This is a test on longer description This is a test on longer description This is a test on longer description This is a test on longer description This is a test on longer description This is a test on longer description This is a test on longer description This is a test on longer description.
      InputParameters:
        maxAccessKeyAge: 90
      MaximumExecutionFrequency: One_Hour
      Source:
        Owner: AWS
        SourceIdentifier: ACCESS_KEYS_ROTATED
```

@PatMyron note, this is still not currently working. I may have incorrectly defined the path for the config rule. This can be marked as a draft if desired.

Thanks for working with me on this.