### PR TITLE
Get the rest of the user data items

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/SubNeededExcludes.json
+++ b/src/cfnlint/data/AdditionalSpecs/SubNeededExcludes.json
@@ -63,23 +63,54 @@
                 }
             }
         },
+        "AWS::EC2::SpotFleet": {
+            "Metadata": {
+                "AWS::CloudFormation::Init": {
+                    "ExcludeAll": true
+                }
+            },
+            "Properties": {
+                "SpotFleetRequestConfigData": {
+                    "Properties": {
+                        "LaunchSpecifications": {
+                            "Properties": {
+                                "UserData": {
+                                    "ExcludeAll": true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "AWS::EC2::LaunchTemplate": {
+            "Properties": {
+                "LaunchTemplateData": {
+                    "Properties": {
+                        "UserData": {
+                            "ExcludeAll": true
+                        }
+                    }
+                }
+            }
+        },
         "AWS::EMR::InstanceGroupConfig": {
             "Properties": {
                 "AutoScalingPolicy": {
                     "Properties": {
-                        "ScalingRule": {
+                        "Rules": {
                             "Properties": {
-                                "ScalingTrigger": {
+                                "Trigger": {
                                     "Properties": {
-                                       "CloudWatchAlarmDefinition": {
+                                        "CloudWatchAlarmDefinition": {
                                             "ExcludeAll": true
-                                        } 
+                                        }
                                     }
                                 }
                             }
                         }
                     }
-                }                        
+                }
             }
         },
         "AWS::IAM::Policy": {

--- a/test/fixtures/templates/good/functions/sub_needed.yaml
+++ b/test/fixtures/templates/good/functions/sub_needed.yaml
@@ -169,3 +169,10 @@ Resources:
       DefinitionSubstitutions:
         definition_substitution_1: test
       RoleArn: arn:aws:iam::123456789012:role/abc
+  NestedProperties:
+    Type: AWS::EMR::InstanceGroupConfig
+    Properties:
+      AutoScalingPolicy:
+        Rules:
+          Trigger:
+            CloudWatchAlarmDefinition: "${test}"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/cfn-python-lint/pull/1788

*Description of changes:*
- Update rule E1029 spec file to handle  all UserData items. Fix typos in `AWS::EMR::InstanceGroupConfig`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
