### PR TITLE
Log warning when a pricing region isn't found in the region map

### DIFF
--- a/scripts/update_specs_from_pricing.py
+++ b/scripts/update_specs_from_pricing.py
@@ -200,6 +200,9 @@ def get_results(service, product_families):
             product = products.get('product', {})
             if product:
                 if product.get('productFamily') in product_families and product.get('attributes').get('locationType') == "AWS Region":
+                    if product.get('attributes').get('location') not in region_map:
+                        LOGGER.warning('Region "%s" not found', product.get('attributes').get('location'))
+                        continue
                     if not results.get(region_map[product.get('attributes').get('location')]):
                         results[region_map[product.get('attributes').get('location')]] = set()
                     results[region_map[product.get('attributes').get('location')]].add(


### PR DESCRIPTION
*Issue #, if available:* [autogenerated maintenance failing with:](https://github.com/aws-cloudformation/cfn-python-lint/runs/2143999284?check_suite_focus=true#step:4:189)

```bash
2021-03-18 22:35:21,875 - cfnlint - INFO - Get ElasticMapReduce pricing
Traceback (most recent call last):
  File "/home/runner/work/cfn-python-lint/cfn-python-lint/scripts/update_specs_from_pricing.py", line 242, in <module>
    main()
  File "/home/runner/work/cfn-python-lint/cfn-python-lint/scripts/update_specs_from_pricing.py", line 228, in main
    outputs = update_outputs('EMRInstanceType', get_results('ElasticMapReduce', ['Elastic Map Reduce Instance']), outputs)
  File "/home/runner/work/cfn-python-lint/cfn-python-lint/scripts/update_specs_from_pricing.py", line 203, in get_results
    if not results.get(region_map[product.get('attributes').get('location')]):
KeyError: 'China'
```

*Description of changes:*
- Log a warning when a region isn't in the region map

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
