### PR TITLE
automating aws-sam-translator updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "aws-sam-translator"


### PR DESCRIPTION
[docs](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates)

previous manual updates: https://github.com/aws-cloudformation/cfn-python-lint/pull/1910, https://github.com/aws-cloudformation/cfn-python-lint/pull/1594, https://github.com/aws-cloudformation/cfn-python-lint/pull/1536, https://github.com/aws-cloudformation/cfn-python-lint/pull/1406, https://github.com/aws-cloudformation/cfn-python-lint/pull/1275, https://github.com/aws-cloudformation/cfn-python-lint/pull/1166, https://github.com/aws-cloudformation/cfn-python-lint/pull/1054, https://github.com/aws-cloudformation/cfn-python-lint/pull/779, https://github.com/aws-cloudformation/cfn-python-lint/pull/634, https://github.com/aws-cloudformation/cfn-python-lint/pull/141

https://github.com/aws-cloudformation/cfn-python-lint/blob/f7c3dee1f77ce8ef2c5b15a121c749c87a6e2e2e/setup.py#L48

tested in my fork which still has `aws-sam-translator>=1.25.0`, [hoped it supported `>=`, but doesn't seem to be supported](https://github.com/dependabot/dependabot-core/issues/2894):
```bash
updater | INFO <job_90124811> Checking if aws-sam-translator  needs updating
  proxy | 2021/02/23 23:12:25 [030] GET https://pypi.org:443/simple/aws-sam-translator/
  proxy | 2021/02/23 23:12:25 [030] 200 https://pypi.org:443/simple/aws-sam-translator/
updater | INFO <job_90124811> Latest version is 1.34.0
  proxy | 2021/02/23 23:12:25 [032] GET https://pypi.org:443/simple/aws-sam-translator/
  proxy | 2021/02/23 23:12:25 [032] 200 https://pypi.org:443/simple/aws-sam-translator/
updater | INFO <job_90124811> Requirements to unlock update_not_possible
updater | INFO <job_90124811> Requirements update strategy bump_versions
updater | INFO <job_90124811> No update possible for aws-sam-translator 
updater | INFO <job_90124811> Finished job processing
```