### PR TITLE
AWS::CloudFormation::StackSet.PermissionModel AllowedValues from botocore

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloudformation.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_cloudformation.json
@@ -6,5 +6,12 @@
       "NumberMax": 43200,
       "NumberMin": 0
     }
+  },
+  {
+    "op": "add",
+    "path": "/ValueTypes/AWS::CloudFormation::StackSet.PermissionModel",
+    "value": {
+      "botocore": "cloudformation/2010-05-15/PermissionModels"
+    }
   }
 ]

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_cloudformation.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_cloudformation.json
@@ -5,5 +5,12 @@
     "value": {
       "ValueType": "AWS::CloudFormation::WaitCondition.Timeout"
     }
+  },
+    {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::CloudFormation::StackSet/Properties/PermissionModel/Value",
+    "value": {
+      "ValueType": "AWS::CloudFormation::StackSet.PermissionModel"
+    }
   }
 ]


### PR DESCRIPTION
fixes https://github.com/aws-cloudformation/cfn-python-lint/issues/1740
https://github.com/aws-cloudformation/cfn-python-lint/pull/1682
[`AWS::CloudFormation::StackSet.PermissionModel`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudformation-stackset.html#cfn-cloudformation-stackset-permissionmodel) from [`botocore`](https://github.com/boto/botocore/blob/048bf67ffbd76b451b3a3f8673fc1a2369e01c39/botocore/data/cloudformation/2010-05-15/service-2.json#L3216)

```bash
E3030 You must specify a valid value for PermissionModel (SELF-MANAGED).
Valid values are ["SELF_MANAGED", "SERVICE_MANAGED"]
```