### PR TITLE
Add support for AWS::SSO::PermissionSet InlinePolicy

### DIFF
--- a/src/cfnlint/rules/resources/iam/Policy.py
+++ b/src/cfnlint/rules/resources/iam/Policy.py
@@ -38,6 +38,7 @@ class Policy(CloudFormationLintRule):
             'AWS::IAM::Policy': 'PolicyDocument',
             'AWS::IAM::Role': 'Policies',
             'AWS::IAM::User': 'Policies',
+            'AWS::SSO::PermissionSet': 'InlinePolicy',
         }
         for resource_type in self.resources_and_keys:
             self.resource_property_types.append(resource_type)
@@ -197,7 +198,7 @@ class Policy(CloudFormationLintRule):
                             resource_exceptions=resource_exceptions,
                             start_mark=key.start_mark, end_mark=key.end_mark,
                         ))
-            elif key in ['KeyPolicy', 'PolicyDocument', 'RepositoryPolicyText', 'AccessPolicies']:
+            elif key in ['KeyPolicy', 'PolicyDocument', 'RepositoryPolicyText', 'AccessPolicies', 'InlinePolicy']:
                 matches.extend(
                     cfn.check_value(
                         obj=properties, key=key,

--- a/src/cfnlint/template.py
+++ b/src/cfnlint/template.py
@@ -470,6 +470,10 @@ class Template(object):  # pylint: disable=R0904
                 result = self.get_location_yaml(text[path[0]], path[1:])
             except KeyError as err:
                 pass
+            # TypeError will help catch string indices must be integers for when
+            # we parse JSON string and get a path inside that json string
+            except TypeError as err:
+                pass
             if not result:
                 try:
                     for key in text:


### PR DESCRIPTION
*Issue #, if available:*
fix #1862 
*Description of changes:*
- Add support for `AWS::SSO::PermissionSet` `InlinePolicy` to [E2507](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/docs/rules.md#E2507)
- Fix an issue when we parse a json string in [E2507](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/docs/rules.md#E2507) and use the parsed json to help with the path and then we try to find the location. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
