### PR TITLE
removing Local Zones from region_map in pricing script

### DIFF
--- a/scripts/update_specs_from_pricing.py
+++ b/scripts/update_specs_from_pricing.py
@@ -199,7 +199,7 @@ def get_results(service, product_families):
             products = json.loads(price_item)
             product = products.get('product', {})
             if product:
-                if product.get('productFamily') in product_families and 'Verizon' not in product.get('attributes').get('location'):
+                if product.get('productFamily') in product_families and product.get('attributes').get('locationType') == "AWS Region":
                     if not results.get(region_map[product.get('attributes').get('location')]):
                         results[region_map[product.get('attributes').get('location')]] = set()
                     results[region_map[product.get('attributes').get('location')]].add(


### PR DESCRIPTION
```bash
Traceback (most recent call last):
  File "/home/runner/work/cfn-python-lint/cfn-python-lint/scripts/update_specs_from_pricing.py", line 242, in <module>
    main()
  File "/home/runner/work/cfn-python-lint/cfn-python-lint/scripts/update_specs_from_pricing.py", line 219, in main
    outputs = update_outputs('Ec2InstanceType', get_results('AmazonEC2', ['Compute Instance', 'Compute Instance (bare metal)']), outputs)
  File "/home/runner/work/cfn-python-lint/cfn-python-lint/scripts/update_specs_from_pricing.py", line 203, in get_results
    if not results.get(region_map[product.get('attributes').get('location')]):
KeyError: 'US East (Houston)'
```

---

expanding beyond [Wavelength Zone removal](https://github.com/aws-cloudformation/cfn-python-lint/pull/1793)
https://aws.amazon.com/blogs/aws/in-the-works-more-aws-local-zones/
https://aws.amazon.com/about-aws/global-infrastructure/localzones/locations/

```
"locationType" : "AWS Region",
"locationType" : "AWS Outposts",
"locationType" : "AWS Local Zone",
"locationType" : "AWS Wavelength Zone",
```

---

tested in my fork, [`Los Angeles` local zone still has `"locationType": "AWS Region"` for some reason](https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/index.json):
```
        "location": "US West (Los Angeles)",
        "locationType": "AWS Region",
```
https://github.com/aws-cloudformation/cfn-python-lint/blob/11532b3462a4caf1c001198448e5ec2ed7acdc4e/scripts/update_specs_from_pricing.py#L46

---

only removes these products from [`all/05_pricing_property_values.json`](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/src/cfnlint/data/ExtendedSpecs/all/05_pricing_property_values.json), but some present in regional directories anyway:
```
        "servicecode" : "ElasticMapReduce",
        "location" : "Any",
        "locationType" : "AWS Outposts",
```
https://github.com/aws-cloudformation/cfn-python-lint/blob/918b0b570dda854e6e9751c26e4969fd1d1ab1da/src/cfnlint/data/ExtendedSpecs/all/05_pricing_property_values.json#L9-L49