### PR TITLE
Colored Output and Pretty Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ Lint all `yaml` files in `path` and all subdirectories (recursive):
 
 *Note*: Glob in Python 3.5 supports recursive searching `**/*.yaml`.  If you are using an earlier version of Python you will have to handle this manually (`folder1/*.yaml`, `folder2/*.yaml`, etc).
 
+##### Exit Codes
+`cfn-lint` will return a non zero exit if there are any issues with your template. The value is dependent on the sevirity of the issues found.  For each level of discovered error `cfn-lint` will use bitwise OR to determine the final exit code.  This will result in these possibilities.
+
+- 0 is no issue was found
+- 2 is an error
+- 4 is a warning
+- 6 is an error and a warning
+- 8 is an informational
+- 10 is an error and informational
+- 12 is an warning and informational
+- 14 is an error and a warning and an informational
+
 ##### Specifying the template as an input stream
 
 The template to be linted can also be passed using standard input:
@@ -138,7 +150,7 @@ Optional parameters:
 | ------------- | ------------- | ------------- | ------------- |
 | -h, --help  |   | | Get description of cfn-lint |
 | -t, --template  |   | filename | Alternative way to specify Template file path to the file that needs to be tested by cfn-lint |
-| -f, --format    | format | quiet, parseable, json, junit | Output format |
+| -f, --format    | format | quiet, parseable, json, junit, pretty | Output format |
 | -l, --list-rules | | | List all the rules |
 | -r, --regions | regions | [REGIONS [REGIONS ...]], ALL_REGIONS  | Test the template against many regions.  [Supported regions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-resource-specification.html) |
 | -b, --ignore-bad-template | ignore_bad_template | | Ignores bad template errors |

--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -19,6 +19,8 @@ from cfnlint.rules import TransformError as _TransformError
 from cfnlint.rules import RuleError as _RuleError
 from cfnlint.runner import Runner as _Runner
 from cfnlint.template import Template as _Template
+
+
 from cfnlint.decode.node import dict_node
 import cfnlint.rules
 

--- a/src/cfnlint/__init__.py
+++ b/src/cfnlint/__init__.py
@@ -19,8 +19,6 @@ from cfnlint.rules import TransformError as _TransformError
 from cfnlint.rules import RuleError as _RuleError
 from cfnlint.runner import Runner as _Runner
 from cfnlint.template import Template as _Template
-
-
 from cfnlint.decode.node import dict_node
 import cfnlint.rules
 

--- a/src/cfnlint/__main__.py
+++ b/src/cfnlint/__main__.py
@@ -38,7 +38,7 @@ def main():
                 matches.extend(errors)
             LOGGER.debug('Completed linting of file: %s', str(filename))
 
-        matches_output = formatter.print_matches(matches, rules)
+        matches_output = formatter.print_matches(matches, rules, filenames)
 
         if matches_output:
             if args.output_file:

--- a/src/cfnlint/config.py
+++ b/src/cfnlint/config.py
@@ -354,7 +354,7 @@ class CliArgs(object):
             '-I', '--info', help='Enable information logging', action='store_true'
         )
         standard.add_argument(
-            '-f', '--format', help='Output Format', choices=['quiet', 'parseable', 'json', 'junit']
+            '-f', '--format', help='Output Format', choices=['quiet', 'parseable', 'json', 'junit', 'pretty']
         )
 
         standard.add_argument(

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -56,11 +56,11 @@ def get_exit_code(matches):
     """ Determine exit code """
     exit_code = 0
     for match in matches:
-        if match.rule.id[0] == 'I':
+        if match.rule.severity == 'informational':
             exit_code = exit_code | 8
-        elif match.rule.id[0] == 'W':
+        elif match.rule.severity == 'warning':
             exit_code = exit_code | 4
-        elif match.rule.id[0] == 'E':
+        elif match.rule.severity == 'error':
             exit_code = exit_code | 2
 
     return exit_code
@@ -79,11 +79,10 @@ def get_formatter(fmt):
             formatter = cfnlint.formatters.JsonFormatter()
         elif fmt == 'junit':
             formatter = cfnlint.formatters.JUnitFormatter()
-    else:
-        if sys.stdout.isatty():
+        elif fmt == 'pretty':
             formatter = cfnlint.formatters.PrettyFormatter()
-        else:
-            formatter = cfnlint.formatters.Formatter()
+    else:
+        formatter = cfnlint.formatters.Formatter()
 
     return formatter
 

--- a/src/cfnlint/core.py
+++ b/src/cfnlint/core.py
@@ -80,7 +80,10 @@ def get_formatter(fmt):
         elif fmt == 'junit':
             formatter = cfnlint.formatters.JUnitFormatter()
     else:
-        formatter = cfnlint.formatters.Formatter()
+        if sys.stdout.isatty():
+            formatter = cfnlint.formatters.PrettyFormatter()
+        else:
+            formatter = cfnlint.formatters.Formatter()
 
     return formatter
 

--- a/src/cfnlint/formatters/__init__.py
+++ b/src/cfnlint/formatters/__init__.py
@@ -17,16 +17,17 @@ class color(object):
     unknown = '\033[37m'
     green = '\033[32m'
     reset = '\033[0m'
-    bold_green = '\033[1;32m'
     bold_reset = '\033[1:0m'
+    underline_reset = '\033[4m'
 
 
 def colored(s, c):
     """ Takes in string s and outputs it with color """
     if sys.stdout.isatty():
         return '{}{}{}'.format(c, s, color.reset)
-    else:
-        return s
+
+    return s
+
 
 class BaseFormatter(object):
     """Base Formatter class"""
@@ -194,11 +195,11 @@ class PrettyFormatter(BaseFormatter):
 
     def _format(self, match):
         """Format output"""
-        formatstr = '{0}:{1}:\t\t{2}\t{3}'
+        formatstr = '{0}{1}{2}'
+        pos = '{0}:{1}:'.format(match.linenumber, match.columnnumber)
         return formatstr.format(
-            colored(match.linenumber, color.green),
-            colored(match.columnnumber, color.green),
-            colored(match.rule.id, getattr(color, match.rule.severity.lower())),
+            colored('{:20}'.format(pos), color.reset),
+            colored('{:10}'.format(match.rule.id), getattr(color, match.rule.severity.lower())),
             match.message,
         )
 
@@ -210,7 +211,8 @@ class PrettyFormatter(BaseFormatter):
             colored(len(rules), color.bold_reset),
             colored(len([i for i in matches if i.rule.severity.lower() == 'error']), color.error),
             colored(len([i for i in matches if i.rule.severity.lower() == 'warning']), color.warning),
-            colored(len([i for i in matches if i.rule.severity.lower() == 'informational']), color.informational),
+            colored(len([i for i in matches if i.rule.severity.lower()
+                         == 'informational']), color.informational),
         ))
         return '\n'.join(results)
 
@@ -229,10 +231,8 @@ class PrettyFormatter(BaseFormatter):
                 'informational': [],
                 'unknown': []
             }
-            if sys.stdout.isatty():
-                output.append(colored(filename, color.bold_green))
-            else:
-                output.append(filename)
+
+            output.append(colored(filename, color.underline_reset))
             for match in file_matches:
                 level = match.rule.severity.lower()
                 if level not in ['error', 'warning', 'informational']:

--- a/src/cfnlint/rules/__init__.py
+++ b/src/cfnlint/rules/__init__.py
@@ -16,7 +16,6 @@ LOGGER = logging.getLogger(__name__)
 
 class CloudFormationLintRule(object):
     """CloudFormation linter rules"""
-
     id = ''
     shortdesc = ''
     description = ''
@@ -34,6 +33,16 @@ class CloudFormationLintRule(object):
 
     def __repr__(self):
         return '%s: %s' % (self.id, self.shortdesc)
+
+    @property
+    def severity(self):
+        """Severity level"""
+        levels = {
+            'I': 'informational',
+            'E': 'error',
+            'W': 'warning',
+        }
+        return levels.get(self.id[0].upper(), 'unknown')
 
     def verbose(self):
         """Verbose output"""


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/cfn-python-lint/issues/971

*Description of changes:*
- Add pretty formatter that groups outputs by file name and adds color for terminals that support ansi

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
