### PR TITLE
Fix only one property check to handle Ref AWS::NoValue

### DIFF
--- a/src/cfnlint/decode/node.py
+++ b/src/cfnlint/decode/node.py
@@ -140,6 +140,17 @@ def create_dict_node_class(cls):
 
             return results
 
+        def clean(self):
+            """Clean object to remove any Ref AWS::NoValue"""
+            result = dict_node({}, self.start_mark, self.end_mark)
+            for k, v in self.items():
+                if isinstance(v, dict) and len(v) == 1:
+                    if v.get('Ref') == 'AWS::NoValue':
+                        continue
+                result[k] = v
+            return result
+
+
         def items_safe(self, path=None, type_t=()):
             """Get items while handling IFs"""
             path = path or []
@@ -163,10 +174,10 @@ def create_dict_node_class(cls):
                                             yield if_v, path[:] + [k, i + 1]
                     elif not (k == 'Ref' and v == 'AWS::NoValue'):
                         if isinstance(self, type_t) or not type_t:
-                            yield self, path[:]
+                            yield self.clean(), path[:]
             else:
                 if isinstance(self, type_t) or not type_t:
-                    yield self, path[:]
+                    yield self.clean(), path[:]
 
         def __getattr__(self, name):
             raise TemplateAttributeError('%s.%s is invalid' % (self.__class__.__name__, name))

--- a/src/cfnlint/rules/resources/properties/OnlyOne.py
+++ b/src/cfnlint/rules/resources/properties/OnlyOne.py
@@ -39,8 +39,13 @@ class OnlyOne(CloudFormationLintRule):
                 for property_set in property_sets:
                     count = 0
                     for prop in onlyoneprop:
-                        if prop in property_set['Object']:
-                            count += 1
+                        obj = property_set['Object']
+                        if prop in obj:
+                            if isinstance(obj.get(prop), dict) and len(obj.get(prop)) == 1:
+                                if not ('Ref' in obj.get(prop) and obj.get(prop).get('Ref') == 'AWS::NoValue'):
+                                    count += 1
+                            else:
+                                count += 1
 
                     if count != 1:
                         if property_set['Scenario'] is None:

--- a/src/cfnlint/rules/resources/properties/OnlyOne.py
+++ b/src/cfnlint/rules/resources/properties/OnlyOne.py
@@ -39,13 +39,8 @@ class OnlyOne(CloudFormationLintRule):
                 for property_set in property_sets:
                     count = 0
                     for prop in onlyoneprop:
-                        obj = property_set['Object']
-                        if prop in obj:
-                            if isinstance(obj.get(prop), dict) and len(obj.get(prop)) == 1:
-                                if not ('Ref' in obj.get(prop) and obj.get(prop).get('Ref') == 'AWS::NoValue'):
-                                    count += 1
-                            else:
-                                count += 1
+                        if prop in property_set['Object']:
+                            count += 1
 
                     if count != 1:
                         if property_set['Scenario'] is None:

--- a/test/fixtures/templates/good/resources/properties/onlyone.yaml
+++ b/test/fixtures/templates/good/resources/properties/onlyone.yaml
@@ -1,0 +1,8 @@
+Resources:
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      SubnetMappings:
+          - SubnetId: subnet-abc1234
+          - SubnetId: subnet-def1234
+      Subnets: !Ref AWS::NoValue

--- a/test/unit/rules/resources/properties/test_onlyone.py
+++ b/test/unit/rules/resources/properties/test_onlyone.py
@@ -13,6 +13,9 @@ class TestPropertyOnlyOne(BaseRuleTestCase):
         """Setup"""
         super(TestPropertyOnlyOne, self).setUp()
         self.collection.register(OnlyOne())
+        self.success_templates = [
+            'test/fixtures/templates/good/resources/properties/onlyone.yaml'
+        ]
 
     def test_file_positive(self):
         """Test Positive"""


### PR DESCRIPTION
*Issue #, if available:*
#1043 
*Description of changes:*
- Fix onlyone check to handle when Ref: AWS::NoValue

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
