### PR TITLE
don't look at globals when finding ref/getatt in W1001

### DIFF
--- a/src/cfnlint/rules/functions/RelationshipConditions.py
+++ b/src/cfnlint/rules/functions/RelationshipConditions.py
@@ -24,7 +24,7 @@ class RelationshipConditions(CloudFormationLintRule):
         matches = []
 
         # Start with Ref checks
-        ref_objs = cfn.search_deep_keys('Ref')
+        ref_objs = cfn.search_deep_keys(searchText='Ref', includeGlobals=False)
         for ref_obj in ref_objs:
             value = ref_obj[-1]
             if value not in PSEUDOPARAMS:
@@ -42,7 +42,7 @@ class RelationshipConditions(CloudFormationLintRule):
                                 '/'.join(map(str, ref_obj[:-1])))))
 
         # The do GetAtt
-        getatt_objs = cfn.search_deep_keys('Fn::GetAtt')
+        getatt_objs = cfn.search_deep_keys(searchText='Fn::GetAtt', includeGlobals=False)
         for getatt_obj in getatt_objs:
             value_obj = getatt_obj[-1]
             value = None

--- a/src/cfnlint/template.py
+++ b/src/cfnlint/template.py
@@ -309,7 +309,7 @@ class Template(object):  # pylint: disable=R0904
 
         return keys
 
-    def search_deep_keys(self, searchText):
+    def search_deep_keys(self, searchText, includeGlobals=True):
         """
             Search for a key in all parts of the template.
             :return if searchText is "Ref", an array like ['Resources', 'myInstance', 'Properties', 'ImageId', 'Ref', 'Ec2ImageId']
@@ -318,7 +318,10 @@ class Template(object):  # pylint: disable=R0904
         results = []
         results.extend(self._search_deep_keys(searchText, self.template, []))
         # Globals are removed during a transform.  They need to be checked manually
-        results.extend(self._search_deep_keys(searchText, self.transform_pre.get('Globals'), []))
+        if includeGlobals:
+            pre_results = self._search_deep_keys(searchText, self.transform_pre.get('Globals'), [])
+            for pre_result in pre_results:
+                results.append(['Globals'] + pre_result)
         return results
 
     def get_condition_values(self, template, path=[]):

--- a/test/fixtures/templates/good/functions/relationship_conditions_sam.yaml
+++ b/test/fixtures/templates/good/functions/relationship_conditions_sam.yaml
@@ -1,0 +1,37 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
+Parameters:
+  DeploymentMode:
+    Type: String
+    AllowedValues:
+    - sandbox
+    - live
+    Default: sandbox
+    ConstraintDescription: Value must be a known deployment mode.
+Conditions:
+  IsLive: !Equals [ !Ref DeploymentMode, live ]
+Globals:
+  Function:
+    Environment:
+      Variables:
+        AppConfig__Environment: !If
+        - IsLive
+        - !Ref ConfigEnvironment
+        - !ImportValue ConfigEnvironment-blah
+Resources:
+  ConfigApplication:
+    Type: AWS::AppConfig::Application
+    Properties:
+      Name: Application-A
+  ConfigEnvironment:
+    Type: AWS::AppConfig::Environment
+    Condition: IsLive
+    Properties:
+      ApplicationId: !Ref ConfigApplication
+      Name: Environment-B
+  FunctionC:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: provided.al2
+      Handler: provided

--- a/test/unit/rules/functions/test_relationship_conditions.py
+++ b/test/unit/rules/functions/test_relationship_conditions.py
@@ -15,6 +15,7 @@ class TestRulesRelationshipConditions(BaseRuleTestCase):
         self.collection.register(RelationshipConditions())
         self.success_templates = [
             'test/fixtures/templates/good/functions/relationship_conditions.yaml',
+            'test/fixtures/templates/good/functions/relationship_conditions_sam.yaml'
         ]
 
     def test_file_positive(self):


### PR DESCRIPTION
*Issue #, if available:*
fix #1987 
*Description of changes:*
- Don't look at `Globals` when processing rule `W1001`
- Add back `Globals` to the path when searching for keys in pre processed templates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
