### PR TITLE
Add a default to string for any type that isn't serializable

### DIFF
--- a/src/cfnlint/rules/resources/properties/ListDuplicates.py
+++ b/src/cfnlint/rules/resources/properties/ListDuplicates.py
@@ -34,7 +34,7 @@ class ListDuplicates(CloudFormationLintRule):
         if isinstance(values, list):
             for index, value in enumerate(values):
                 value_hash = hashlib.sha1(json.dumps(
-                    value, sort_keys=True).encode('utf-8')).hexdigest()
+                    value, sort_keys=True, default=str).encode('utf-8')).hexdigest()
                 if value_hash in list_items:
                     if not scenario:
                         message = 'List has a duplicate value at {0}'


### PR DESCRIPTION
*Issue #, if available:*
fix #1881 
*Description of changes:*
- fix an issue with rule E3037 when certain types aren't serializable and changing them to strings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
