### PR TITLE
enable manual maintenance runs

### DIFF
--- a/.github/workflows/maintenance.yaml
+++ b/.github/workflows/maintenance.yaml
@@ -1,6 +1,7 @@
 on:
   schedule:
     - cron: '*/35 * * * *'
+  workflow_dispatch: # Enables on-demand/manual triggering: https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
 jobs:
   job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[Manual triggers with `workflow_dispatch`](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) in addition to [`cron schedule`](https://github.com/aws-cloudformation/cfn-python-lint/pull/1792)

(similar to https://github.com/aws-cloudformation/cloudformation-cli/pull/665)