### PR TITLE
Add AWS::Kinesis::StreamConsumer as a REF for AWS::Lambda::EventSourceMapping.EventSourceArn

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_lambda.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_lambda.json
@@ -41,7 +41,8 @@
           "String"
         ],
         "Resources": [
-          "AWS::MSK::Cluster"
+          "AWS::MSK::Cluster",
+          "AWS::Kinesis::StreamConsumer"
         ]
       }
     }


### PR DESCRIPTION
*Issue #, if available:*
issue #1844 
*Description of changes:*
- Add AWS::Kinesis::StreamConsumer as a REF for AWS::Lambda::EventSourceMapping.EventSourceArn

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
