### PR TITLE
Add Kinesis Data Firehose to permitted SNS subscription protocols

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types.json
@@ -594,6 +594,7 @@
           "application",
           "email-json",
           "email",
+          "firehose",
           "http",
           "https",
           "lambda",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* When creating a resource of type `AWS::SNS::Subscription`, using `"Protocol": "firehose"`, `cfn-lint` returns "_E3030: You must specify a valid value for Protocol (firehose). Valid values are ["application", "email-json", "email", "http", "https", "lambda", "sms", "sqs"]_". To fix this, the protocol "firehose" must be added to the list of valid values for an SNS Subscription resource.

*Problem*: SNS was recently updated to support [delivering messages from SNS topics to Kinesis Data Firehose delivery streams](https://aws.amazon.com/about-aws/whats-new/2021/01/amazon-sns-adds-support-for-message-archiving-and-analytics-via-kineses-data-firehose-subscriptions/). The CloudFormation [documentation for the `AWS::SNS::Subscription` resource](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-protocol) points at [the SNS API documentation for the Subscribe action](https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html) for a list of valid SNS subscription protocols. This list has been updated to include the `firehose` protocol for a delivery stream, however `cfn-lint` has not been updated; it fails to validate a template if the `firehose` protocol is used, but the template will deploy successfully when executed in CloudFormation.

*Example*: 

```
"MyKinesisFireHoseSNSSub": {
    "Type": "AWS::SNS::Subscription",
    "Properties": {
        "TopicArn": { "Fn::GetAtt": ["MySNSTopic", "Arn"] },
        "SubscriptionRoleArn": { "Fn::GetAtt": [ "MySNSSubIAMRole", "Arn" ] },
        "Endpoint": {
            "Fn::GetAtt": ["MyKinesisFirehoseDeliveryStream", "Arn"]
        },
        "Protocol": "firehose",
        "RawMessageDelivery": true
    }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
