### PR TITLE
AWS::ElasticLoadBalancingV2::Listener.Protocol AllowedValues expansion (GENEVE)

### DIFF
--- a/src/cfnlint/rules/resources/elb/Elb.py
+++ b/src/cfnlint/rules/resources/elb/Elb.py
@@ -130,7 +130,7 @@ HTTPS has certificate HTTP has no certificate'
                 cfn.check_value(
                     result['Value'], 'Protocol', result['Path'],
                     check_value=self.check_protocol_value,
-                    accepted_protocols=['HTTP', 'HTTPS', 'TCP', 'TCP_UDP', 'TLS', 'UDP'],
+                    accepted_protocols=['GENEVE', 'HTTP', 'HTTPS', 'TCP', 'TCP_UDP', 'TLS', 'UDP'],
                     certificate_protocols=['HTTPS', 'TLS'],
                     certificates=result['Value'].get('Certificates')))
 


### PR DESCRIPTION
similar to previous: https://github.com/aws-cloudformation/cfn-python-lint/pull/649, https://github.com/aws-cloudformation/cfn-python-lint/pull/983
[`AWS::ElasticLoadBalancingV2::Listener.Protocol`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listener.html#cfn-elasticloadbalancingv2-listener-protocol)

[Highest churn for a service-specific rule](https://github.com/aws-cloudformation/cfn-python-lint/pull/1646#issuecomment-727257299). [`elbv2/2015-12-01/ProtocolEnum`](https://github.com/boto/botocore/blob/ccdc98aa50929fab77cb29863301e90718f4a5ad/botocore/data/elbv2/2015-12-01/service-2.json#L2425) [should be sourced automatically from botocore](https://github.com/aws-cloudformation/cfn-python-lint/pull/1682/)
