### PR TITLE
Make sure types are strings before assuming they are

### DIFF
--- a/src/cfnlint/rules/resources/ServerlessTransform.py
+++ b/src/cfnlint/rules/resources/ServerlessTransform.py
@@ -2,6 +2,7 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: MIT-0
 """
+import six
 from cfnlint.rules import CloudFormationLintRule
 from cfnlint.rules import RuleMatch
 
@@ -31,10 +32,11 @@ class ServerlessTransform(CloudFormationLintRule):
 
         for resource_name, resource_values in cfn.get_resources().items():
             resource_type = resource_values['Type']
-            if resource_type.startswith('AWS::Serverless::'):
-                message = 'Serverless Transform required for Type {0} for resource {1}'
-                matches.append(
-                    RuleMatch(['Transform'], message.format(resource_type, resource_name))
-                )
-                break
+            if isinstance(resource_type, six.string_types):
+                if resource_type.startswith('AWS::Serverless::'):
+                    message = 'Serverless Transform required for Type {0} for resource {1}'
+                    matches.append(
+                        RuleMatch(['Transform'], message.format(resource_type, resource_name))
+                    )
+                    break
         return matches

--- a/src/cfnlint/template.py
+++ b/src/cfnlint/template.py
@@ -166,20 +166,21 @@ class Template(object):  # pylint: disable=R0904
         for name, value in resources.items():
             if 'Type' in value:
                 valtype = value['Type']
-                if valtype.startswith(astrik_string_types):
-                    LOGGER.debug('Cant build an appropriate getatt list from %s', valtype)
-                    results[name] = {'*': {'PrimitiveItemType': 'String'}}
-                elif valtype.startswith(astrik_unknown_types):
-                    LOGGER.debug('Cant build an appropriate getatt list from %s', valtype)
-                    results[name] = {'*': {}}
-                else:
-                    if value['Type'] in resourcetypes:
-                        if 'Attributes' in resourcetypes[valtype]:
-                            results[name] = {}
-                            for attname, attvalue in resourcetypes[valtype]['Attributes'].items():
-                                element = {}
-                                element.update(attvalue)
-                                results[name][attname] = element
+                if isinstance(valtype, six.string_types):
+                    if valtype.startswith(astrik_string_types):
+                        LOGGER.debug('Cant build an appropriate getatt list from %s', valtype)
+                        results[name] = {'*': {'PrimitiveItemType': 'String'}}
+                    elif valtype.startswith(astrik_unknown_types):
+                        LOGGER.debug('Cant build an appropriate getatt list from %s', valtype)
+                        results[name] = {'*': {}}
+                    else:
+                        if value['Type'] in resourcetypes:
+                            if 'Attributes' in resourcetypes[valtype]:
+                                results[name] = {}
+                                for attname, attvalue in resourcetypes[valtype]['Attributes'].items():
+                                    element = {}
+                                    element.update(attvalue)
+                                    results[name][attname] = element
 
         return results
 


### PR DESCRIPTION
*Issue #, if available:*
fix #1521
*Description of changes:*
- Fix an issues with get valid getatts that was an issue if the type wasn't a string
- fix an issue with rule E3038 to make sure types are strings before assuming they are

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
