### PR TITLE
python2.7 Lambda runtime support extended

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
+++ b/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
@@ -35,8 +35,8 @@
         "successor": "nodejs10.x"
     },
     "python2.7": {
-        "eol": "2020-12-31",
-        "deprecated": "2020-12-31",
+        "eol": "2021-06-01",
+        "deprecated": "2021-06-01",
         "successor": "python3.8"
     }
 }


### PR DESCRIPTION
closes https://github.com/aws-cloudformation/cfn-python-lint/issues/1705
[Runtime support policy](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html)
[`UPDATE – Oct 20, 2020 – We’re extending the support of Python 2.7 in AWS Lambda until at least June 1, 2021.`](https://aws.amazon.com/blogs/compute/continued-support-for-python-2-7-on-aws-lambda/)