### PR TITLE
Lambda runtime deprecation updates

### DIFF
--- a/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
+++ b/src/cfnlint/data/AdditionalSpecs/LmbdRuntimeLifecycle.json
@@ -2,41 +2,51 @@
     "dotnetcore1.0": {
         "eol": "2019-06-27",
         "deprecated": "2019-07-31",
-        "successor": "dotnetcore2.1"
+        "successor": "dotnetcore3.1"
     },
     "dotnetcore2.0": {
         "eol": "2019-04-30",
         "deprecated": "2019-05-30",
-        "successor": "dotnetcore2.1"
+        "successor": "dotnetcore3.1"
     },
     "nodejs": {
         "eol": "2016-10-31",
         "deprecated": "2016-10-31",
-        "successor": "nodejs10.x"
+        "successor": "nodejs14.x"
     },
     "nodejs4.3": {
         "eol": "2018-04-30",
         "deprecated": "2019-04-30",
-        "successor": "nodejs10.x"
+        "successor": "nodejs14.x"
     },
     "nodejs4.3-edge": {
         "eol": "2018-04-30",
         "deprecated": "2019-04-30",
-        "successor": "nodejs10.x"
+        "successor": "nodejs14.x"
     },
     "nodejs6.10": {
         "eol": "2019-04-30",
         "deprecated": "2019-08-12",
-        "successor": "nodejs10.x"
+        "successor": "nodejs14.x"
     },
     "nodejs8.10": {
         "eol": "2019-12-31",
         "deprecated": "2020-02-03",
-        "successor": "nodejs10.x"
+        "successor": "nodejs14.x"
+    },
+    "nodejs10.x": {
+        "eol": "2021-05-31",
+        "deprecated": "2021-06-30",
+        "successor": "nodejs14.x"
     },
     "python2.7": {
-        "eol": "2021-06-01",
-        "deprecated": "2021-06-01",
+        "eol": "2021-07-15",
+        "deprecated": "2021-09-30",
         "successor": "python3.8"
+    },
+    "ruby2.5": {
+        "eol": "2021-05-31",
+        "deprecated": "2021-06-30",
+        "successor": "ruby2.7"
     }
 }

--- a/test/fixtures/results/public/lambda-poller.json
+++ b/test/fixtures/results/public/lambda-poller.json
@@ -18,7 +18,7 @@
                 "LineNumber": 151
             }
         },
-        "Message": "Deprecated runtime (nodejs6.10) specified. Updating disabled since 2019-08-12. Please consider updating to nodejs10.x",
+        "Message": "Deprecated runtime (nodejs6.10) specified. Updating disabled since 2019-08-12. Please consider updating to nodejs14.x",
         "Rule": {
             "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
             "Id": "E2531",

--- a/test/fixtures/results/quickstart/nist_config_rules.json
+++ b/test/fixtures/results/quickstart/nist_config_rules.json
@@ -44,7 +44,7 @@
                 "LineNumber": 94
             }
         },
-        "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31. Please consider updating to nodejs10.x",
+        "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31. Please consider updating to nodejs14.x",
         "Rule": {
             "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
             "Id": "E2531",
@@ -124,7 +124,7 @@
                 "LineNumber": 159
             }
         },
-        "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31. Please consider updating to nodejs10.x",
+        "Message": "Deprecated runtime (nodejs) specified. Updating disabled since 2016-10-31. Please consider updating to nodejs14.x",
         "Rule": {
             "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
             "Id": "E2531",

--- a/test/integration/test_good_templates.py
+++ b/test/integration/test_good_templates.py
@@ -139,7 +139,7 @@ class TestQuickStartTemplates(BaseCliTestCase):
                             "LineNumber": 10
                         }
                     },
-                    "Message": "Deprecated runtime (nodejs6.10) specified. Updating disabled since 2019-08-12. Please consider updating to nodejs10.x",
+                    "Message": "Deprecated runtime (nodejs6.10) specified. Updating disabled since 2019-08-12. Please consider updating to nodejs14.x",
                     "Rule": {
                         "Description": "Check if an EOL Lambda Runtime is specified and give an error if used. ",
                         "Id": "E2531",


### PR DESCRIPTION
https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html
[`AWS::Lambda::Function.Runtime`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime)

updated test results with:
```bash
gsed -i 's/Please consider updating to nodejs10/Please consider updating to nodejs14/' test/integration/*.py
gsed -i 's/Please consider updating to nodejs10/Please consider updating to nodejs14/' test/fixtures/results/*/*.json
```