### PR TITLE
ap-northeast-2d availability zone

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -83,7 +83,7 @@ AVAILABILITY_ZONES = [
     'af-south-1a', 'af-south-1b', 'af-south-1c',
     'ap-east-1a', 'ap-east-1b', 'ap-east-1c',
     'ap-northeast-1a', 'ap-northeast-1b', 'ap-northeast-1c', 'ap-northeast-1d',
-    'ap-northeast-2a', 'ap-northeast-2b', 'ap-northeast-2c',
+    'ap-northeast-2a', 'ap-northeast-2b', 'ap-northeast-2c', 'ap-northeast-2d',
     'ap-northeast-3a',
     'ap-south-1a', 'ap-south-1b', 'ap-south-1c',
     'ap-southeast-1a', 'ap-southeast-1b', 'ap-southeast-1c',


### PR DESCRIPTION
https://aws.amazon.com/blogs/aws/now-open-fourth-availability-zone-in-the-aws-asia-pacific-seoul-region/
https://aws.amazon.com/blogs/aws/category/regions/

```shell
aws ec2 describe-regions | pcregrep -o1 '"RegionName": "(.*)"' | xargs -L1 bash -c 'aws ec2 describe-availability-zones --region $0 | grep "ZoneName"'
            "ZoneName": "ap-northeast-2a",
            "ZoneName": "ap-northeast-2b",
            "ZoneName": "ap-northeast-2c",
            "ZoneName": "ap-northeast-2d",
```

---

similar to previous https://github.com/aws-cloudformation/cfn-python-lint/pull/1447, https://github.com/aws-cloudformation/cfn-python-lint/pull/1241, https://github.com/aws-cloudformation/cfn-python-lint/pull/1070, https://github.com/aws-cloudformation/cfn-python-lint/pull/1052, https://github.com/aws-cloudformation/cfn-python-lint/pull/1021