### PR TITLE
Update E2520 to handle Ref AWS::NoValue

### DIFF
--- a/src/cfnlint/rules/resources/properties/Exclusive.py
+++ b/src/cfnlint/rules/resources/properties/Exclusive.py
@@ -33,10 +33,11 @@ class Exclusive(CloudFormationLintRule):
 
         property_sets = cfn.get_object_without_conditions(properties)
         for property_set in property_sets:
-            for prop in property_set['Object']:
+            obj = property_set['Object'].clean()
+            for prop in obj:
                 if prop in exclusions:
                     for excl_property in exclusions[prop]:
-                        if excl_property in property_set['Object']:
+                        if excl_property in obj:
                             if property_set['Scenario'] is None:
                                 message = 'Property {0} should NOT exist with {1} for {2}'
                                 matches.append(RuleMatch(

--- a/test/fixtures/templates/bad/resources/properties/exclusive.yaml
+++ b/test/fixtures/templates/bad/resources/properties/exclusive.yaml
@@ -25,3 +25,10 @@ Resources:
           DeviceIndex: String
       - ImageId: ami-123456
         SubnetId: subnet-123456
+  Ingress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      SourceSecurityGroupId: sg-abc12345
+      CidrIp: 10.0.0.0/24
+      IpProtocol: "-1"
+      GroupId: sg-abc1234567

--- a/test/fixtures/templates/good/resources/properties/exclusive.yaml
+++ b/test/fixtures/templates/good/resources/properties/exclusive.yaml
@@ -1,0 +1,8 @@
+Resources:
+  Ingress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      SourceSecurityGroupId: sg-abc12345
+      CidrIp: !Ref AWS::NoValue
+      IpProtocol: "-1"
+      GroupId: sg-abc1234567

--- a/test/unit/rules/resources/properties/test_exclusive.py
+++ b/test/unit/rules/resources/properties/test_exclusive.py
@@ -21,4 +21,4 @@ class TestPropertyExclusive(BaseRuleTestCase):
     def test_file_negative(self):
         """Test failure"""
         self.helper_file_negative(
-            'test/fixtures/templates/bad/resources/properties/exclusive.yaml', 2)
+            'test/fixtures/templates/bad/resources/properties/exclusive.yaml', 3)


### PR DESCRIPTION
*Issue #, if available:*
#1043 
*Description of changes:*
- Update rule E2520 to better handle Ref [`AWS::NoValue`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-novalue)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
