### PR TITLE
Switch RegexDict to only string match based on if the type is Module

### DIFF
--- a/src/cfnlint/helpers.py
+++ b/src/cfnlint/helpers.py
@@ -204,15 +204,32 @@ VALID_PARAMETER_TYPES = VALID_PARAMETER_TYPES_SINGLE + VALID_PARAMETER_TYPES_LIS
 class RegexDict(dict):
 
     def __getitem__(self, item):
-        possible_items = {k: v for k, v in self.items() if re.match(k, item)}
+        possible_items = {}
+        for k, v  in self.items():
+            if isinstance(v, dict):
+                if v.get('Type') == 'MODULE':
+                    if re.match(k, item):
+                        possible_items[k] = v
+                else:
+                    if k == item:
+                        possible_items[k] = v
+            elif re.match(k, item):
+                possible_items[k] = v
         if not possible_items:
             raise KeyError
         longest_match = sorted(possible_items.keys(), key=len)[-1]
         return possible_items[longest_match]
 
     def __contains__(self, item):
-        for k in self.keys():
-            if re.match(k, item):
+        for k, v in self.items():
+            if isinstance(v, dict):
+                if v.get('Type') == 'MODULE':
+                    if re.match(k, item):
+                        return True
+                else:
+                    if k == item:
+                        return True
+            elif re.match(k, item):
                 return True
         return False
 


### PR DESCRIPTION
*Issue #, if available:*
fix #1955

*Description of changes:*
- Switch RegexDict to only do re.match on MODULE type if the value is a dict

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
