### PR TITLE
Patch AWS::EC2::CarrierGateway for Tags

### DIFF
--- a/src/cfnlint/data/CloudSpecs/us-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-1.json
@@ -14316,19 +14316,6 @@
         }
       }
     },
-    "AWS::EC2::CarrierGateway.Tags": {
-      "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-carriergateway-tags.html",
-      "Properties": {
-        "Tags": {
-          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-carriergateway-tags.html#cfn-ec2-carriergateway-tags-tags",
-          "DuplicatesAllowed": false,
-          "ItemType": "Tag",
-          "Required": false,
-          "Type": "List",
-          "UpdateType": "Mutable"
-        }
-      }
-    },
     "AWS::EC2::ClientVpnEndpoint.CertificateAuthenticationRequest": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-clientvpnendpoint-certificateauthenticationrequest.html",
       "Properties": {
@@ -54621,7 +54608,7 @@
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-carriergateway.html#cfn-ec2-carriergateway-tags",
           "Required": false,
-          "Type": "Tags",
+          "Type": "Tag",
           "UpdateType": "Mutable"
         },
         "VpcId": {

--- a/src/cfnlint/data/CloudSpecs/us-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-2.json
@@ -14147,19 +14147,6 @@
         }
       }
     },
-    "AWS::EC2::CarrierGateway.Tags": {
-      "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-carriergateway-tags.html",
-      "Properties": {
-        "Tags": {
-          "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-carriergateway-tags.html#cfn-ec2-carriergateway-tags-tags",
-          "DuplicatesAllowed": false,
-          "ItemType": "Tag",
-          "Required": false,
-          "Type": "List",
-          "UpdateType": "Mutable"
-        }
-      }
-    },
     "AWS::EC2::ClientVpnEndpoint.CertificateAuthenticationRequest": {
       "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-clientvpnendpoint-certificateauthenticationrequest.html",
       "Properties": {
@@ -54382,7 +54369,7 @@
         "Tags": {
           "Documentation": "http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-carriergateway.html#cfn-ec2-carriergateway-tags",
           "Required": false,
-          "Type": "Tags",
+          "Type": "Tag",
           "UpdateType": "Mutable"
         },
         "VpcId": {

--- a/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
@@ -417,5 +417,14 @@
     "op": "replace",
     "path": "/ResourceTypes/AWS::IoT::DomainConfiguration/Properties/Tags/Type",
     "value": "Tag"
+  },
+  {
+    "op": "remove",
+    "path": "/PropertyTypes/AWS::EC2::CarrierGateway.Tags"
+  },
+  {
+    "op": "replace",
+    "path": "/ResourceTypes/AWS::EC2::CarrierGateway/Properties/Tags/Type",
+    "value": "Tag"
   }
 ]


### PR DESCRIPTION
*Issue #, if available:*
fix #1755
*Description of changes:*
- Fix an issue with Tags on the AWS::EC2::CarrierGateway resource type

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
