### PR TITLE
Update the regex for the key name in rule E7003

### DIFF
--- a/test/fixtures/templates/bad/mappings/key_name.yaml
+++ b/test/fixtures/templates/bad/mappings/key_name.yaml
@@ -7,4 +7,8 @@ Mappings:
     us-east-1a:
       123456789012: "ami-951945d0"
       us-east-1b: "ami-951945d1"
+  NameServers:
+    10.90.0.0/16:
+      NameServer1: 10.90.0.10
+      NameServer2: 10.90.4.10
 Resources: {}

--- a/test/unit/rules/mappings/test_key_name.py
+++ b/test/unit/rules/mappings/test_key_name.py
@@ -23,4 +23,4 @@ class TestKeyName(BaseRuleTestCase):
 
     def test_file_negative(self):
         """Test failure"""
-        self.helper_file_negative('test/fixtures/templates/bad/mappings/key_name.yaml', 3)
+        self.helper_file_negative('test/fixtures/templates/bad/mappings/key_name.yaml', 4)


### PR DESCRIPTION
*Issue #, if available:*
fix #2004 
*Description of changes:*
- Update rule E7003 to check the key name for alphanumeric, '-' or '.'

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
