### PR TITLE
AWS::DMS::Endpoint.EngineName AllowedValues (documentdb to docdb)

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -140,7 +140,7 @@
           "aurora",
           "azuredb",
           "db2",
-          "documentdb",
+          "docdb",
           "dynamodb",
           "elasticsearch",
           "kafka",


### PR DESCRIPTION
*Issue , if available: #1916

*Description of changes:* changed DMS endpoint engine name for DocumentDB to docdb as per https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dms-endpoint.html#cfn-dms-endpoint-enginename


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
