### PR TITLE
AWS::AmazonMQ::Broker.EngineVersion AllowedValues expansion

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_amazonmq.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_amazonmq.json
@@ -18,12 +18,14 @@
     "path": "/ValueTypes/AWS::AmazonMQ::Broker.EngineVersion",
     "value": {
       "AllowedValues": [
+        "3.8.6",
         "5.15.0",
         "5.15.6",
         "5.15.8",
         "5.15.9",
         "5.15.10",
-        "5.15.12"
+        "5.15.12",
+        "5.15.13"
       ]
     }
   },


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/issues/50
one of the few AllowedValues lists left to actively maintain:
https://github.com/aws-cloudformation/cfn-python-lint/pull/1682
https://github.com/aws-cloudformation/cfn-python-lint/pull/1680
[`AWS::AmazonMQ::Broker.EngineVersion`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html#cfn-amazonmq-broker-engineversion)
https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html
https://aws.amazon.com/blogs/aws/amazon-mq-update-new-rabbitmq-message-broker-service/