### PR TITLE
Subscription filters now support 2

### DIFF
--- a/src/cfnlint/rules/resources/lmbd/EventsLogGroupName.py
+++ b/src/cfnlint/rules/resources/lmbd/EventsLogGroupName.py
@@ -2,6 +2,7 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
+import json
 from cfnlint.rules import CloudFormationLintRule
 from cfnlint.rules import RuleMatch
 
@@ -9,45 +10,41 @@ from cfnlint.rules import RuleMatch
 class EventsLogGroupName(CloudFormationLintRule):
     """Check if the settings of multiple subscriptions are included for one LogGroup"""
     id = 'E2529'
-    shortdesc = 'Check for duplicate Lambda events'
-    description = 'Check if there are any duplicate log groups in the Lambda event trigger element.'
+    shortdesc = 'Check for SubscriptionFilters have beyond 2 attachments to a CloudWatch Log Group'
+    description = 'The current limit for a CloudWatch Log Group is they can have 2 subscription filters. ' \
+        'We will look for duplicate LogGroupNames inside Subscription Filters and make sure they are within 2. ' \
+        'This doesn\'t account for any other subscription filters getting set.'
     source_url = 'https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#user-content-cloudwatchlogs'
     tags = ['resources', 'lambda']
+    limit = 2
 
     def check_events_subscription_duplicated(self, cfn):
         """Check if Lambda Events Subscription is duplicated"""
         matches = []
-        message = 'You must specify the AWS::Serverless::Function event correctly. ' \
-                  'LogGroups are duplicated. '
+        message = 'You can only have {} Subscription Filters per CloudWatch Log Group'.format(self.limit)
 
-        log_group_name_list = self.__get_log_group_name_list(cfn)
-
-        if self.__is_duplicated(log_group_name_list):
-            matches.append(
-                RuleMatch(
-                    'path', message.format()
+        log_group_paths = self.__get_log_group_name_list(cfn)
+        for _, c in log_group_paths.items():
+            if len(c) > self.limit:
+                matches.append(
+                    RuleMatch(
+                        ['Resources', c[2]], message.format()
+                    )
                 )
-            )
 
         return matches
 
-    def __is_duplicated(self, duplicate_list):
-        unique_list = self.__remove(duplicate_list)
-        return len(unique_list) != len(duplicate_list)
-
-    def __remove(self, duplicate):
-        final_list = []
-        for ele in duplicate:
-            if ele not in final_list:
-                final_list.append(ele)
-        return final_list
-
     def __get_log_group_name_list(self, cfn):
-        log_group_name_list = []
+        log_group_paths = {}
         for value in cfn.get_resources('AWS::Logs::SubscriptionFilter').items():
             prop = value[1].get('Properties')
-            log_group_name_list.append(prop.get('LogGroupName'))
-        return log_group_name_list
+            log_group_name = json.dumps(prop.get('LogGroupName'))
+
+            if log_group_name not in log_group_paths:
+                log_group_paths[log_group_name] = []
+
+            log_group_paths[log_group_name].append(value[0])
+        return log_group_paths
 
     def match(self, cfn):
         """Check if Lambda Events Subscription is duplicated"""

--- a/test/fixtures/templates/bad/some_logs_stream_lambda.yaml
+++ b/test/fixtures/templates/bad/some_logs_stream_lambda.yaml
@@ -70,6 +70,11 @@ Resources:
           Properties:
             LogGroupName: !Ref FunctionALogGroup
             FilterPattern: ""
+        FunctionDLogGroup:
+          Type: CloudWatchLogs
+          Properties:
+            LogGroupName: !Ref FunctionALogGroup
+            FilterPattern: ""
   LogSubscriptionFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:


### PR DESCRIPTION
*Issue #, if available:*
Fix #1743 
*Description of changes:*
- Update rule E2529 to allow for increased limit of two subscription filters per log group.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
