### PR TITLE
Update E2521 to better handle Ref AWS::NoValue

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/Inclusive.json
+++ b/src/cfnlint/data/AdditionalSpecs/Inclusive.json
@@ -12,22 +12,6 @@
       "IamCertificateId": [
         "SslSupportMethod"
       ]
-    },
-    "AWS::EC2::SecurityGroup.Ingress": {
-      "FromPort": [
-        "ToPort"
-      ],
-      "ToPort": [
-        "FromPort"
-      ]
-    },
-    "AWS::EC2::SecurityGroup.Egress": {
-      "FromPort": [
-        "ToPort"
-      ],
-      "ToPort": [
-        "FromPort"
-      ]
     }
   },
   "ResourceTypes": {
@@ -65,30 +49,11 @@
       "VpcId": [
         "DefaultSubnetId"
       ]
+    },
+    "AWS::EC2::SecurityGroup": {
+      "SecurityGroupEgress": [
+        "VpcId"
+      ]
     }
-  },
-  "AWS::EC2::SecurityGroup": {
-    "SecurityGroupEgress": [
-      "VpcId"
-    ],
-    "VpcId": [
-      "SecurityGroupEgress"
-    ]
-  },
-  "AWS::EC2::SecurityGroupIngress": {
-    "FromPort": [
-      "ToPort"
-    ],
-    "ToPort": [
-      "FromPort"
-    ]
-  },
-  "AWS::EC2::SecurityGroupEgress": {
-    "FromPort": [
-      "ToPort"
-    ],
-    "ToPort": [
-      "FromPort"
-    ]
   }
 }

--- a/src/cfnlint/rules/resources/properties/Inclusive.py
+++ b/src/cfnlint/rules/resources/properties/Inclusive.py
@@ -35,10 +35,11 @@ class Inclusive(CloudFormationLintRule):
 
         property_sets = cfn.get_object_without_conditions(properties)
         for property_set in property_sets:
-            for prop in property_set['Object']:
+            obj = property_set['Object'].clean()
+            for prop in obj:
                 if prop in inclusions:
                     for incl_property in inclusions[prop]:
-                        if incl_property not in property_set['Object']:
+                        if incl_property not in obj:
                             if property_set['Scenario'] is None:
                                 message = 'Property {0} should exist with {1} for {2}'
                                 matches.append(RuleMatch(

--- a/test/fixtures/templates/bad/resources/properties/inclusive.yaml
+++ b/test/fixtures/templates/bad/resources/properties/inclusive.yaml
@@ -20,3 +20,11 @@ Resources:
       - MasterUsername: admin
         MasterUserPassword: test
         Engine: test
+  LoadBalancer:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: Test
+      ScalableDimension: Test
+      ResourceId: Id
+      PolicyType: StepScaling
+      ServiceNamespace: !Ref 'AWS::NoValue'

--- a/test/fixtures/templates/good/resources/properties/inclusive.yaml
+++ b/test/fixtures/templates/good/resources/properties/inclusive.yaml
@@ -1,0 +1,9 @@
+Resources:
+  LoadBalancer:
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: Test
+      ScalableDimension: Test
+      ResourceId: Id
+      PolicyType: StepScaling
+      ServiceNamespace: Test

--- a/test/unit/rules/resources/properties/test_inclusive.py
+++ b/test/unit/rules/resources/properties/test_inclusive.py
@@ -13,6 +13,9 @@ class TestPropertyInclusive(BaseRuleTestCase):
         """Setup"""
         super(TestPropertyInclusive, self).setUp()
         self.collection.register(Inclusive())
+        self.success_templates = [
+            'test/fixtures/templates/good/resources/properties/inclusive.yaml'
+        ]
 
     def test_file_positive(self):
         """Test Positive"""
@@ -21,4 +24,4 @@ class TestPropertyInclusive(BaseRuleTestCase):
     def test_file_negative(self):
         """Test failure"""
         self.helper_file_negative(
-            'test/fixtures/templates/bad/resources/properties/inclusive.yaml', 2)
+            'test/fixtures/templates/bad/resources/properties/inclusive.yaml', 4)


### PR DESCRIPTION
*Issue #, if available:*
#1043

*Description of changes:*
- Update rule E2521 to do better handling of Ref [`AWS::NoValue`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-novalue)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
