### PR TITLE
Use the longest regex match when searching for a Ref

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -204,10 +204,11 @@ VALID_PARAMETER_TYPES = VALID_PARAMETER_TYPES_SINGLE + VALID_PARAMETER_TYPES_LIS
 class RegexDict(dict):
 
     def __getitem__(self, item):
-        for k, v in self.items():
-            if re.match(k, item):
-                return v
-        raise KeyError
+        possible_items = {k: v for k, v in self.items() if re.match(k, item)}
+        if not possible_items:
+            raise KeyError
+        longest_match = sorted(possible_items.keys(), key=len)[-1]
+        return possible_items[longest_match]
 
     def __contains__(self, item):
         for k in self.keys():


### PR DESCRIPTION
Fixes #1813 (from my limited testing)

I didn't change the regex to `startswith`, because that would be a bigger change requiring changing class names.

*Issue #, if available:*
#1813

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
