### PR TITLE
Update rule E3008 to allow for lists in getatt allowed values

### DIFF
--- a/src/cfnlint/data/CloudSpecs/af-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/af-south-1.json
@@ -35947,6 +35947,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/ap-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-east-1.json
@@ -47741,6 +47741,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-1.json
@@ -77104,6 +77104,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-2.json
@@ -71455,6 +71455,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
+++ b/src/cfnlint/data/CloudSpecs/ap-northeast-3.json
@@ -22096,6 +22096,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/ap-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-south-1.json
@@ -71330,6 +71330,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-1.json
@@ -72424,6 +72424,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
+++ b/src/cfnlint/data/CloudSpecs/ap-southeast-2.json
@@ -79199,6 +79199,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/ca-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/ca-central-1.json
@@ -61529,6 +61529,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/cn-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-north-1.json
@@ -41032,6 +41032,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
+++ b/src/cfnlint/data/CloudSpecs/cn-northwest-1.json
@@ -38180,6 +38180,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/eu-central-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-central-1.json
@@ -77960,6 +77960,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/eu-north-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-north-1.json
@@ -54201,6 +54201,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/eu-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/eu-south-1.json
@@ -37555,6 +37555,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-2.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-2.json
@@ -66493,6 +66493,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/eu-west-3.json
+++ b/src/cfnlint/data/CloudSpecs/eu-west-3.json
@@ -58436,6 +58436,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/me-south-1.json
+++ b/src/cfnlint/data/CloudSpecs/me-south-1.json
@@ -46523,6 +46523,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/sa-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/sa-east-1.json
@@ -63493,6 +63493,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/us-east-2.json
+++ b/src/cfnlint/data/CloudSpecs/us-east-2.json
@@ -71351,6 +71351,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-east-1.json
@@ -40045,6 +40045,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-gov-west-1.json
@@ -43533,6 +43533,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/CloudSpecs/us-west-1.json
+++ b/src/cfnlint/data/CloudSpecs/us-west-1.json
@@ -63005,6 +63005,10 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ],
         "AWS::SQS::Queue": "Arn"
       },
       "Ref": {

--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_lambda.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_lambda.json
@@ -84,7 +84,11 @@
       "GetAtt": {
         "AWS::DynamoDB::Table": "StreamArn",
         "AWS::Kinesis::Stream": "Arn",
-        "AWS::SQS::Queue": "Arn"
+        "AWS::SQS::Queue": "Arn",
+        "AWS::Kinesis::StreamConsumer": [
+          "StreamARN",
+          "ConsumerARN"
+        ]
       },
       "Ref": {
         "Parameters": [

--- a/src/cfnlint/rules/resources/properties/ValueRefGetAtt.py
+++ b/src/cfnlint/rules/resources/properties/ValueRefGetAtt.py
@@ -157,7 +157,22 @@ class ValueRefGetAtt(CloudFormationLintRule):
                         property_name,
                         ', '.join(map(str, specs)),
                         '/'.join(map(str, path)))))
+        elif isinstance(specs[resource_type], list):
+            found = False
+            for allowed_att in specs[resource_type]:
+                if '.'.join(map(str, resource_attribute)) == allowed_att:
+                    found = True
+            if not found:
+                message = 'Property "{0}" can Fn::GetAtt to a resource attribute "{1}" at {2}'
+                matches.append(
+                    RuleMatch(
+                        path,
+                        message.format(
+                            property_name,
+                            specs[resource_type],
+                            '/'.join(map(str, path)))))
         elif '.'.join(map(str, resource_attribute)) != specs[resource_type]:
+            print(resource_type)
             message = 'Property "{0}" can Fn::GetAtt to a resource attribute "{1}" at {2}'
             matches.append(
                 RuleMatch(

--- a/test/fixtures/templates/bad/resources/properties/value.yaml
+++ b/test/fixtures/templates/bad/resources/properties/value.yaml
@@ -124,3 +124,20 @@ Resources:
       - Key: idle_timeout.timeout_seconds
         Value: '50'
       SecurityGroups: !GetAtt SubStack.Outputs.SecurityGroups
+  KinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      ShardCount: 1
+  StreamConsumer:
+    Type: AWS::Kinesis::StreamConsumer
+    Properties:
+      ConsumerName: MyConsumer
+      StreamARN: !GetAtt KinesisStream.Arn
+  EventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      BatchSize: 500
+      Enabled: true
+      EventSourceArn: !GetAtt StreamConsumer.AnotherARN
+      FunctionName: !Ref LambdaFunctionArn
+      StartingPosition: LATEST

--- a/test/fixtures/templates/good/resources/properties/value.yaml
+++ b/test/fixtures/templates/good/resources/properties/value.yaml
@@ -133,3 +133,28 @@ Resources:
         - SubStack
         - Outputs.Protocol
       LoadBalancerArn: !GetAtt SubStack.Outputs.LoadBalancerArn
+  KinesisStream:
+    Type: AWS::Kinesis::Stream
+    Properties:
+      ShardCount: 1
+  StreamConsumer:
+    Type: AWS::Kinesis::StreamConsumer
+    Properties:
+      ConsumerName: MyConsumer
+      StreamARN: !GetAtt KinesisStream.Arn
+  03EventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      BatchSize: 500
+      Enabled: true
+      EventSourceArn: !GetAtt StreamConsumer.ConsumerARN
+      FunctionName: !Ref LambdaFunctionArn
+      StartingPosition: LATEST
+  04EventSourceMapping:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      BatchSize: 500
+      Enabled: true
+      EventSourceArn: !GetAtt StreamConsumer.StreamARN
+      FunctionName: !Ref LambdaFunctionArn
+      StartingPosition: LATEST

--- a/test/integration/test_patched_specs.py
+++ b/test/integration/test_patched_specs.py
@@ -153,11 +153,15 @@ class TestPatchedSpecs(BaseTestCase):
                         p_values, dict, 'ValueTypes: %s, Type: %s' % (v_name, p_name))
                     for g_name, g_value in p_values.items():
                         self.assertIsInstance(
-                            g_value, six.string_types, 'ValueTypes: %s, Type: %s, Additional Type: %s' % (v_name, p_name, g_name))
+                            g_value, (six.string_types, list), 'ValueTypes: %s, Type: %s, Additional Type: %s' % (v_name, p_name, g_name))
                         self.assertIn(g_name, self.spec.get(
                             'ResourceTypes'), 'ValueTypes: %s, Type: %s, Additional Type: %s' % (v_name, p_name, g_name))
-                        self.assertIn(g_value, self.spec.get('ResourceTypes', {}).get(g_name, {}).get(
-                            'Attributes', {}), 'ValueTypes: %s, Type: %s, Additional Type: %s' % (v_name, p_name, g_name))
+                        values = g_value
+                        if isinstance(values, six.string_types):
+                            values = [values]
+                        for value in values:
+                            self.assertIn(value, self.spec.get('ResourceTypes', {}).get(g_name, {}).get(
+                                'Attributes', {}), 'ValueTypes: %s, Type: %s, Additional Type: %s' % (v_name, p_name, g_name))
                 elif p_name == 'AllowedValues':
                     self.assertIsInstance(p_values, list)
                     for l_value in p_values:

--- a/test/unit/rules/resources/properties/test_value_ref_getatt.py
+++ b/test/unit/rules/resources/properties/test_value_ref_getatt.py
@@ -28,7 +28,7 @@ class TestValueRefGetAtt(BaseRuleTestCase):
 
     def test_file_negative_value(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/value.yaml', 7)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/properties/value.yaml', 8)
 
     def test_file_negative_vpc_id_value(self):
         """Test failure"""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update rule E3008 to allow for lists in GetAtt attributes
- Update AWS::Lambda::EventSourceMapping.EventSourceArn to allow `StreamARN` and `ConsumerARN`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
