### PR TITLE
Patch back in CloudFormation provisioned product attribute Outputs

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/01_spec_patch.json
@@ -332,5 +332,13 @@
     "op": "replace",
     "path": "/ResourceTypes/AWS::SageMaker::DeviceFleet/Properties/Tags/ItemType",
     "value": "Tag"
+  },
+  {
+    "op": "add",
+    "path": "/ResourceTypes/AWS::ServiceCatalog::CloudFormationProvisionedProduct/Attributes/Outputs",
+    "value": {
+      "PrimitiveItemType": "String",
+      "Type": "Map"
+    }
   }
 ]


### PR DESCRIPTION
*Issue #, if available:*
#1931 
*Description of changes:*
Add in `Outputs` back to `Attributes` of `AWS::ServiceCatalog::CloudFormationProvisionedProduct`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
