### PR TITLE
AWS::DMS::Endpoint.EngineName AllowedValues expansion (neptune)

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -67,6 +67,7 @@
           "mariadb",
           "mongodb",
           "mysql",
+          "neptune",
           "oracle",
           "postgres",
           "redshift",


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/issues/50
https://github.com/aws-cloudformation/cfn-python-lint/pull/1472, https://github.com/aws-cloudformation/cfn-python-lint/pull/1473
[`AWS::DMS::Endpoint.EngineName`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-endpoint.html#cfn-dms-endpoint-enginename)

one of the few AllowedValues lists left to actively maintain:
https://github.com/aws-cloudformation/cfn-python-lint/pull/1682