### PR TITLE
Fix rules for Iops property and EBS volume types.

### DIFF
--- a/src/cfnlint/rules/resources/ectwo/Ebs.py
+++ b/src/cfnlint/rules/resources/ectwo/Ebs.py
@@ -9,10 +9,10 @@ from cfnlint.rules import RuleMatch
 
 
 class Ebs(CloudFormationLintRule):
-    """Check if Ec2 Ebs Resource Properties"""
+    """Check Ec2 Ebs Resource Properties"""
     id = 'E2504'
     shortdesc = 'Check Ec2 Ebs Properties'
-    description = 'See if Ec2 Eb2 Properties are valid'
+    description = 'See if Ec2 Ebs Properties are valid'
     source_url = 'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-blockdev-template.html'
     tags = ['properties', 'ec2', 'ebs']
 
@@ -26,13 +26,15 @@ class Ebs(CloudFormationLintRule):
                 for volume_type_obj in volume_types_obj:
                     volume_type = volume_type_obj.get('Value')
                     if isinstance(volume_type, six.string_types):
-                        if volume_type == 'io1':
+                        if volume_type in ('io1', 'io2'):
                             if iops_obj is None:
                                 pathmessage = path[:] + ['VolumeType']
-                                message = 'VolumeType io1 requires Iops to be specified for {0}'
+                                message = 'VolumeType {0} requires Iops to be specified for {1}'
                                 matches.append(
-                                    RuleMatch(pathmessage, message.format('/'.join(map(str, pathmessage)))))
-                        elif volume_type:
+                                    RuleMatch(
+                                        pathmessage,
+                                        message.format(volume_type, '/'.join(map(str, pathmessage)))))
+                        elif volume_type in ('gp2', 'st1', 'sc1', 'standard'):
                             if iops_obj is not None:
                                 pathmessage = path[:] + ['Iops']
                                 message = 'Iops shouldn\'t be defined for type {0} for {1}'

--- a/test/fixtures/templates/good/resources/ec2/ebs.yaml
+++ b/test/fixtures/templates/good/resources/ec2/ebs.yaml
@@ -47,6 +47,12 @@ Resources:
             VolumeSize: 20
         - DeviceName: /dev/sdn
           Ebs:
+            VolumeType: io2
+            Iops: !Ref myIops
+            DeleteOnTermination: false
+            VolumeSize: 20
+        - DeviceName: /dev/sdo
+          Ebs:
             VolumeType: standard
             DeleteOnTermination: false
             VolumeSize: 20

--- a/test/unit/rules/resources/ec2/test_ec2_ebs.py
+++ b/test/unit/rules/resources/ec2/test_ec2_ebs.py
@@ -23,4 +23,4 @@ class TestPropertyEc2Ebs(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/resources/ec2/ebs.yaml', 5)
+        self.helper_file_negative('test/fixtures/templates/bad/resources/ec2/ebs.yaml', 4)


### PR DESCRIPTION
*Issue #, if available:*

Fixes #1977.

*Description of changes:*

The 'Iops' property on an EBS volume is required for io1 and io2
volumes, optional for gp3 volumes, and not supported for gp2, st1, sc1
and standard volumes.

The previous code treated the property as required for io1 and not
supported for all other volume types.  This gave the wrong outcome for
io2 and gp3 specifically, and is generally the wrong move for any new
volume types that are added in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
