### PR TITLE
removing AWS::AmazonMQ::Broker.EngineVersion AllowedValues

### DIFF
--- a/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_amazonmq.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/03_value_types/aws_amazonmq.json
@@ -15,23 +15,6 @@
   },
   {
     "op": "add",
-    "path": "/ValueTypes/AWS::AmazonMQ::Broker.EngineVersion",
-    "value": {
-      "AllowedValues": [
-        "3.8.6",
-        "5.15.0",
-        "5.15.6",
-        "5.15.8",
-        "5.15.9",
-        "5.15.10",
-        "5.15.12",
-        "5.15.13",
-        "5.15.14"
-      ]
-    }
-  },
-  {
-    "op": "add",
     "path": "/ValueTypes/AWS::AmazonMQ::Broker.HostInstanceType",
     "value": {
       "Ref": {

--- a/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_amazonmq.json
+++ b/src/cfnlint/data/ExtendedSpecs/all/04_property_values/aws_amazonmq.json
@@ -15,13 +15,6 @@
   },
   {
     "op": "add",
-    "path": "/ResourceTypes/AWS::AmazonMQ::Broker/Properties/EngineVersion/Value",
-    "value": {
-      "ValueType": "AWS::AmazonMQ::Broker.EngineVersion"
-    }
-  },
-  {
-    "op": "add",
     "path": "/ResourceTypes/AWS::AmazonMQ::Broker/Properties/HostInstanceType/Value",
     "value": {
       "ValueType": "AWS::AmazonMQ::Broker.HostInstanceType"
@@ -32,13 +25,6 @@
     "path": "/ResourceTypes/AWS::AmazonMQ::Configuration/Properties/EngineType/Value",
     "value": {
       "ValueType": "AWS::AmazonMQ::Broker.EngineType"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/ResourceTypes/AWS::AmazonMQ::Configuration/Properties/EngineVersion/Value",
-    "value": {
-      "ValueType": "AWS::AmazonMQ::Broker.EngineVersion"
     }
   }
 ]


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/issues/50
most churn of remaining manually maintained AllowedValues:
https://github.com/aws-cloudformation/cfn-python-lint/pull/1682, https://github.com/aws-cloudformation/cfn-python-lint/pull/1680, https://github.com/aws-cloudformation/cfn-python-lint/pull/1778, https://github.com/aws-cloudformation/cfn-python-lint/pull/1841, `3.8.11` just added
[`AWS::AmazonMQ::Broker.EngineVersion`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html#cfn-amazonmq-broker-engineversion)
https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html