### PR TITLE
Fix bug with Custom:: resources

### DIFF
--- a/src/cfnlint/rules/resources/properties/Required.py
+++ b/src/cfnlint/rules/resources/properties/Required.py
@@ -96,7 +96,7 @@ class Required(CloudFormationLintRule):
         for resourcename, resourcevalue in cfn.get_resources().items():
             if 'Properties' in resourcevalue and 'Type' in resourcevalue:
                 resource_type = resourcevalue['Type']
-                if resource_type.startswith('Custom::') and resource_type not in self.resourcetypes:
+                if resource_type.startswith('Custom::') and resource_type in self.resourcetypes:
                     resource_type = 'AWS::CloudFormation::CustomResource'
                     matches.extend(
                         self.check_obj(


### PR DESCRIPTION
*Description of changes:*
We are having an issue since 38.0 with the extension of our own linter getting the below error;
`E0002 Unknown exception while processing rule E3003: 'NoneType' object has no attribute 'get'`

On the following piece of YAML;
```
Resources:
  CustomResource:
    Type: "Custom::Resource"
    Properties:
      test: "test"
```

At the condition you check if the resource does not exists in the self.resourcetypes. After that it tries to get the custom resource it already saw it was not there and it fails. The result will be None and internally in this function there a get via this None object. I would guess that on your if condition, you should not have the "not" on "resource_type not in self.resourcetypes". This PR at least solves it on our end. 

The change in the PR solves it. If its not intended to be like this or I should instead raise an issue so that you can solve it in a better way, please close the PR. 

@kddejong 