### PR TITLE
update FSx Storage Capacity to a minimum of 32

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_fsx.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_fsx.json
@@ -4,7 +4,7 @@
     "path": "/ValueTypes/AWS::FSx::FileSystem.StorageCapacity",
     "value": {
       "NumberMax": 65536,
-      "NumberMin": 300
+      "NumberMin": 32
     }
   }
 ]


### PR DESCRIPTION
*Issue #, if available:*
fix #1826 
*Description of changes:*
- Lower the minimum for Windows based FSx File Systems

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
